### PR TITLE
chore(ci): pin the Rust toolchain to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned toolchain (keep `toolchain:` in sync with rust-toolchain.toml).
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master, pinned
         with:
+          toolchain: "1.95.0"
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -32,8 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned toolchain (keep `toolchain:` in sync with rust-toolchain.toml).
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master, pinned
         with:
+          toolchain: "1.95.0"
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
@@ -47,7 +51,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned toolchain (keep `toolchain:` in sync with rust-toolchain.toml).
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master, pinned
+        with:
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
       # owl-dl-py is a PyO3 `cdylib`; building it via plain `cargo` links it
       # as an ordinary lib, which fails on macOS (undefined `_PyExc_*` symbols
@@ -74,7 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned toolchain (keep `toolchain:` in sync with rust-toolchain.toml).
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master, pinned
+        with:
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
       # NOTE: fixtures must be provisioned by the runner (large, gitignored).
       # This job documents the entrypoint; provisioning is out of Phase 0 scope.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,12 @@
+# Pinned toolchain. CI's floating `stable` drifted to a newer rustfmt/clippy
+# (1.9.0) than the repo was formatted/linted against, turning the fmt and
+# clippy jobs red. Pin the version so that drift can't recur: rustup honours
+# this file for every `cargo` invocation (CI and local), so contributors
+# format/lint with exactly what CI enforces.
+#
+# Bump deliberately in a dedicated PR, and keep the version in sync with the
+# `toolchain:` input in .github/workflows/ci.yml.
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
-profile = "default"
+profile = "minimal"


### PR DESCRIPTION
Stops the rustfmt/clippy drift that turned CI red: CI's `dtolnay/rust-toolchain@stable` floated to a newer toolchain than the repo's baseline.

- **rust-toolchain.toml** (channel 1.95.0 + rustfmt/clippy) — rustup honours it for every `cargo` call, so local devs format/lint with exactly what CI enforces (root-cause fix).
- **ci.yml** — pin the action (SHA) + explicit `toolchain: "1.95.0"` in all 4 jobs, so CI is deterministic regardless of what `stable` resolves to or any exported RUSTUP_TOOLCHAIN.

Bumping is now a deliberate one-line change in both files. No code changes; CI should stay green.