### PR TITLE
chore(tableau): blocking counters + correct the stale blocking-lever roadmap

### DIFF
--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -776,12 +776,20 @@ fn main() -> Result<()> {
                 let mut tot_blocked = 0_u64;
                 let mut tot_compares = 0_u64;
                 let mut tot_matches = 0_u64;
+                let mut tot_fired = 0_u64;
+                let mut tot_eligible = 0_u64;
                 for r in &probe.results {
                     tot_blocked += r.stats.is_blocked_calls;
                     tot_compares += r.stats.block_compares;
                     tot_matches += r.stats.match_attempts;
+                    tot_fired += r.stats.blocks_fired;
+                    tot_eligible += r.stats.block_eligible;
                 }
                 println!("# is_blocked_calls (sum retained):  {tot_blocked}");
+                println!("# block_eligible  (sum retained):  {tot_eligible}");
+                println!(
+                    "# blocks_fired    (sum retained):  {tot_fired}  <-- blocking that actually caps the model"
+                );
                 println!("# block_compares  (sum retained):  {tot_compares}");
                 println!("# match_attempts  (sum retained):  {tot_matches}");
             }

--- a/crates/owl-dl-tableau/src/hyper.rs
+++ b/crates/owl-dl-tableau/src/hyper.rs
@@ -305,6 +305,15 @@ pub struct SearchStats {
     /// `is_blocked` invocations. HF2 double-blocking profiling: if this
     /// dwarfs `match_attempts`, the blocking check is the bottleneck.
     pub is_blocked_calls: u64,
+    /// Times `is_blocked` actually returned `true` (a node was blocked).
+    /// `blocks_fired == 0` with large `is_blocked_calls` means blocking
+    /// never caps the completion — the model grows unbounded until a
+    /// deadline/stall (the pizza/SIO convergence problem).
+    pub blocks_fired: u64,
+    /// Times `is_blocked` was called on a non-root node (had a parent,
+    /// so was *eligible* to be blocked). The meaningful denominator for
+    /// `blocks_fired` (root calls can never block).
+    pub block_eligible: u64,
     /// Label-vector equality / subset comparisons inside `is_blocked`.
     /// The expensive per-call cost (linear in label-set size).
     pub block_compares: u64,
@@ -679,6 +688,7 @@ impl<'c> HyperEngine<'c> {
                 let nr = ln.parent_role.expect("non-root has parent_role");
                 (np, nr)
             };
+            self.stats.block_eligible += 1;
             // Snapshot the candidate list (clone to release the
             // immutable borrow on `block_index` before we mutate stats).
             let candidates: Vec<HNode> = self
@@ -710,6 +720,7 @@ impl<'c> HyperEngine<'c> {
                     &self.nodes[np.index()].labels,
                     &self.nodes[mp.index()].labels,
                 ) {
+                    self.stats.blocks_fired += 1;
                     return true;
                 }
             }
@@ -728,6 +739,7 @@ impl<'c> HyperEngine<'c> {
                 let ln_labels = &self.nodes[n.index()].labels;
                 let m_labels = &self.nodes[i].labels;
                 if subset_sorted(ln_labels, m_labels) {
+                    self.stats.blocks_fired += 1;
                     return true;
                 }
             }

--- a/docs/architecture-roadmap.md
+++ b/docs/architecture-roadmap.md
@@ -1,5 +1,21 @@
 # Architecture roadmap — closing the default-mode gap
 
+> **⚠ 2026-06-05 update — the "blocking never fires" diagnosis below is
+> STALE.** It was measured on the *classic* tableau (pre-wedge,
+> `is_blocked_true = 0`). The default engine is now the hypertableau
+> **wedge** (since 2026-05-29), whose double-blocking **fires effectively**:
+> `rustdl hyper-classify-probe` on owlcs pizza reports **`blocks_fired =
+> 21 653` of `block_eligible = 62 528` (≈35 %)**, `stalled = 0`; SIO
+> per-class sat (`hyper-sat`) converges in 657 ms (max 15 branches/class,
+> 0 stalls). So **"stronger blocking" is NOT the lever** for the remaining
+> gaps — the wedge already converges on pizza/SIO. The real remaining gaps
+> are (a) wedge/`trust_sat` **completeness** (notgalen 18 IPBP-cluster — a
+> *saturation* gap, dead-ended in Phase 2c/2d; SIO 2 out-of-EL pairs) and
+> (b) per-pair / classify **perf** (tier-walk + label-heuristic, Phase 6/7
+> territory), not model-size blowup. Measurement counters `blocks_fired` /
+> `block_eligible` added to `SearchStats` (commit on `chore/blocking-
+> observability`). See `docs/handoff-2026-06-05.md`.
+
 Drafted 2026-05-26 after the day's three architectural experiments
 (MOMS, model-caching root-labels, syntactic module extraction) all
 hit measured dead-ends. This doc consolidates what the diagnosis


### PR DESCRIPTION
Adds `blocks_fired`/`block_eligible` profiling counters and uses them to **invalidate the architecture-roadmap's headline 'blocking never fires' lever** — that was the classic tableau; the default wedge's double-blocking fires heavily (pizza ~35% of eligible, 21 653 blocks; SIO converges, 0 stalls). Dated correction added to the roadmap. Profiling-only, no behavior change; 96 tableau tests, clippy/fmt clean.