### PR TITLE
feat(saturation): Phase 2e — close notgalen's 18 MISSED via functional super-role merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,18 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   pairs recovered).** Wall cost: GALEN +6.5%, notgalen +2.7%. FP=0
   held throughout. Resolves dead-end §15. See
   `docs/phase2d-2c-redux-results.md`.
+  Phase 2e (commit 883bc2f) closed notgalen's residual 18. The
+  witness-merge back-prop skipped the merge-*triggering* sub-role
+  (`other.role == fact.role`), so the merged synthetic never reached
+  the sub-role an existential body lives on when that role's fact was
+  processed second — an order-dependent miss (GALEN hit the good
+  order; notgalen's equiv-vs-subclass structure hit the bad one).
+  Dropping the skip is sound by functionality of `R_f` (every sub-role
+  witness coincides with the single `R_f`-successor carrying the merged
+  atom set). **notgalen MISSED 18 → 0 (full Konclude parity, closure
+  32739=32739); GALEN stays 0; FP=0 across the whole corpus.** The
+  only remaining corpus MISS is SIO's 2 (out-of-EL). Canary
+  `functional_role_merge_body_on_sub_role`. See `docs/phase2e-results.md`.
 
 - **`crates/owl-dl-tableau`** — SROIQ tableau. `CompletionGraph` (`graph.rs`)
   of label-carrying nodes; `TableauTrail` (`trail.rs`) gives log-and-undo

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -855,23 +855,34 @@ impl WorklistEngine {
                 // docs/phase2c-fix-target.md §"Rule design" for the
                 // original argument).
                 //
-                // We skip `other.role == fact.role` to avoid the
-                // trivially redundant emission on R_arr (Phase 2a's CR9
-                // hierarchy propagation already covers it). We snapshot
-                // `facts_by_sub[fact.sub]` before iterating because
-                // `push_fact` writes into it.
+                // Phase 2e: we DO emit on the merge-triggering role
+                // (`other.role == fact.role`) too. Pre-2e skipped it,
+                // reasoning CR9 hierarchy propagation already covered
+                // R_arr — but CR9 only propagates the *original* witness
+                // `target` UP to the super-role `R_f`; it does NOT push
+                // the merged *synthetic* DOWN to R_arr. When the
+                // existential body lives on R_arr itself (notgalen IPBP:
+                // `∃hasIntrinsicPathologicalStatus.pathological`), the
+                // merged filler must land on R_arr or the fold never
+                // fires — an order-dependent miss (whichever sub-role's
+                // fact was processed second triggered the merge and was
+                // then the only role NOT to receive the synthetic). See
+                // `functional_role_merge_body_on_sub_role`.
+                //
+                // Soundness: by functionality of `R_f`, EVERY sub-role
+                // witness (including R_arr's) coincides with the single
+                // `R_f`-successor that carries the full merged atom set,
+                // so `(sub, R_arr, synthetic)` holds in every model.
                 //
                 // Re-using `push_fact` here (vs the manual insertion
                 // pattern Phase 2c originally used) means each emitted
                 // `(X, R_k, synthetic)` also recursively inherits to X's
                 // subclasses via Phase 2d — sound by the same witness-
-                // inheritance argument.
+                // inheritance argument. We snapshot `facts_by_sub[fact.sub]`
+                // before iterating because `push_fact` writes into it.
                 let facts_snapshot = self.facts_by_sub[fact.sub.index() as usize].clone();
                 for other_idx in facts_snapshot {
                     let other = self.facts[other_idx];
-                    if other.role == fact.role {
-                        continue;
-                    }
                     if !self.rules.functional_supers_of(other.role).contains(&rf) {
                         continue;
                     }
@@ -2723,6 +2734,65 @@ Ontology(<http://rustdl.test/p2a3/test>
             subsumers.contains(subject, target),
             "Phase 2a 3-sub-property fan-in: the witness-merge rule failed \
              to accumulate {{A, B, C}} across three sub-property facts."
+        );
+    }
+
+    /// Phase 2e — witness-merge with the existential body on a SUB-role
+    /// (not the functional super-role). This is the notgalen IPBP shape:
+    /// `Subject` has `∃r_i.A` and `∃r_j.B` (both `r_i,r_j ⊑` functional
+    /// `r_func`); `Target ≡ ∃r_i.B`. By functionality of `r_func` the two
+    /// witnesses coincide, so `r_i`'s witness is `A ⊓ B` and `Subject ⊑
+    /// ∃r_i.B = Target`. The pre-Phase-2e back-prop skipped the
+    /// merge-triggering sub-role, so the merged synthetic never reached
+    /// `r_i` when `r_i`'s fact happened to be processed second — an
+    /// order-dependent miss. Mirrors `Anonymous-349 ⊑
+    /// IntrinsicallyPathologicalBodyProcess` (notgalen's 18 MISSED).
+    #[test]
+    fn functional_role_merge_body_on_sub_role() {
+        use horned_owl::io::ParserConfiguration;
+        use horned_owl::io::ofn::reader::read;
+        use horned_owl::model::RcStr;
+        use horned_owl::ontology::set::SetOntology;
+        use owl_dl_core::convert::convert_ontology;
+        use std::io::Cursor;
+
+        let src = "\
+Prefix(:=<http://rustdl.test/p2e/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://rustdl.test/p2e/test>
+    Declaration(Class(:Subject))
+    Declaration(Class(:A))
+    Declaration(Class(:B))
+    Declaration(Class(:Target))
+    Declaration(Class(:D))
+    Declaration(ObjectProperty(:r_func))
+    Declaration(ObjectProperty(:r_i))
+    Declaration(ObjectProperty(:r_j))
+    FunctionalObjectProperty(:r_func)
+    SubObjectPropertyOf(:r_i :r_func)
+    SubObjectPropertyOf(:r_j :r_func)
+    EquivalentClasses(:Subject ObjectIntersectionOf(:D ObjectSomeValuesFrom(:r_i :A)))
+    SubClassOf(:Subject ObjectSomeValuesFrom(:r_j :B))
+    EquivalentClasses(:Target ObjectIntersectionOf(ObjectSomeValuesFrom(:r_i :B) :D))
+)
+";
+        let mut reader = Cursor::new(src);
+        let (set_onto, _): (SetOntology<RcStr>, _) =
+            read(&mut reader, ParserConfiguration::default()).expect("parses");
+        let internal = convert_ontology(&set_onto).expect("lowers");
+        let subsumers = crate::saturate(&internal);
+        let subject = internal
+            .vocabulary
+            .class_id("http://rustdl.test/p2e/Subject")
+            .expect("Subject declared");
+        let target = internal
+            .vocabulary
+            .class_id("http://rustdl.test/p2e/Target")
+            .expect("Target declared");
+        assert!(
+            subsumers.contains(subject, target),
+            "Phase 2e: witness-merge failed to propagate the merged synthetic \
+             to the body's sub-role r_i (Subject ⊑ ∃r_i.B = Target)."
         );
     }
 

--- a/docs/phase2e-results.md
+++ b/docs/phase2e-results.md
@@ -1,0 +1,79 @@
+# Phase 2e — functional super-role witness-merge on the body sub-role
+
+Run 2026-06-05. Closes the notgalen residual 18 MISSED (full Konclude parity)
+by fixing an order-dependent gap in the Phase 2a/2c-redux witness-merge rule.
+
+## Headline
+
+**notgalen MISSED 18 → 0** (rustdl_closure = konclude_closure = 32 739, FP=0).
+First time notgalen reaches full Konclude parity. GALEN stays at 0. FP=0 held
+across the entire corpus. The only remaining corpus MISS is SIO's 2 (out-of-EL,
+separate gap).
+
+## Root cause
+
+The 18 reduce to one root, `Anonymous-349 ⊑ Anonymous-324`
+(≡ `IntrinsicallyPathologicalBodyProcess`); the other 17 inherit via
+`9 cardiac classes ⊑ IneffectiveCardiacFunction ⊑ Anonymous-349`.
+
+```
+Anonymous-349 ≡ BodyProcess ⊓ ∃hasEffectiveness.(…ineffective…)
+                           ⊓ ∃hasIntrinsicPathologicalStatus.physiological
+Anonymous-349 ⊑ ∃hasPathologicalStatus.pathological
+Anonymous-324 ≡ ∃hasIntrinsicPathologicalStatus.pathological ⊓ BodyProcess
+```
+
+`hasIntrinsicPathologicalStatus` and `hasPathologicalStatus` are both sub-roles
+of `StatusAttribute`, which is **functional**. So A349's two status witnesses
+(`physiological`, `pathological`) coincide into one node = `physiological ⊓
+pathological`, reached via `hasIntrinsicPathologicalStatus` ⇒ A349 ⊑
+`∃hasIntrinsicPathologicalStatus.pathological` ⇒ A349 ⊑ Anonymous-324. Standard
+SROIQ functional super-role merge; Konclude does it, the EL saturator did not.
+
+**The bug.** The Phase 2a merge rule (in `process_fact`) emits the merged
+synthetic on the functional super-role `R_f` and back-propagates it to the
+*other* sub-roles `R_k` that the subject has witnesses on — but it **skipped the
+merge-triggering role** (`other.role == fact.role`), on the rationale that CR9
+hierarchy propagation already covers `R_arr`. CR9 only propagates the *original*
+witness *up* to `R_f`; it never pushes the merged *synthetic* *down* to `R_arr`.
+When the existential body lives on `R_arr` itself (IPBP's body is on
+`hasIntrinsicPathologicalStatus`), the merged filler must land on `R_arr`. Which
+sub-role is `R_arr` depends on fact-processing order — so the synthetic reached
+`hasIntrinsicPathologicalStatus` in some orders and not others. On notgalen it
+landed the wrong way ⇒ 18 MISSED. The Phase 2a canaries never caught it because
+their `Target` body is on the super-role (`∃r_func.…`), which uses the rule's
+*direct* super-role emit and never exercises the sub-role back-prop.
+
+## The fix
+
+Remove the `other.role == fact.role` skip in the back-prop loop
+(`crates/owl-dl-saturation/src/lib.rs`). The merged synthetic now also lands on
+the triggering sub-role, making the rule order-independent.
+
+**Soundness.** By functionality of `R_f`, every sub-role witness — including
+`R_arr`'s — coincides with the single `R_f`-successor carrying the full merged
+atom set, so `(sub, R_arr, synthetic)` holds in every model. The back-prop
+condition still requires `R_f ∈ functional_supers_of(other.role)`, i.e.
+`other.role ⊑ R_f` functional. FP=0 empirically across alehif, ore-10908,
+ore-15672, shoiq-knowledge, ro, sulo, sio, galen, notgalen.
+
+## Test
+
+`functional_role_merge_body_on_sub_role` (saturation crate): the minimal A349
+shape (Subject ≡ D ⊓ ∃r_i.A; Subject ⊑ ∃r_j.B; Target ≡ ∃r_i.B ⊓ D, with
+r_i,r_j ⊑ functional r_func). Red before the fix, green after. The pre-existing
+super-role-body canaries still pass.
+
+## Corpus gate
+
+| Fixture | FP | MISSED | wall |
+|---|---|---|---|
+| alehif | 0 | 0 | 0.15 s |
+| galen | 0 | 0 | 0.52 s |
+| **notgalen** | **0** | **18 → 0** | 1.00 s |
+| ro | 0 | 0 | 5.88 s |
+| shoiq-knowledge | 0 | 0 | 17.77 s |
+| ore-10908-sroiq | 0 | 0 | 19.89 s |
+| sulo | 0 | 0 | 0.25 s |
+| sio | 0 | 2 (out-of-EL) | 31.11 s |
+| ore-15672-shoin | 0 | 0 | 42.89 s |


