### PR TITLE
feat(materialize): fold SameIndividual in data-property assertions + HermiT oracle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,8 +253,12 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `docs/superpowers/specs/2026-06-21-inferred-property-assertions-design.md`.
   `materialize_data_property_assertions` (reasoner) / `materialize_inferred_data_property_assertions`
   (Python) surface inferred DATA property assertions (5-tuple subject/property/lexical/datatype/lang)
-  via a structural sub-data-property + equivalent-data-property closure (sound; under-approx: no
-  SameIndividual / class-axiom-derived). Folded into `realize --properties`. See
+  via a structural sub-data-property + equivalent-data-property + SameIndividual-folding closure
+  (sound; under-approx: no class-axiom-derived, e.g. DataHasValue). SameIndividual folding added
+  2026-07-01, guarded by a HermiT/ROBOT DataPropertyAssertion oracle
+  (`crates/owl-dl-reasoner/tests/materialize_oracle.rs::materialize_data_matches_hermit_oracle`);
+  the oracle fixture deliberately excludes EquivalentDataProperties because HermiT's
+  InferredPropertyAssertionGenerator does not traverse it. Folded into `realize --properties`. See
   `docs/superpowers/specs/2026-06-21-inferred-data-property-assertions-design.md`.
   `materialize_sub{object,data}property_axioms` (reasoner) /
   `materialize_inferred_sub{object,data}property_axioms` (Python) return the inferred named

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -125,9 +125,9 @@ pub fn materialize_object_property_assertions<A: horned_owl::model::ForIRI>(
 
 /// Materialize the inferred DATA property assertions entailed over **named
 /// individuals** — `(subject_iri, property_iri, lexical, datatype_iri, lang)`
-/// 5-tuples (the full entailed closure under sub-data-property hierarchy and
-/// equivalent-data-properties). Sound; complete for that fragment. Under-
-/// approximate: omits `SameIndividual` folding and class-axiom-derived assertions
+/// 5-tuples (the full entailed closure under sub-data-property hierarchy,
+/// equivalent-data-properties, and `SameIndividual` folding). Sound; complete for
+/// that fragment. Under-approximate: omits class-axiom-derived assertions
 /// (e.g. `DataHasValue`). Read-only.
 ///
 /// # Errors
@@ -138,7 +138,26 @@ pub fn materialize_data_property_assertions<A: horned_owl::model::ForIRI>(
     onto: &horned_owl::ontology::set::SetOntology<A>,
 ) -> Result<Vec<(String, String, String, String, String)>, ReasonError> {
     use horned_owl::model::{Component as C, Individual, Literal};
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeSet, HashMap, HashSet};
+
+    // Iterative union-find over individual IRIs (path-compressing). An individual
+    // absent from `parent` is its own root, so unrelated individuals need no seed.
+    fn uf_find(parent: &mut HashMap<String, String>, x: &str) -> String {
+        let mut root = x.to_string();
+        while let Some(p) = parent.get(&root) {
+            if p == &root {
+                break;
+            }
+            root.clone_from(p);
+        }
+        let mut cur = x.to_string();
+        while cur != root {
+            let next = parent.get(&cur).cloned().unwrap_or_else(|| root.clone());
+            parent.insert(cur.clone(), root.clone());
+            cur = next;
+        }
+        root
+    }
 
     const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
     const LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
@@ -150,6 +169,11 @@ pub fn materialize_data_property_assertions<A: horned_owl::model::ForIRI>(
 
     let mut asserted: Vec<(String, String, (String, String, String))> = Vec::new();
     let mut hierarchy: Vec<(String, String)> = Vec::new();
+    // SameIndividual folding: a data value asserted on `x` holds for every
+    // individual equal to `x`. Build equivalence classes via union-find over
+    // SameIndividual axioms (transitive), then replicate values across each class.
+    let mut parent: HashMap<String, String> = HashMap::new();
+    let mut all_inds: HashSet<String> = HashSet::new();
     for ac in onto {
         match &ac.component {
             C::DataPropertyAssertion(ax) => {
@@ -174,7 +198,26 @@ pub fn materialize_data_property_assertions<A: horned_owl::model::ForIRI>(
                         String::new(),
                     ),
                 };
+                all_inds.insert(subj.clone());
                 asserted.push((subj, dp, value));
+            }
+            C::SameIndividual(ax) => {
+                let named: Vec<String> =
+                    ax.0.iter()
+                        .filter_map(|i| match i {
+                            Individual::Named(n) => Some(n.0.as_ref().to_string()),
+                            Individual::Anonymous(_) => None,
+                        })
+                        .collect();
+                for w in named.windows(2) {
+                    all_inds.insert(w[0].clone());
+                    all_inds.insert(w[1].clone());
+                    let ra = uf_find(&mut parent, &w[0]);
+                    let rb = uf_find(&mut parent, &w[1]);
+                    if ra != rb {
+                        parent.insert(ra, rb);
+                    }
+                }
             }
             C::SubDataPropertyOf(ax) => {
                 hierarchy.push((ax.sub.0.as_ref().to_string(), ax.sup.0.as_ref().to_string()));
@@ -207,10 +250,25 @@ pub fn materialize_data_property_assertions<A: horned_owl::model::ForIRI>(
         set
     };
 
+    // Group each individual with its SameIndividual-equivalence class.
+    let mut by_root: HashMap<String, Vec<String>> = HashMap::new();
+    for ind in &all_inds {
+        let r = uf_find(&mut parent, ind);
+        by_root.entry(r).or_default().push(ind.clone());
+    }
+
     let mut out: Vec<(String, String, String, String, String)> = Vec::new();
     for (subj, dp, (lex, dt, lang)) in &asserted {
-        for sup in closure(dp) {
-            out.push((subj.clone(), sup, lex.clone(), dt.clone(), lang.clone()));
+        let root = uf_find(&mut parent, subj);
+        // Members of subj's equivalence class (includes subj); a subject with no
+        // SameIndividual axiom is its own singleton class.
+        let members: &[String] = by_root
+            .get(&root)
+            .map_or(std::slice::from_ref(subj), Vec::as_slice);
+        for m in members {
+            for sup in closure(dp) {
+                out.push((m.clone(), sup, lex.clone(), dt.clone(), lang.clone()));
+            }
         }
     }
     out.sort();

--- a/crates/owl-dl-reasoner/tests/data_property_assertions.rs
+++ b/crates/owl-dl-reasoner/tests/data_property_assertions.rs
@@ -80,6 +80,43 @@ fn equivalent_data_properties() {
 }
 
 #[test]
+fn same_individual_data_folding() {
+    // SameIndividual(a,b), hasAge(a,30) ⇒ hasAge(b,30) (and sub-property closure
+    // for both). HermiT confirms this (materialize_data_matches_hermit_oracle);
+    // this is the docker-free unit guard.
+    use horned_owl::model::SameIndividual;
+    let b = Build::new_rc();
+    let mut o = SetOntology::new();
+    o.insert(DeclareDataProperty(b.data_property("urn:hasAge")));
+    o.insert(DeclareDataProperty(b.data_property("urn:hasMeasurement")));
+    o.insert(DeclareNamedIndividual(b.named_individual("urn:a")));
+    o.insert(DeclareNamedIndividual(b.named_individual("urn:b")));
+    o.insert(subdp(&b, "urn:hasAge", "urn:hasMeasurement"));
+    o.insert(SameIndividual(vec![
+        Individual::Named(b.named_individual("urn:a")),
+        Individual::Named(b.named_individual("urn:b")),
+    ]));
+    o.insert(dpa(&b, "urn:hasAge", "urn:a", "30", XSD_INT));
+
+    let got = materialize_data_property_assertions(&o).expect("materialize");
+    let t = |s: &str, p: &str| {
+        got.iter()
+            .any(|(gs, gp, l, _, _)| gs == s && gp == p && l == "30")
+    };
+    // Folded onto b via SameIndividual, through the sub-property closure too.
+    assert!(
+        t("urn:b", "urn:hasAge"),
+        "b hasAge 30 (folded); got: {got:?}"
+    );
+    assert!(
+        t("urn:b", "urn:hasMeasurement"),
+        "b hasMeasurement 30 (folded + sub); got: {got:?}"
+    );
+    // The original subject still present.
+    assert!(t("urn:a", "urn:hasAge"));
+}
+
+#[test]
 fn language_tag_round_trips() {
     let b = Build::new_rc();
     let mut o = SetOntology::new();

--- a/crates/owl-dl-reasoner/tests/fixtures/materialize/rbox-materialized.owx
+++ b/crates/owl-dl-reasoner/tests/fixtures/materialize/rbox-materialized.owx
@@ -33,7 +33,19 @@
         <ObjectProperty IRI="#knows"/>
     </Declaration>
     <Declaration>
+        <DataProperty IRI="#age"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="#lifespan"/>
+    </Declaration>
+    <Declaration>
         <NamedIndividual IRI="#alice"/>
+    </Declaration>
+    <Declaration>
+        <NamedIndividual IRI="#bob"/>
+    </Declaration>
+    <Declaration>
+        <NamedIndividual IRI="#carol"/>
     </Declaration>
     <Declaration>
         <NamedIndividual IRI="#e"/>
@@ -46,6 +58,9 @@
     </Declaration>
     <Declaration>
         <NamedIndividual IRI="#mary"/>
+    </Declaration>
+    <Declaration>
+        <NamedIndividual IRI="#robert"/>
     </Declaration>
     <Declaration>
         <NamedIndividual IRI="#s1"/>
@@ -83,6 +98,10 @@
         <Class IRI="#C"/>
         <NamedIndividual IRI="#g"/>
     </ClassAssertion>
+    <SameIndividual>
+        <NamedIndividual IRI="#bob"/>
+        <NamedIndividual IRI="#robert"/>
+    </SameIndividual>
     <ObjectPropertyAssertion>
         <ObjectProperty IRI="#hasAncestor"/>
         <NamedIndividual IRI="#alice"/>
@@ -153,6 +172,36 @@
         <NamedIndividual IRI="#t2"/>
         <NamedIndividual IRI="#t3"/>
     </ObjectPropertyAssertion>
+    <DataPropertyAssertion>
+        <DataProperty IRI="#age"/>
+        <NamedIndividual IRI="#bob"/>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#integer">7</Literal>
+    </DataPropertyAssertion>
+    <DataPropertyAssertion>
+        <DataProperty IRI="#lifespan"/>
+        <NamedIndividual IRI="#bob"/>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#integer">7</Literal>
+    </DataPropertyAssertion>
+    <DataPropertyAssertion>
+        <DataProperty IRI="#age"/>
+        <NamedIndividual IRI="#carol"/>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#integer">42</Literal>
+    </DataPropertyAssertion>
+    <DataPropertyAssertion>
+        <DataProperty IRI="#lifespan"/>
+        <NamedIndividual IRI="#carol"/>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#integer">42</Literal>
+    </DataPropertyAssertion>
+    <DataPropertyAssertion>
+        <DataProperty IRI="#age"/>
+        <NamedIndividual IRI="#robert"/>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#integer">7</Literal>
+    </DataPropertyAssertion>
+    <DataPropertyAssertion>
+        <DataProperty IRI="#lifespan"/>
+        <NamedIndividual IRI="#robert"/>
+        <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#integer">7</Literal>
+    </DataPropertyAssertion>
     <SubObjectPropertyOf>
         <ObjectProperty IRI="#hasParent"/>
         <ObjectProperty IRI="#hasAncestor"/>
@@ -170,6 +219,10 @@
     <TransitiveObjectProperty>
         <ObjectProperty IRI="#hasAncestor"/>
     </TransitiveObjectProperty>
+    <SubDataPropertyOf>
+        <DataProperty IRI="#age"/>
+        <DataProperty IRI="#lifespan"/>
+    </SubDataPropertyOf>
 </Ontology>
 
 

--- a/crates/owl-dl-reasoner/tests/fixtures/materialize/rbox.ofn
+++ b/crates/owl-dl-reasoner/tests/fixtures/materialize/rbox.ofn
@@ -1,4 +1,5 @@
 Prefix(:=<urn:mt#>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Ontology(<urn:mt>
   Declaration(ObjectProperty(:anc)) TransitiveObjectProperty(:anc)
   Declaration(ObjectProperty(:knows)) SymmetricObjectProperty(:knows)
@@ -20,4 +21,11 @@ Ontology(<urn:mt>
   ClassAssertion(ObjectHasValue(:hv :v) :e)
   SubClassOf(:C ObjectHasValue(:hv :v))
   ClassAssertion(:C :g)
+  Declaration(DataProperty(:age)) Declaration(DataProperty(:lifespan))
+  SubDataPropertyOf(:age :lifespan)
+  Declaration(NamedIndividual(:carol))
+  DataPropertyAssertion(:age :carol "42"^^xsd:integer)
+  Declaration(NamedIndividual(:bob)) Declaration(NamedIndividual(:robert))
+  SameIndividual(:bob :robert)
+  DataPropertyAssertion(:age :bob "7"^^xsd:integer)
 )

--- a/crates/owl-dl-reasoner/tests/materialize_oracle.rs
+++ b/crates/owl-dl-reasoner/tests/materialize_oracle.rs
@@ -5,8 +5,9 @@
 //! diffed against **HermiT**-inferred property assertions (the only reasoner
 //! interface that materializes them — Konclude emits the classification hierarchy
 //! and individual realization, not inferred role edges; and rustdl's own
-//! `entails()` is *weaker* than the materializer here, so it can't be the
-//! reference). The oracle is generated offline by `docker/robot/property-oracle.sh`
+//! `entails(OPA)` now routes through `materialize_object` itself (issue #28), so
+//! it would be circular as a reference). The oracle is generated offline by
+//! `docker/robot/property-oracle.sh`
 //! (ROBOT + embedded HermiT) and committed as `*-materialized.owx`, so this test
 //! needs no docker at run time.
 //!
@@ -18,9 +19,11 @@
 use horned_owl::io::ParserConfiguration;
 use horned_owl::io::ofn::reader::read as read_ofn;
 use horned_owl::io::owx::reader::read as read_owx;
-use horned_owl::model::{Component, Individual, ObjectPropertyExpression, RcStr};
+use horned_owl::model::{Component, Individual, Literal, ObjectPropertyExpression, RcStr};
 use horned_owl::ontology::set::SetOntology;
-use owl_dl_reasoner::materialize_object_property_assertions;
+use owl_dl_reasoner::{
+    materialize_data_property_assertions, materialize_object_property_assertions,
+};
 use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::BufReader;
@@ -80,5 +83,76 @@ fn materialize_matches_hermit_oracle() {
     assert!(
         fp.is_empty(),
         "FP — materialize returns, HermiT does not: {fp:?}"
+    );
+}
+
+/// (subject, data-property, lexical, datatype) 4-tuples; lang is dropped since the
+/// fixture is all typed integer literals. Restricted to `DataPropertyAssertion`
+/// over NAMED individuals, matching `materialize_data_property_assertions`.
+type DataQuads = BTreeSet<(String, String, String, String)>;
+
+/// HermiT-inferred data-property assertions between NAMED individuals from the
+/// committed oracle.
+///
+/// NOTE: HermiT's `InferredPropertyAssertionGenerator` does **not** traverse
+/// `EquivalentDataProperties` (an assertion on `p` is not re-emitted on an
+/// equivalent `q`), so the fixture deliberately exercises only the constructs
+/// where the generator is complete — `SubDataPropertyOf` and `SameIndividual`
+/// folding — keeping this a clean bidirectional oracle.
+fn oracle_data_quads(path: &Path) -> DataQuads {
+    let file = File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = BufReader::new(file);
+    let (onto, _): (SetOntology<RcStr>, _) = read_owx(&mut reader, ParserConfiguration::default())
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    let mut set = DataQuads::new();
+    for ax in &onto {
+        if let Component::DataPropertyAssertion(dpa) = &ax.component
+            && let Individual::Named(s) = &dpa.from
+        {
+            let prop = dpa.dp.0.to_string();
+            let (lex, dt) = match &dpa.to {
+                Literal::Datatype {
+                    literal,
+                    datatype_iri,
+                } => (literal.clone(), datatype_iri.to_string()),
+                Literal::Simple { literal } => (
+                    literal.clone(),
+                    "http://www.w3.org/2001/XMLSchema#string".to_string(),
+                ),
+                // Language-tagged literals are not part of the oracle fixture.
+                Literal::Language { .. } => continue,
+            };
+            set.insert((s.0.to_string(), prop, lex, dt));
+        }
+    }
+    set
+}
+
+#[test]
+fn materialize_data_matches_hermit_oracle() {
+    let dir = Path::new("tests/fixtures/materialize");
+    let file = File::open(dir.join("rbox.ofn")).expect("fixture");
+    let mut reader = BufReader::new(file);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse fixture");
+
+    // materialize_data returns 5-tuples (subj, prop, lexical, datatype, lang);
+    // drop lang (fixture is all typed integer literals ⇒ lang == "").
+    let materialized: DataQuads = materialize_data_property_assertions(&onto)
+        .expect("materialize data")
+        .into_iter()
+        .map(|(s, p, lex, dt, _lang)| (s, p, lex, dt))
+        .collect();
+    let oracle = oracle_data_quads(&dir.join("rbox-materialized.owx"));
+
+    let missed: Vec<_> = oracle.difference(&materialized).collect();
+    let fp: Vec<_> = materialized.difference(&oracle).collect();
+    assert!(
+        missed.is_empty(),
+        "MISSED — HermiT infers, materialize_data omits: {missed:?}"
+    );
+    assert!(
+        fp.is_empty(),
+        "FP — materialize_data returns, HermiT does not: {fp:?}"
     );
 }


### PR DESCRIPTION
Follow-up to #28 (the "harden the materialize surface" half).

## Problem

`materialize_data_property_assertions` **under-reported**: it omitted `SameIndividual` folding, which is genuinely entailed (`a=b, dp(a,v) ⇒ dp(b,v)`) and which HermiT infers. Surfaced while building a completeness oracle for the data-property materialize surface — the data analog of the #26 object-property oracle.

## Measure-first

Before touching anything, I probed the parallel `entails(DataPropertyValue)` routing (the symmetric of the #28 object fix). It's **inert** — the NegDPA probe (full tableau) already catches `SameIndividual` folding, so routing through materialize would recover nothing. Not built.

## Changes

- **Fold `SameIndividual`** via a union-find over the axioms; replicate each asserted value across its equivalence class before the sub/equivalent-property closure. Sound: `SameIndividual` is an equivalence relation, and the top-level `saturate_abox_consistency` clash check gates out the inconsistent (`SameAs∩DifferentFrom`) case before any folding.
- **Extend the HermiT/ROBOT property-assertion oracle to data assertions** (`materialize_data_matches_hermit_oracle`). Confirmed the gap (test failed at exactly the 2 folded assertions), then closed it.
  - The oracle fixture **excludes `EquivalentDataProperties`**: HermiT's `InferredPropertyAssertionGenerator` doesn't traverse it, so materialize's (genuinely-entailed) equivalent-property emission would read as a spurious FP. Scoping to the sub-property + `SameIndividual` intersection keeps a clean bidirectional check. Equivalent closure is guarded by a separate direct unit test.
- **Guards:** docker-free `same_individual_data_folding` unit test; existing `every_data_triple_is_entailed` cross-check; object oracle unchanged (green). Docstring/CLAUDE.md updated; the now-circular "entails is weaker" oracle-header note corrected (post-#28 `entails(OPA)` calls materialize).

## Soundness / testing

Additive, no classifier change — FP=0 untouched by construction. Full reasoner suite (46 groups), CLI tests, fmt, clippy all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSzon7V2wkhrudxBNAJduh