### PR TITLE
Fix inverse-role + qualified-cardinality soundness bug (spurious unsat → FP)

### DIFF
--- a/crates/owl-dl-reasoner/tests/inverse_cardinality_soundness.rs
+++ b/crates/owl-dl-reasoner/tests/inverse_cardinality_soundness.rs
@@ -1,0 +1,84 @@
+//! Soundness regression: inverse role + qualified number restrictions must not
+//! make a satisfiable class spuriously unsatisfiable.
+//!
+//! Minimal core distilled (via ddmin) from ORE-2015 `ore_ont_9786` (an
+//! approximated-DL SIO), where rustdl reported `SIO_000500 ⊑ SIO_000440/441`
+//! that both Konclude and HermiT reject. Root cause: `apply_min` generated a
+//! redundant `≥n r.C532` witness because the `≥m r.C500` witnesses had not yet
+//! had the told super-label `C532` (`C500 ⊑ C532`) propagated, and the extra
+//! pairwise-distinct witness then made `≤k r.C532` spuriously clash — so the
+//! class became unsatisfiable (⊑ everything). The fix counts a told *subclass*
+//! of the filler as a witness (`ConceptRule` told-subsumer closure).
+//!
+//! With `r ≡ s⁻`:
+//!   C500 ⊑ C532
+//!   C500 ⊑ ≥2 s.C501
+//!   C501 ⊑ C512
+//!   C501 ⊑ =2 r.C500
+//!   C512 ⊑ =2 r.C532
+//! `C500` is satisfiable (Konclude + HermiT agree); the inverse role is
+//! essential (it makes the C500-node a shared `r`-neighbour of the C501-nodes).
+//!
+//! Run: `cargo test -p owl-dl-reasoner --test inverse_cardinality_soundness`
+
+#![allow(clippy::unwrap_used, clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+const SRC: &str = r#"Prefix(:=<http://ex/>)
+Ontology(<http://ex/cardfp>
+Declaration(Class(:C500)) Declaration(Class(:C501)) Declaration(Class(:C512))
+Declaration(Class(:C532)) Declaration(Class(:Probe))
+Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))
+InverseObjectProperties(:r :s)
+SubClassOf(:C500 :C532)
+SubClassOf(:C500 ObjectMinCardinality(2 :s :C501))
+SubClassOf(:C501 :C512)
+SubClassOf(:C501 ObjectExactCardinality(2 :r :C500))
+SubClassOf(:C512 ObjectExactCardinality(2 :r :C532))
+)"#;
+
+fn onto() -> SetOntology<RcStr> {
+    let mut r = Cursor::new(SRC);
+    let (o, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut r, ParserConfiguration::default()).expect("parse");
+    o
+}
+
+const C500: &str = "http://ex/C500";
+const C532: &str = "http://ex/C532";
+const PROBE: &str = "http://ex/Probe";
+
+#[test]
+fn c500_is_satisfiable() {
+    let o = onto();
+    assert!(
+        owl_dl_reasoner::is_class_satisfiable(&o, C500).expect("sat check"),
+        "C500 must be satisfiable (Konclude + HermiT agree); spurious unsat = inverse+cardinality soundness bug"
+    );
+}
+
+#[test]
+fn c500_not_subsumed_by_unrelated_class() {
+    let o = onto();
+    // If C500 were spuriously unsatisfiable it would be ⊑ everything, incl. the
+    // unrelated `Probe`. This is the direct false-positive symptom.
+    assert!(
+        !owl_dl_reasoner::is_subclass_of(&o, C500, PROBE).expect("subclass check"),
+        "C500 ⊑ Probe (unrelated) is a false positive — C500 wrongly unsatisfiable"
+    );
+}
+
+#[test]
+fn c500_genuine_subsumption_preserved() {
+    let o = onto();
+    // The real subsumption must still hold (no completeness regression here).
+    assert!(
+        owl_dl_reasoner::is_subclass_of(&o, C500, C532).expect("subclass check"),
+        "C500 ⊑ C532 is a told subsumption and must still be found"
+    );
+}

--- a/crates/owl-dl-reasoner/tests/inverse_cardinality_soundness.rs
+++ b/crates/owl-dl-reasoner/tests/inverse_cardinality_soundness.rs
@@ -29,7 +29,7 @@ use horned_owl::model::RcStr;
 use horned_owl::ontology::set::SetOntology;
 use std::io::Cursor;
 
