### PR TITLE
fix(justify): entails(OPA) via RBox-complete materialize edge set (#28)

### DIFF
--- a/crates/owl-dl-reasoner/src/justify.rs
+++ b/crates/owl-dl-reasoner/src/justify.rs
@@ -394,6 +394,27 @@ pub fn entails<A: ForIRI>(onto: &SetOntology<A>, q: &Entailment) -> Result<bool,
             prop,
             target,
         } => {
+            // Union of two sound, monotone oracles (soundness by composition):
+            //   (1) the RBox-complete named-individual edge set from
+            //       `materialize_object_property_assertions` (transitivity /
+            //       symmetry / inverse / SameIndividual folding / ObjectHasValue),
+            //       validated FP-free against the HermiT oracle in #26; and
+            //   (2) the NegOPA inconsistency probe, which still covers edges
+            //       outside that fragment (class-axiom / tableau-derived).
+            // The NegOPA probe alone was incomplete for (1) — see issue #28.
+            match crate::materialize_object_property_assertions(onto) {
+                Ok(edges) => {
+                    if edges
+                        .iter()
+                        .any(|(s, p, t)| s == source && p == prop && t == target)
+                    {
+                        return Ok(true);
+                    }
+                }
+                // Inconsistent ⇒ everything is entailed (matches the probe below).
+                Err(ReasonError::Inconsistent) => return Ok(true),
+                Err(e) => return Err(e),
+            }
             let b: Build<A> = Build::new();
             inconsistent_with(
                 onto,

--- a/crates/owl-dl-reasoner/tests/justification.rs
+++ b/crates/owl-dl-reasoner/tests/justification.rs
@@ -711,6 +711,60 @@ fn justify_object_property_assertion() {
 }
 
 #[test]
+fn justify_object_property_assertion_transitive() {
+    // Issue #28: `anc(a,c)` is entailed purely by RBox transitivity over named
+    // individuals. The old NegOPA-probe oracle returned `false` here; routing
+    // through the RBox-complete `materialize` edge set closes the gap.
+    let o = onto(
+        "Declaration(ObjectProperty(:anc))\n\
+         Declaration(NamedIndividual(:a)) Declaration(NamedIndividual(:b)) Declaration(NamedIndividual(:c))\n\
+         TransitiveObjectProperty(:anc) ObjectPropertyAssertion(:anc :a :b) ObjectPropertyAssertion(:anc :b :c)",
+    );
+    let q = Entailment::ObjectPropertyAssertion {
+        source: "http://t/a".into(),
+        prop: "http://t/anc".into(),
+        target: "http://t/c".into(),
+    };
+    assert!(
+        entails(&o, &q).unwrap(),
+        "anc(a,c) entailed via transitivity"
+    );
+    let j = find_one_justification(&o, &q)
+        .unwrap()
+        .expect("anc(a,c) entailed");
+    // Justification is exactly the transitivity axiom + the two ground edges.
+    assert_eq!(j.axioms.len(), 3, "got {:?}", j.axioms);
+    // Negative control: the reverse edge anc(c,a) is not entailed.
+    let nq = Entailment::ObjectPropertyAssertion {
+        source: "http://t/c".into(),
+        prop: "http://t/anc".into(),
+        target: "http://t/a".into(),
+    };
+    assert!(find_one_justification(&o, &nq).unwrap().is_none());
+}
+
+#[test]
+fn justify_object_property_assertion_symmetric() {
+    // Issue #28: `sib(b,a)` entailed by RBox symmetry over named individuals.
+    let o = onto(
+        "Declaration(ObjectProperty(:sib))\n\
+         Declaration(NamedIndividual(:a)) Declaration(NamedIndividual(:b))\n\
+         SymmetricObjectProperty(:sib) ObjectPropertyAssertion(:sib :a :b)",
+    );
+    let q = Entailment::ObjectPropertyAssertion {
+        source: "http://t/b".into(),
+        prop: "http://t/sib".into(),
+        target: "http://t/a".into(),
+    };
+    assert!(entails(&o, &q).unwrap(), "sib(b,a) entailed via symmetry");
+    let j = find_one_justification(&o, &q)
+        .unwrap()
+        .expect("sib(b,a) entailed");
+    // Justification is exactly the symmetry axiom + the ground edge.
+    assert_eq!(j.axioms.len(), 2, "got {:?}", j.axioms);
+}
+
+#[test]
 fn justify_same_individual() {
     let o = onto(
         "Declaration(ObjectProperty(:p)) Declaration(NamedIndividual(:x)) \


### PR DESCRIPTION
Closes #28.

## Problem

`entails(Entailment::ObjectPropertyAssertion { .. })` — and therefore the CLI/Python `justify property` query — was implemented solely as a NegOPA inconsistency probe. That probe returns `false` for object-property assertions entailed purely by RBox reasoning over named individuals (transitivity, symmetry, inverse, `SameIndividual` folding, `ObjectHasValue`). `materialize_object_property_assertions` returns these correctly (#26), so `entails()` was strictly **weaker** than `materialize` on that query class.

## Fix

Route the OPA arm of `entails` through a **union of two sound, monotone oracles**:

1. the RBox-complete named-individual edge set from `materialize_object_property_assertions` — checked first; validated FP-free against the HermiT oracle in #26;
2. the existing NegOPA probe — kept as fallback for edges *outside* that fragment (class-axiom / tableau-derived).

Union of two sound oracles is sound and strictly more complete. QuickXplain/HST (the justify minimization loops) only require monotonicity, which both components have. `Err(Inconsistent) => Ok(true)` preserves the "everything is entailed" case.

Soundness is by composition, not a fresh claim: the materialize edge set was just validated FP-free vs HermiT in #26.

## Tests

`justify_object_property_assertion_{transitive,symmetric}` assert both the `entails` bool **and** the exact justification axiom set (transitivity + 2 ground edges = 3; symmetry + 1 edge = 2), plus a negative control on the reverse edge. Both fail by construction before the fix.

Full `justification.rs` suite (36 tests) + reasoner suite green; fmt + clippy clean.

## Scope

Object-property only, per the issue. A plausibly-symmetric `DataPropertyValue` gap (`SameIndividual`-folded data values) is noted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSzon7V2wkhrudxBNAJduh