### PR TITLE
feat(py): expose explanation/justification via rustdl.explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to rustdl are documented here. Format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); rustdl follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python bindings for explanation / justification.** `rustdl.explain(path, sub, sup)`
+  returns the minimal responsible-axiom set(s) — *justifications* — for an entailed
+  `SubClassOf`, each rendered as Manchester-syntax axiom strings (`[]` if not entailed).
+  `all=True` returns up to `max` justifications (Reiter Hitting-Set Tree). Companions:
+  `explain_unsatisfiable(path, class)`, `explain_inconsistency(path)`,
+  `explain_instance(path, individual, class)`. Black-box over the existing reasoner
+  (`owl_dl_reasoner::justify`); no engine changes. Implements the previously deferred
+  `rustdl.explain` roadmap item.
+
 ## [0.3.1] — 2026-06-05
 
 ### Added

--- a/crates/owl-dl-py/python/rustdl/__init__.py
+++ b/crates/owl-dl-py/python/rustdl/__init__.py
@@ -26,6 +26,10 @@ from rustdl._native import (
     UnknownClassError as UnknownClassError,
     materialize_inferred_subclass_axioms as materialize_inferred_subclass_axioms,
     materialize_inferred_class_assertions as materialize_inferred_class_assertions,
+    explain as explain,
+    explain_unsatisfiable as explain_unsatisfiable,
+    explain_inconsistency as explain_inconsistency,
+    explain_instance as explain_instance,
 )
 
 from . import examples as examples
@@ -129,4 +133,8 @@ __all__ = [
     "UnknownClassError",
     "materialize_inferred_subclass_axioms",
     "materialize_inferred_class_assertions",
+    "explain",
+    "explain_unsatisfiable",
+    "explain_inconsistency",
+    "explain_instance",
 ]

--- a/crates/owl-dl-py/src/explain.rs
+++ b/crates/owl-dl-py/src/explain.rs
@@ -1,0 +1,129 @@
+//! Explanation / justification helpers — the minimal responsible-axiom set(s)
+//! for an entailment ("why does this hold?"), via the reasoner's black-box
+//! justification search (`QuickXplain` for one, Reiter HST for all). Reuses
+//! `owl_dl_reasoner::justify`; no engine changes.
+
+use horned_owl::curie::PrefixMapping;
+use horned_owl::io::omn::AsManchester;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::justify::{Entailment, find_all_justifications, find_one_justification};
+use pyo3::prelude::*;
+
+use crate::errors::reason_error_to_py;
+use crate::load;
+
+/// Run the justification search for `q` and render each justification as a list
+/// of Manchester axiom strings. `all = false` → at most one (`QuickXplain`);
+/// `all = true` → up to `max` (Reiter Hitting-Set Tree). An empty outer list
+/// means `q` is not entailed (nothing to justify).
+fn justify(
+    onto: &SetOntology<RcStr>,
+    q: &Entailment,
+    all: bool,
+    max: usize,
+) -> PyResult<Vec<Vec<String>>> {
+    let pm = PrefixMapping::default();
+    let justs = if all {
+        find_all_justifications(onto, q, max).map_err(reason_error_to_py)?
+    } else {
+        find_one_justification(onto, q)
+            .map_err(reason_error_to_py)?
+            .into_iter()
+            .collect()
+    };
+    Ok(justs
+        .into_iter()
+        .map(|j| {
+            j.axioms
+                .iter()
+                .map(|ax| ax.as_manchester_with_prefixes(&pm).to_string())
+                .collect()
+        })
+        .collect())
+}
+
+/// Explain an entailed `SubClassOf(sub, sup)`. Returns a list of justifications,
+/// each a list of Manchester-rendered axiom strings. Empty list ⇒ not entailed.
+#[pyfunction]
+#[pyo3(signature = (path, sub, sup, *, all=false, max=10))]
+pub(crate) fn explain(
+    path: &str,
+    sub: &str,
+    sup: &str,
+    all: bool,
+    max: usize,
+) -> PyResult<Vec<Vec<String>>> {
+    let onto = load::load_path(path)?;
+    justify(
+        &onto,
+        &Entailment::SubClassOf {
+            sub: sub.to_string(),
+            sup: sup.to_string(),
+        },
+        all,
+        max,
+    )
+}
+
+/// Explain why `class` is unsatisfiable (entailed equivalent to `owl:Nothing`).
+#[pyfunction]
+#[pyo3(signature = (path, class, *, all=false, max=10))]
+pub(crate) fn explain_unsatisfiable(
+    path: &str,
+    class: &str,
+    all: bool,
+    max: usize,
+) -> PyResult<Vec<Vec<String>>> {
+    let onto = load::load_path(path)?;
+    justify(
+        &onto,
+        &Entailment::Unsatisfiable {
+            class: class.to_string(),
+        },
+        all,
+        max,
+    )
+}
+
+/// Explain why the ontology is inconsistent. Empty list ⇒ it is consistent.
+#[pyfunction]
+#[pyo3(signature = (path, *, all=false, max=10))]
+pub(crate) fn explain_inconsistency(
+    path: &str,
+    all: bool,
+    max: usize,
+) -> PyResult<Vec<Vec<String>>> {
+    let onto = load::load_path(path)?;
+    justify(&onto, &Entailment::Inconsistent, all, max)
+}
+
+/// Explain an entailed `ClassAssertion(class, individual)`.
+#[pyfunction]
+#[pyo3(signature = (path, individual, class, *, all=false, max=10))]
+pub(crate) fn explain_instance(
+    path: &str,
+    individual: &str,
+    class: &str,
+    all: bool,
+    max: usize,
+) -> PyResult<Vec<Vec<String>>> {
+    let onto = load::load_path(path)?;
+    justify(
+        &onto,
+        &Entailment::InstanceOf {
+            individual: individual.to_string(),
+            class: class.to_string(),
+        },
+        all,
+        max,
+    )
+}
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(explain, m)?)?;
+    m.add_function(wrap_pyfunction!(explain_unsatisfiable, m)?)?;
+    m.add_function(wrap_pyfunction!(explain_inconsistency, m)?)?;
+    m.add_function(wrap_pyfunction!(explain_instance, m)?)?;
+    Ok(())
+}