### PR DESCRIPTION
## Result

**notgalen MISSED 18 → 0** — first full Konclude parity for notgalen (`rustdl_closure = konclude_closure = 32 739`, FP=0). The corpus completeness gap is now just SIO's 2 out-of-EL pairs.

| Fixture | FP | MISSED | wall |
|---|---|---|---|
| alehif | 0 | 0 | 0.15 s |
| galen | 0 | 0 | 0.52 s |
| **notgalen** | **0** | **18 → 0** | 1.00 s |
| ro | 0 | 0 | 5.88 s |
| shoiq-knowledge | 0 | 0 | 17.77 s |
| ore-10908-sroiq | 0 | 0 | 19.89 s |
| sulo | 0 | 0 | 0.25 s |
| sio | 0 | 2 (out-of-EL, unchanged) | 31.11 s |
| ore-15672-shoin | 0 | 0 | 42.89 s |

## Root cause

The 18 reduce to one root `Anonymous-349 ⊑ Anonymous-324` (the other 17 inherit via `9 cardiac classes ⊑ IneffectiveCardiacFunction ⊑ Anonymous-349`). It needs **functional super-role witness merge**: `hasIntrinsicPathologicalStatus` and `hasPathologicalStatus` are sibling sub-roles of the **functional** `StatusAttribute`, so A349's two status witnesses (`physiological`, `pathological`) coincide ⇒ `A349 ⊑ ∃hasIntrinsicPathologicalStatus.pathological` ⇒ `⊑ Anonymous-324`.

The mechanism existed (Phase 2a), but the back-prop loop **skipped the merge-triggering sub-role** (`other.role == fact.role`), wrongly assuming CR9 covered it — CR9 only lifts the original witness *up* to the super-role, never pushes the merged synthetic *down* to the triggering sub-role. When the existential body lives on that sub-role, the merged filler must land there; which sub-role triggers depends on processing order, so GALEN hit the good order (closed in 2d) while notgalen's equiv-vs-subclass structure hit the bad one.

## Fix

Drop the skip (one-liner). **Sound by functionality of R_f**: every sub-role witness — including the triggering one — coincides with the single R_f-successor carrying the full merged atom set, so `(sub, R_arr, synthetic)` holds in every model. This extends a GALEN-validated path (the same `functional_supers_of` guard, FP=0 there) to the order notgalen needed — no new trust assumption. Verified three ways: saturator = rustdl tableau (on a minimal module) = Konclude (9 corpus ontologies).

## Tests / gates

- New canary `functional_role_merge_body_on_sub_role` (red before, green after); existing super-role-body canaries still pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo test --workspace` + doctests pass; fmt clean.
- FP=0 across the full corpus closure-diff.

See `docs/phase2e-results.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)