-const SRC: &str = r#"Prefix(:=<http://ex/>)
+const SRC: &str = r"Prefix(:=<http://ex/>)
 Ontology(<http://ex/cardfp>
 Declaration(Class(:C500)) Declaration(Class(:C501)) Declaration(Class(:C512))
 Declaration(Class(:C532)) Declaration(Class(:Probe))
@@ -40,7 +40,7 @@ SubClassOf(:C500 ObjectMinCardinality(2 :s :C501))
 SubClassOf(:C501 :C512)
 SubClassOf(:C501 ObjectExactCardinality(2 :r :C500))
 SubClassOf(:C512 ObjectExactCardinality(2 :r :C532))
-)"#;
+)";
 
 fn onto() -> SetOntology<RcStr> {
     let mut r = Cursor::new(SRC);

--- a/crates/owl-dl-reasoner/tests/konclude_closure_diff.rs
+++ b/crates/owl-dl-reasoner/tests/konclude_closure_diff.rs
@@ -957,12 +957,9 @@ fn anytime_global_sweep() {
 #[test]
 #[ignore = "single-ontology ORE diff; needs ORE_ONE_INPUT + ORE_ONE_ORACLE"]
 fn ore_one_closure_matches_oracle() {
-    let input = match std::env::var("ORE_ONE_INPUT") {
-        Ok(p) => p,
-        Err(_) => {
-            eprintln!("SKIP: ORE_ONE_INPUT not set");
-            return;
-        }
+    let Ok(input) = std::env::var("ORE_ONE_INPUT") else {
+        eprintln!("SKIP: ORE_ONE_INPUT not set");
+        return;
     };
     let oracle = std::env::var("ORE_ONE_ORACLE").expect("ORE_ONE_ORACLE");
     let stem = Path::new(&input)
@@ -990,12 +987,9 @@ fn ore_one_closure_matches_oracle() {
 #[test]
 #[ignore = "at-scale ORE sweep; needs ORE_INPUT_DIR + ORE_ORACLE_DIR"]
 fn ore_dir_closure_matches_oracle() {
-    let input_dir = match std::env::var("ORE_INPUT_DIR") {
-        Ok(d) => d,
-        Err(_) => {
-            eprintln!("SKIP: ORE_INPUT_DIR not set");
-            return;
-        }
+    let Ok(input_dir) = std::env::var("ORE_INPUT_DIR") else {
+        eprintln!("SKIP: ORE_INPUT_DIR not set");
+        return;
     };
     let oracle_dir = std::env::var("ORE_ORACLE_DIR").unwrap_or_else(|_| input_dir.clone());
     let pair_ms = test_pair_ms();
@@ -1010,7 +1004,13 @@ fn ore_dir_closure_matches_oracle() {
         .collect();
     entries.sort();
     for input in entries {
-        let stem = input.file_stem().and_then(|s| s.to_str()).unwrap().to_owned();
+        let Some(stem) = input
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(ToOwned::to_owned)
+        else {
+            continue;
+        };
         let oracle = Path::new(&oracle_dir).join(format!("{stem}-classified.owx"));
         if oracle.exists() {
             pairs.push((stem, input, oracle));
@@ -1040,7 +1040,7 @@ fn ore_dir_closure_matches_oracle() {
             }
             Err(_) => eprintln!("--- {stem} --- SKIP (panic: parse/classify error)"),
         }
-        if done % 10 == 0 {
+        if done.is_multiple_of(10) {
             eprintln!(
                 "[progress] {done}/{} done, running FP total={total_fp}",
                 pairs.len()

--- a/crates/owl-dl-reasoner/tests/konclude_closure_diff.rs
+++ b/crates/owl-dl-reasoner/tests/konclude_closure_diff.rs
@@ -948,3 +948,109 @@ fn anytime_global_sweep() {
         .unwrap_or_else(|e| panic!("write CSV to {}: {e}", csv_path.display()));
     println!("wrote {}", csv_path.display());
 }
+
+/// Single (input, oracle) diff driven by env — for wall-capped subprocess use
+/// in the at-scale ORE sweep (one process per ontology so an OS-level timeout
+/// can bound each without stalling the whole corpus). Prints a `RESULT` line.
+///
+/// Env: `ORE_ONE_INPUT`, `ORE_ONE_ORACLE`, `RUSTDL_TEST_PAIR_MS` (default 200).
+#[test]
+#[ignore = "single-ontology ORE diff; needs ORE_ONE_INPUT + ORE_ONE_ORACLE"]
+fn ore_one_closure_matches_oracle() {
+    let input = match std::env::var("ORE_ONE_INPUT") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("SKIP: ORE_ONE_INPUT not set");
+            return;
+        }
+    };
+    let oracle = std::env::var("ORE_ONE_ORACLE").expect("ORE_ONE_ORACLE");
+    let stem = Path::new(&input)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?")
+        .to_owned();
+    let (r, k, fp, m) =
+        diff_corpus_ontology(&stem, Path::new(&input), Path::new(&oracle), test_pair_ms());
+    println!("RESULT\t{stem}\trustdl={r}\tkonclude={k}\tFP={fp}\tMISSED={m}");
+}
+
+/// Generic at-scale FP sweep over a directory of (input, oracle) pairs.
+///
+/// Drives the *same* trusted closure-diff (`diff_corpus_ontology`) used by the
+/// per-fixture tests over an arbitrary corpus — built for the ORE 2015 sweep.
+///
+/// Env:
+/// - `ORE_INPUT_DIR`  — dir of `<stem>.ofn` (OWL functional syntax) inputs.
+/// - `ORE_ORACLE_DIR` — dir of `<stem>-classified.owx` oracle classifications.
+/// - `RUSTDL_TEST_PAIR_MS` — per-pair tableau budget (default 200).
+///
+/// For every input whose oracle exists, prints one diff line and accumulates
+/// FP/MISSED, then asserts the corpus-wide FP total is 0 (the soundness gate).
+#[test]
+#[ignore = "at-scale ORE sweep; needs ORE_INPUT_DIR + ORE_ORACLE_DIR"]
+fn ore_dir_closure_matches_oracle() {
+    let input_dir = match std::env::var("ORE_INPUT_DIR") {
+        Ok(d) => d,
+        Err(_) => {
+            eprintln!("SKIP: ORE_INPUT_DIR not set");
+            return;
+        }
+    };
+    let oracle_dir = std::env::var("ORE_ORACLE_DIR").unwrap_or_else(|_| input_dir.clone());
+    let pair_ms = test_pair_ms();
+
+    // Collect (stem, input, oracle) for every input with a matching oracle.
+    let mut pairs: Vec<(String, std::path::PathBuf, std::path::PathBuf)> = Vec::new();
+    let mut entries: Vec<_> = std::fs::read_dir(&input_dir)
+        .unwrap_or_else(|e| panic!("read_dir {input_dir}: {e}"))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("ofn"))
+        .collect();
+    entries.sort();
+    for input in entries {
+        let stem = input.file_stem().and_then(|s| s.to_str()).unwrap().to_owned();
+        let oracle = Path::new(&oracle_dir).join(format!("{stem}-classified.owx"));
+        if oracle.exists() {
+            pairs.push((stem, input, oracle));
+        }
+    }
+    eprintln!(
+        "### ORE sweep: {} pairs, per-pair budget {pair_ms} ms ###",
+        pairs.len()
+    );
+
+    let mut total_fp = 0usize;
+    let mut fp_onts: Vec<String> = Vec::new();
+    let mut done = 0usize;
+    for (stem, input, oracle) in &pairs {
+        // Guard the oracle parse + classify so one bad ontology doesn't abort
+        // the whole sweep; a panic is recorded as a skip, not a pass.
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            diff_corpus_ontology(stem, input, oracle, pair_ms)
+        }));
+        done += 1;
+        match res {
+            Ok((_r, _k, fp, _m)) => {
+                if fp > 0 {
+                    total_fp += fp;
+                    fp_onts.push(format!("{stem} (FP={fp})"));
+                }
+            }
+            Err(_) => eprintln!("--- {stem} --- SKIP (panic: parse/classify error)"),
+        }
+        if done % 10 == 0 {
+            eprintln!(
+                "[progress] {done}/{} done, running FP total={total_fp}",
+                pairs.len()
+            );
+        }
+    }
+
+    eprintln!("### ORE sweep complete: {done} ontologies, total FP={total_fp} ###");
+    if !fp_onts.is_empty() {
+        eprintln!("FP ontologies: {}", fp_onts.join(", "));
+    }
+    assert_eq!(total_fp, 0, "ORE sweep found {total_fp} false positives");
+}

--- a/crates/owl-dl-tableau/src/lib.rs
+++ b/crates/owl-dl-tableau/src/lib.rs
@@ -218,6 +218,15 @@ pub struct TableauContext<'pool, 'tbox, 'hier> {
     /// hot `is_blocked` path pays no per-call env read. See
     /// `docs/superpowers/plans/2026-06-15-anywhere-pairwise-blocking.md`.
     anywhere_blocking: bool,
+    /// Memoised transitive told-subsumer closure over **atomic** classes:
+    /// `trigger ClassId → sorted atomic-super ConceptIds` reachable through
+    /// chains of `ConceptRule`s whose conclusion is itself `Atomic(_)`. Built
+    /// lazily once from [`Self::tbox`]. Used by [`apply_min`](crate::rules::apply_min)
+    /// so that a `≥n R.C` count recognises an existing `R`-neighbour carrying a
+    /// told *sub*class of `C` as a witness — preventing a redundant successor
+    /// that would otherwise make a `≤m R.D` (with `C ⊑ D`) spuriously clash
+    /// (inverse-role + qualified-cardinality soundness fix).
+    told_super_closure: std::cell::OnceCell<HashMap<owl_dl_core::ClassId, Vec<ConceptId>>>,
     /// Per-rule call counters, populated under `cfg(feature =
     /// "counters")`. Dumped to stderr in `Drop` when
     /// `RUSTDL_COUNTERS=1`. Zero cost in non-counter builds (field
@@ -252,6 +261,7 @@ impl<'pool> TableauContext<'pool, 'static, 'static> {
             decision_labels: Vec::new(),
             dkey_ranges: HashMap::new(),
             anywhere_blocking: anywhere_blocking_enabled(),
+            told_super_closure: std::cell::OnceCell::new(),
             #[cfg(feature = "counters")]
             counters: crate::counters::RuleCounters::default(),
         }
@@ -283,6 +293,7 @@ impl<'pool, 'tbox> TableauContext<'pool, 'tbox, 'static> {
             decision_labels: Vec::new(),
             dkey_ranges: HashMap::new(),
             anywhere_blocking: anywhere_blocking_enabled(),
+            told_super_closure: std::cell::OnceCell::new(),
             #[cfg(feature = "counters")]
             counters: crate::counters::RuleCounters::default(),
         }
@@ -319,6 +330,7 @@ impl<'pool, 'tbox, 'hier> TableauContext<'pool, 'tbox, 'hier> {
             decision_labels: Vec::new(),
             dkey_ranges: HashMap::new(),
             anywhere_blocking: anywhere_blocking_enabled(),
+            told_super_closure: std::cell::OnceCell::new(),
             #[cfg(feature = "counters")]
             counters: crate::counters::RuleCounters::default(),
         }
@@ -537,6 +549,78 @@ impl<'pool, 'tbox, 'hier> TableauContext<'pool, 'tbox, 'hier> {
     #[must_use]
     pub fn tbox(&self) -> Option<&AbsorbedTBox> {
         self.tbox
+    }
+
+    /// True iff `node`'s label set entails the atomic filler `body` either
+    /// directly (`body ∈ L(node)`) or through the told-subsumer closure (some
+    /// `Atomic(C) ∈ L(node)` with `C ⊑* body` via atomic `ConceptRule`s).
+    ///
+    /// Soundness: an atomic `ConceptRule` (`trigger ClassId → Atomic super`) is
+    /// an unconditional told subsumption, so a node carrying `C` is in every
+    /// model also a `body` when `C ⊑* body`. Counting it as a `≥n R.body`
+    /// witness therefore never over-counts; it only avoids generating a
+    /// redundant successor that a later `≤m R.body` would clash on.
+    #[must_use]
+    pub fn node_entails_filler(&self, node: NodeId, body: ConceptId) -> bool {
+        let labels = &self.graph.node(node).labels;
+        if labels.binary_search(&body).is_ok() {
+            return true;
+        }
+        let closure = self
+            .told_super_closure
+            .get_or_init(|| self.build_told_super_closure());
+        if closure.is_empty() {
+            return false;
+        }
+        for &l in labels {
+            if let owl_dl_core::ConceptExpr::Atomic(cls) = self.pool.get(l)
+                && let Some(supers) = closure.get(cls)
+                && supers.binary_search(&body).is_ok()
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Build the transitive told-subsumer closure over atomic classes from the
+    /// `TBox`'s atomic `ConceptRule`s. `trigger → sorted [atomic super ConceptId]`.
+    fn build_told_super_closure(&self) -> HashMap<owl_dl_core::ClassId, Vec<ConceptId>> {
+        use owl_dl_core::ConceptExpr;
+        let mut closure: HashMap<owl_dl_core::ClassId, Vec<ConceptId>> = HashMap::new();
+        let Some(tbox) = self.tbox else {
+            return closure;
+        };
+        // Direct atomic told-supers: trigger ClassId -> [Atomic super ConceptId].
+        let mut direct: HashMap<owl_dl_core::ClassId, Vec<ConceptId>> = HashMap::new();
+        for rule in &tbox.concept_rules {
+            if matches!(self.pool.get(rule.conclusion), ConceptExpr::Atomic(_)) {
+                direct.entry(rule.trigger).or_default().push(rule.conclusion);
+            }
+        }
+        // Transitive closure via BFS over atomic super -> its ClassId -> direct.
+        for (&trigger, seeds) in &direct {
+            let mut seen: Vec<ConceptId> = Vec::new();
+            let mut stack: Vec<ConceptId> = seeds.clone();
+            while let Some(c) = stack.pop() {
+                if seen.contains(&c) {
+                    continue;
+                }
+                seen.push(c);
+                if let ConceptExpr::Atomic(super_cls) = self.pool.get(c)
+                    && let Some(next) = direct.get(super_cls)
+                {
+                    for &n in next {
+                        if !seen.contains(&n) {
+                            stack.push(n);
+                        }
+                    }
+                }
+            }
+            seen.sort_unstable();
+            closure.insert(trigger, seen);
+        }
+        closure
     }
 
     #[must_use]

--- a/crates/owl-dl-tableau/src/lib.rs
+++ b/crates/owl-dl-tableau/src/lib.rs
@@ -595,7 +595,10 @@ impl<'pool, 'tbox, 'hier> TableauContext<'pool, 'tbox, 'hier> {
         let mut direct: HashMap<owl_dl_core::ClassId, Vec<ConceptId>> = HashMap::new();
         for rule in &tbox.concept_rules {
             if matches!(self.pool.get(rule.conclusion), ConceptExpr::Atomic(_)) {
-                direct.entry(rule.trigger).or_default().push(rule.conclusion);
+                direct
+                    .entry(rule.trigger)
+                    .or_default()
+                    .push(rule.conclusion);
             }
         }
         // Transitive closure via BFS over atomic super -> its ClassId -> direct.

--- a/crates/owl-dl-tableau/src/rules.rs
+++ b/crates/owl-dl-tableau/src/rules.rs
@@ -818,13 +818,18 @@ pub fn apply_min(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> RuleOutc
         if n == 0 {
             continue;
         }
-        // Existing R-witnesses carrying `body`. Collect into a Vec
-        // (deduped: an edge that loops or that we'd otherwise count
-        // twice for some reason gets counted once).
+        // Existing R-witnesses carrying `body` — OR a told *subclass* of `body`
+        // (e.g. `C ⊑ D` ⟹ a `C`-neighbour witnesses `≥n R.D`). Without the
+        // told-subclass check, a freshly generated `≥m R.C` successor — whose
+        // `D` super-label has not yet propagated — is missed here, a redundant
+        // `R.D` successor is created, and a later `≤k R.D` (with `C ⊑ D`) then
+        // spuriously clashes on the extra pairwise-distinct witness. That is the
+        // inverse-role + qualified-cardinality unsoundness; `node_entails_filler`
+        // is sound (an atomic told subsumption holds in every model).
         let mut existing: Vec<NodeId> = Vec::new();
         for (seen, neighbour) in ctx.graph().node(node).neighbours() {
             if ctx.edge_satisfies(seen, role)
-                && ctx.graph().node(neighbour).has_label(body)
+                && ctx.node_entails_filler(neighbour, body)
                 && !existing.contains(&neighbour)
             {
                 existing.push(neighbour);

--- a/scripts/konclude-oracle.sh
+++ b/scripts/konclude-oracle.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Generate Konclude classification oracles (.owx) for the closure-diff net.
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$REPO_ROOT/ontologies/real"
+ORACLE="$OUT/konclude-input"
+ROBOT_IMG="${ROBOT_IMAGE:-obolibrary/robot:latest}"
+KON_IMG="konclude/konclude:latest"
+mkdir -p "$ORACLE"
+
+for f in sio sulo ro wine; do
+  echo "==> $f"
+  # back up the HermiT oracle if present
+  [[ -f "$ORACLE/$f-classified.owx" && ! -f "$ORACLE/$f-classified.hermit.owx" ]] \
+    && cp "$ORACLE/$f-classified.owx" "$ORACLE/$f-classified.hermit.owx"
+  # .ofn -> .owx (Konclude input)
+  docker run --rm -v "$OUT:/work" -w /work "$ROBOT_IMG" \
+    robot convert --input "$f.ofn" --format owx --output "konclude-input/$f.owx" >/dev/null 2>&1 \
+    || { echo "   CONVERT FAILED"; continue; }
+  # Konclude classification -> oracle .owx
+  log="$(docker run --rm -v "$ORACLE:/work" -w /work "$KON_IMG" \
+    classification -w AUTO -i "$f.owx" -o "$f-classified.owx" 2>&1)" || true
+  if [[ -f "$ORACLE/$f-classified.owx" ]]; then
+    echo "   konclude oracle ok ($(grep -oE 'Finished class classification in [0-9]+ ms' <<<"$log" | head -1))"
+  else
+    echo "   KONCLUDE FAILED:"; echo "$log" | tail -3
+  fi
+done
+echo "=== oracles ==="
+ls -la "$ORACLE"/*-classified.owx 2>/dev/null

--- a/scripts/ore-fp-sweep.sh
+++ b/scripts/ore-fp-sweep.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Per-ontology, wall-capped ORE FP sweep. One subprocess per ontology so a
+# hard SROIQ ontology can be killed without stalling the corpus.
+INPUT=/Users/micheldumontier/data/ore-run/input
+ORACLE=/Users/micheldumontier/data/ore-run/oracle
+TESTBIN="$1"                     # compiled konclude_closure_diff test binary
+CAP="${WALL_CAP:-120}"           # per-ontology wall cap (s)
+export RUSTDL_TEST_PAIR_MS="${RUSTDL_TEST_PAIR_MS:-200}"
+RESULTS=/tmp/ore_fp_results.tsv
+: > "$RESULTS"
+n=0; fp_total=0; fp_onts=""; killed=0; nooracle=0
+for inp in "$INPUT"/*.ofn; do
+  stem=$(basename "$inp" .ofn)
+  orc="$ORACLE/$stem-classified.owx"
+  [ -f "$orc" ] || { nooracle=$((nooracle+1)); continue; }
+  n=$((n+1))
+  ORE_ONE_INPUT="$inp" ORE_ONE_ORACLE="$orc" \
+    "$TESTBIN" --ignored --nocapture --exact ore_one_closure_matches_oracle \
+    > /tmp/ore_one.out 2>/dev/null &
+  pid=$!
+  ( sleep "$CAP"; kill -9 $pid 2>/dev/null ) 2>/dev/null & wpid=$!
+  wait $pid 2>/dev/null; rc=$?
+  kill -9 $wpid 2>/dev/null
+  if [ $rc -eq 137 ] || [ $rc -eq 9 ]; then
+    echo -e "$stem\tTIMEOUT(${CAP}s)" >> "$RESULTS"; killed=$((killed+1))
+  else
+    line=$(grep -m1 '^RESULT' /tmp/ore_one.out)
+    if [ -n "$line" ]; then
+      echo "$line" | cut -f2- >> "$RESULTS"
+      fp=$(echo "$line" | grep -oE 'FP=[0-9]+' | cut -d= -f2)
+      if [ "${fp:-0}" -gt 0 ]; then fp_total=$((fp_total+fp)); fp_onts="$fp_onts $stem(FP=$fp)"; fi
+    else
+      echo -e "$stem\tPANIC/parse-error" >> "$RESULTS"
+    fi
+  fi
+  [ $((n%20)) -eq 0 ] && echo "[progress] $n done, FP_total=$fp_total, timeouts=$killed ($(date +%H:%M:%S))"
+done
+echo "===================================================="
+echo "ORE SROIQ FP sweep complete: $n ontologies diffed"
+echo "  no-oracle skipped: $nooracle   timeouts: $killed"
+echo "  TOTAL FALSE POSITIVES: $fp_total"
+[ -n "$fp_onts" ] && echo "  FP ontologies:$fp_onts"
+echo "  results: $RESULTS"
+echo "  fragment-level FP counts:"; awk -F'\t' '/FP=/{print}' "$RESULTS" | grep -oE 'FP=[0-9]+' | sort | uniq -c

--- a/scripts/ore-fragment-prepass.sh
+++ b/scripts/ore-fragment-prepass.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Saturation-only fragment pre-pass: label each candidate ontology
+# PureEl / Horn / out-of-EL so the FP sweep can target the SROIQ subset.
+POOL=/Users/micheldumontier/data/ore-run/pool_sample
+RUSTDL=/Users/micheldumontier/code/rustdl/target/release/rustdl
+LIST=/tmp/ore_u5.txt
+OUT=/tmp/ore_fragments.tsv
+: > "$OUT"
+n=0
+while read -r f; do
+  n=$((n+1))
+  # per-file watchdog: kill saturation-only after 30s (treat as TIMEOUT)
+  "$RUSTDL" classify --saturation-only "$POOL/files/$f" >/tmp/ore_frag_one.txt 2>/dev/null &
+  pid=$!
+  ( sleep 30; kill -9 $pid 2>/dev/null ) 2>/dev/null &
+  wpid=$!
+  wait $pid 2>/dev/null; rc=$?
+  kill -9 $wpid 2>/dev/null
+  if [ $rc -eq 137 ] || [ $rc -eq 9 ]; then
+    frag="TIMEOUT"
+  else
+    frag=$(grep -m1 "# fragment:" /tmp/ore_frag_one.txt | sed 's/# fragment: //' | cut -c1-22)
+    [ -z "$frag" ] && frag="ERROR/empty"
+  fi
+  printf '%s\t%s\n' "$f" "$frag" >> "$OUT"
+  [ $((n % 50)) -eq 0 ] && echo "  ...$n/$(wc -l < $LIST) $(date +%H:%M:%S)"
+done < "$LIST"
+echo "=== fragment distribution ==="
+cut -f2 "$OUT" | sort | uniq -c | sort -rn
+grep "out-of-EL" "$OUT" | cut -f1 > /tmp/ore_sroiq.txt
+echo "=== out-of-EL (SROIQ) selected: $(wc -l < /tmp/ore_sroiq.txt) ==="

--- a/scripts/ore-minimize-fp.py
+++ b/scripts/ore-minimize-fp.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""ddmin over the 52-axiom neighborhood (fast: tiny ontology per test)."""
+import re, subprocess, os, tempfile
+RUSTDL="/Users/micheldumontier/code/rustdl/target/release/rustdl"
+SRC=os.path.expanduser("~/data/ore-run/input/ore_ont_9786.ofn")
+SUB="http://semanticscience.org/resource/SIO_000500"
+SUP="http://semanticscience.org/resource/SIO_000441"
+raw=open(SRC).read()
+m=re.match(r'(.*?Ontology\([^\n]*\n)(.*)\n\)\s*$',raw,re.S)
+header=m.group(1)
+lines=[l.strip() for l in m.group(2).split('\n') if l.strip()]
+logical=[l for l in lines if not l.startswith(('Declaration(','Prefix('))]
+core={'SIO_000500','SIO_000501','SIO_000441','SIO_000440','SIO_000507','SIO_000532',
+      'SIO_000402','SIO_000541','SIO_000400','SIO_000401','SIO_000313','SIO_000369'}
+def ids(s): return set(re.findall(r'SIO_\d+',s)) | set(re.findall(r'SIO_0\d+',s))
+nb=[l for l in logical if ids(l) & core]
+def write(sub):
+    used=set().union(*[ids(a) for a in sub]) if sub else set()
+    props=set(re.findall(r'SIO_\d+', " ".join(sub)))
+    decls=[f"Declaration(Class(<http://semanticscience.org/resource/{c}>))" for c in sorted(used)]
+    # declare object properties used in role positions
+    pdecls=[f"Declaration(ObjectProperty(<http://semanticscience.org/resource/{p}>))"
+            for p in ('SIO_000369','SIO_000313','SIO_000310','SIO_000273','SIO_000068','SIO_000059')]
+    f=tempfile.NamedTemporaryFile("w",suffix=".ofn",delete=False)
+    f.write(header+"\n".join(decls+pdecls+sub)+"\n)\n"); f.close(); return f.name
+def holds(sub):
+    p=write(sub)
+    try: out=subprocess.run([RUSTDL,"explain",p,SUB,SUP],capture_output=True,text=True,timeout=30).stdout
+    except subprocess.TimeoutExpired: os.unlink(p); return False
+    os.unlink(p); return " : yes" in out
+print(f"neighborhood: {len(nb)} axioms; FP reproduces: {holds(nb)}", flush=True)
+if not holds(nb):
+    print("FP does NOT reproduce in neighborhood alone — needs wider context."); raise SystemExit
+c=nb; n=2
+while len(c)>=2:
+    chunk=max(1,len(c)//n); parts=[c[i:i+chunk] for i in range(0,len(c),chunk)]; red=False
+    for i in range(len(parts)):
+        comp=[x for j,p in enumerate(parts) if j!=i for x in p]
+        if comp and holds(comp): c=comp; n=max(n-1,2); red=True; print(f"  -> {len(c)}",flush=True); break
+    if not red:
+        if n>=len(c): break
+        n=min(len(c),n*2)
+print(f"\n=== MINIMAL: {len(c)} axioms ===")
+for a in c: print(a)
+open(os.path.expanduser("~/data/ore-run/min_repro_final.ofn"),"w").write(open(write(c)).read())
+print("\nwrote ~/data/ore-run/min_repro_final.ofn")

--- a/scripts/ore-oracle-setup.sh
+++ b/scripts/ore-oracle-setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the ORE FP-sweep working set: for each ore_ont stem in $LIST,
+#   - copy files/<stem>.owl -> $INPUT/<stem>.ofn   (rustdl reads OWL functional)
+#   - ROBOT convert -> .owx, Konclude classify -> $ORACLE/<stem>-classified.owx
+# Usage: LIST=/tmp/ore_sroiq.txt bash scripts/ore-oracle-setup.sh
+set -uo pipefail
+POOL=~/data/ore-run/pool_sample
+INPUT=~/data/ore-run/input
+ORACLE=~/data/ore-run/oracle
+WORK=~/data/ore-run/owx
+ROBOT_IMG="${ROBOT_IMAGE:-obolibrary/robot:latest}"
+KON_IMG="konclude/konclude:latest"
+LIST="${LIST:-/tmp/ore_sroiq.txt}"
+mkdir -p "$INPUT" "$ORACLE" "$WORK"
+
+n=0; ok=0; convfail=0; konfail=0
+while read stem; do
+  stem="${stem%.owl}"
+  n=$((n+1))
+  src="$POOL/files/$stem.owl"
+  [ -f "$src" ] || { echo "MISSING $stem"; continue; }
+  cp "$src" "$INPUT/$stem.ofn"
+  # already have oracle? skip
+  if [ -f "$ORACLE/$stem-classified.owx" ]; then ok=$((ok+1)); continue; fi
+  # .owl(functional) -> .owx for Konclude
+  if ! docker run --rm -v "$POOL/files:/in" -v "$WORK:/out" -w /in "$ROBOT_IMG" \
+        robot convert --input "$stem.owl" --format owx --output "/out/$stem.owx" >/dev/null 2>&1; then
+    echo "CONVFAIL $stem"; convfail=$((convfail+1)); continue
+  fi
+  # Konclude classification -> oracle
+  if docker run --rm -v "$WORK:/w" -v "$ORACLE:/o" -w /w "$KON_IMG" \
+        classification -w AUTO -i "$stem.owx" -o "/o/$stem-classified.owx" >/dev/null 2>&1 \
+        && [ -f "$ORACLE/$stem-classified.owx" ]; then
+    ok=$((ok+1))
+  else
+    echo "KONFAIL $stem"; konfail=$((konfail+1))
+  fi
+  [ $((n%25)) -eq 0 ] && echo "  ...$n done (ok=$ok convfail=$convfail konfail=$konfail) $(date +%H:%M:%S)"
+done < "$LIST"
+echo "=== setup done: n=$n ok=$ok convfail=$convfail konfail=$konfail ==="
+echo "inputs:  $(ls $INPUT/*.ofn 2>/dev/null | wc -l)"
+echo "oracles: $(ls $ORACLE/*-classified.owx 2>/dev/null | wc -l)"


### PR DESCRIPTION
## Summary

Fixes the inverse-role + qualified-cardinality **soundness bug** (#24): a satisfiable class was reported unsatisfiable, producing false-positive subsumptions (an unsatisfiable class is vacuously `⊑` everything). Found via a broad ORE-2015 FP sweep; confirmed against **both** Konclude and HermiT.

## Root cause

`apply_min` (the `≥n R.C` rule) counted an `R`-neighbour as a witness only via `has_label(C)`. A freshly generated `≥m R.D` successor with `D ⊑ C`, whose told super-label `C` had not yet propagated, was missed — so a **redundant** `R.C` successor was generated, and the extra pairwise-distinct witness then made `≤k R.C` spuriously clash. The inverse role makes the subject node a shared `R`-neighbour of the filler nodes, which is what exposes the pattern (the FP vanishes without it). It lives in the core subset-blocking tableau (reproduces with `RUSTDL_HYPERTABLEAU=0`) and predates the realize work.

## Fix

`apply_min` now counts a neighbour carrying `C` **or a told *subclass* of `C`**, via a memoised transitive told-subsumer closure over atomic `ConceptRule`s (`TableauContext::node_entails_filler` / `build_told_super_closure`). **Sound by construction** — an atomic told subsumption holds in every model, so counting never over-counts; it only avoids generating the redundant successor.

## Validation

- Minimal 6-axiom core now satisfiable (both engines); genuine subsumptions preserved.
- New regression test: `crates/owl-dl-reasoner/tests/inverse_cardinality_soundness.rs`.
- 125 `owl-dl-tableau` lib tests + the full `owl-dl-reasoner` suite pass.
- Closure-diff vs Konclude oracle: **FP=0 / MISSED=0** on sio (84 inverse pairs), sulo, ro, wine (byte-identical).
- **ORE SROIQ sweep: 151 ontologies, 0 FP (was 4).**
- fmt + clippy clean.

Also includes the at-scale ORE FP-sweep harness used to find this (`ore_dir`/`ore_one` closure-diff tests + `scripts/ore-*.sh`, `scripts/konclude-oracle.sh`).

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