--- a/crates/owl-dl-py/src/lib.rs
+++ b/crates/owl-dl-py/src/lib.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 
 mod classify;
 mod errors;
+mod explain;
 mod load;
 mod materialize;
 mod queries;
@@ -19,5 +20,6 @@ fn _native(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     classify::register(m)?;
     queries::register(m)?;
     materialize::register(m)?;
+    explain::register(m)?;
     Ok(())
 }

--- a/crates/owl-dl-py/tests/python/test_explain.py
+++ b/crates/owl-dl-py/tests/python/test_explain.py
@@ -1,0 +1,26 @@
+import rustdl
+
+
+def test_explain_subclass_returns_justifications(fixtures_dir):
+    # datatype_definition.ofn entails Adult ⊑ Person (see test_materialize).
+    fixture = fixtures_dir / "datatype" / "datatype_definition.ofn"
+    js = rustdl.explain(str(fixture), "http://t/Adult", "http://t/Person")
+    assert isinstance(js, list)
+    assert js, "entailed subsumption should have at least one justification"
+    # Each justification is a non-empty list of rendered axiom strings.
+    for j in js:
+        assert isinstance(j, list) and j
+        assert all(isinstance(s, str) for s in j)
+
+
+def test_explain_not_entailed_is_empty(fixtures_dir):
+    # The reverse, Person ⊑ Adult, is NOT entailed.
+    fixture = fixtures_dir / "datatype" / "datatype_definition.ofn"
+    assert rustdl.explain(str(fixture), "http://t/Person", "http://t/Adult") == []
+
+
+def test_explain_all(fixtures_dir):
+    fixture = fixtures_dir / "datatype" / "datatype_definition.ofn"
+    js = rustdl.explain(str(fixture), "http://t/Adult", "http://t/Person", all=True, max=5)
+    assert isinstance(js, list) and js
+    assert all(isinstance(j, list) for j in js)


### PR DESCRIPTION
## Summary

Implements the deferred roadmap item **“Black-box `rustdl.explain(path, sub, sup)`
axiom-justifications”** — exposing the reasoner's existing justification engine
(`owl_dl_reasoner::justify`) through the Python bindings. **No engine changes**; this is a
thin black-box binding mirroring `materialize.rs` and the CLI's `justify` command.

## New Python API
```python
rustdl.explain(path, sub, sup, *, all=False, max=10)            # SubClassOf justifications
rustdl.explain_unsatisfiable(path, class_, *, all=False, max=10)
rustdl.explain_inconsistency(path, *, all=False, max=10)
rustdl.explain_instance(path, individual, class_, *, all=False, max=10)
```
Each returns `list[list[str]]` — a list of justifications, each a list of axioms rendered in
Manchester syntax (via `AsManchester`); `[]` when the entailment doesn't hold. `all=False`
uses `find_one_justification` (QuickXplain); `all=True` uses `find_all_justifications` (Reiter
Hitting-Set Tree, capped at `max`).

```python
>>> rustdl.explain("onto.ofn", "http://ex#A", "http://ex#C")
[['<http://ex#A> SubClassOf <http://ex#B>', '<http://ex#B> SubClassOf <http://ex#C>']]
```

## Changes
- `crates/owl-dl-py/src/explain.rs` (new) — the four `#[pyfunction]`s + a shared `justify()` helper.
- `crates/owl-dl-py/src/lib.rs` — `mod explain;` + `explain::register(m)?;`.
- `crates/owl-dl-py/python/rustdl/__init__.py` — re-export the four names + `__all__`.
- `crates/owl-dl-py/tests/python/test_explain.py` (new) — entailed/non-entailed/`all=True` tests.
- `CHANGELOG.md` — Unreleased / Added.

## Testing
- `maturin develop` builds clean; `cargo fmt --check` clean; `cargo clippy -p owl-dl-py` clean.
- `pytest crates/owl-dl-py/tests/python` → all green (new `test_explain.py` + existing suite, no regression).
- Verified justifications are minimal (excludes irrelevant axioms), `[]` for non-entailments,
  and `all=True` returns multiple justifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
