### PR TITLE
ci: fix cargo-deny (runner-based, honours toolchain pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      # Run cargo-deny on the runner, NOT the EmbarkStudios containerized
+      # action: that action's musl container honours our `rust-toolchain.toml`
+      # pin (1.95.0) but has no `1.95.0-*-musl` toolchain installed, so a
+      # cargo-deny-action@v2 tag update (2026-06) started failing setup with
+      # "override toolchain … is not installed". Installing the pinned toolchain
+      # + a cargo-deny binary on the runner honours the pin correctly and dodges
+      # the container. Keep `toolchain:` in sync with rust-toolchain.toml.
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master, pinned
         with:
-          command: check
-          arguments: --workspace
+          toolchain: "1.95.0"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check --workspace
 
   soundness-diff:
     name: closure-diff soundness net (manual)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
-      - run: cargo deny check --workspace
+      # `--workspace` is a global flag (before the subcommand) in current
+      # cargo-deny; the old containerized action ran an older cargo-deny where
+      # `check --workspace` parsed.
+      - run: cargo deny --workspace check
 
   soundness-diff:
     name: closure-diff soundness net (manual)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"


### PR DESCRIPTION
Fixes the cargo-deny CI failure introduced by a cargo-deny-action@v2 tag update that can't install the rust-toolchain.toml-pinned 1.95.0 in its musl container. Runs cargo-deny on the runner with the pinned toolchain instead. Clippy CI was separately fixed in dd68422.