### PR TITLE
feat(saturation): ObjectHasSelf self-loop propagates super-role range (ORE #4827)

### DIFF
--- a/crates/owl-dl-reasoner/tests/object_has_self_domain.rs
+++ b/crates/owl-dl-reasoner/tests/object_has_self_domain.rs
@@ -1,16 +1,17 @@
-//! Completeness canary: ObjectHasSelf (`∃R.Self`) + domain/range.
+//! Completeness canary: ObjectHasSelf (`∃R.Self`) + domain/range, asserted at the
+//! SATURATION-CLOSURE layer (`owl_dl_saturation::saturate`), NOT via
+//! `is_subclass_of` — the wedge/tableau closes these entailments regardless, so a
+//! full-classifier probe cannot isolate (or guard) the saturator rule.
 //!
-//! The saturator dropped `SelfRestriction(R)` (ObjectHasSelf) entirely. But
 //! `X ⊑ ∃R.Self` means X is both the source and target of an R-edge to itself, so
-//! `X ⊑ domain(R) ⊓ range(R)`. Without this the whole self-loop → domain/range
-//! chain is lost (olia/OBO: cost 43 of ore_ont_4827's self-restriction-driven
-//! subsumptions with an atomic domain, e.g. AspectFeature ⊑ ∃hasAspect.Self,
-//! domain(hasAspect)=Verb ⟹ AspectFeature ⊑ Verb). Fix routes `X ⊑ ∃R.Self` to
-//! `domain(R)`/`range(R)`. Sound under-approximation (the full self-semantics —
-//! the successor coincides with X — is otherwise handled by the tableau).
-//!
-//! (Disjunctive domains — `domain(R) = D1 ⊔ … ⊔ Dn` — are a SEPARATE lever and are
-//! not closed by this fix; see ore_ont_4827's residual.)
+//! `X ⊑ domain(R) ⊓ range(R)`. Moreover the self-loop `(x,x) ∈ R` is an `S`-edge
+//! for every super-role `R ⊑* S`, so `X ⊑ range(S)` for the *effective*
+//! (super-role-closed) range too — this closes the ore_ont_4827 pattern
+//! (`ClusivityFeature ⊑ ∃hasClusivity.Self`, `hasClusivity ⊑ hasFeature`,
+//! `range(hasFeature)=Feature` ⟹ `ClusivityFeature ⊑ Feature`; 79 silent MISSED →
+//! 0, FP=0). Sound: the successor coincides with X, so the range obligation lands
+//! on X itself (unlike general range propagation, which is deliberately omitted —
+//! there the range target is a distinct existential body).
 
 #![allow(clippy::unwrap_used, clippy::doc_markdown)]
 
@@ -18,17 +19,22 @@ use horned_owl::io::ParserConfiguration;
 use horned_owl::io::ofn::reader::read as read_ofn;
 use horned_owl::model::RcStr;
 use horned_owl::ontology::set::SetOntology;
+use owl_dl_core::convert::convert_ontology;
 use std::io::Cursor;
 
 const ONT: &str = r"Prefix(:=<http://t/>)
 Ontology(<http://t/o>
   Declaration(Class(:AspectFeature)) Declaration(Class(:Verb)) Declaration(Class(:Word))
-  Declaration(Class(:Animal))
-  Declaration(ObjectProperty(:hasAspect))
+  Declaration(Class(:Animal)) Declaration(Class(:Feature)) Declaration(Class(:Bogus))
+  Declaration(ObjectProperty(:hasAspect)) Declaration(ObjectProperty(:hasFeature))
+  Declaration(ObjectProperty(:unrelated))
   SubClassOf(:AspectFeature ObjectHasSelf(:hasAspect))
   ObjectPropertyDomain(:hasAspect :Verb)
   ObjectPropertyRange(:hasAspect :Word)
   SubClassOf(:Verb :Word)
+  SubObjectPropertyOf(:hasAspect :hasFeature)
+  ObjectPropertyRange(:hasFeature :Feature)
+  ObjectPropertyRange(:unrelated :Bogus)
 )";
 
 fn load() -> SetOntology<RcStr> {
@@ -37,30 +43,64 @@ fn load() -> SetOntology<RcStr> {
     ont
 }
 
-fn sub(o: &SetOntology<RcStr>, s: &str, t: &str) -> bool {
-    owl_dl_reasoner::is_subclass_of(o, &format!("http://t/{s}"), &format!("http://t/{t}"))
-        .expect("classify ok")
+/// `true` iff the SATURATOR's subsumer closure contains `X ⊑ Y` (isolates the
+/// saturation rule from the wedge/tableau).
+fn sat_sub(o: &SetOntology<RcStr>, x: &str, y: &str) -> bool {
+    let internal = convert_ontology(o).expect("lower to IR");
+    let subsumers = owl_dl_saturation::saturate(&internal);
+    let xid = internal
+        .vocabulary
+        .class_id(&format!("http://t/{x}"))
+        .expect("x declared");
+    let yid = internal
+        .vocabulary
+        .class_id(&format!("http://t/{y}"))
+        .expect("y declared");
+    subsumers.contains(xid, yid)
 }
 
 #[test]
 fn self_restriction_propagates_domain_and_range() {
     let o = load();
     assert!(
-        sub(&o, "AspectFeature", "Verb"),
-        "∃hasAspect.Self + domain=Verb ⟹ ⊑ Verb"
+        sat_sub(&o, "AspectFeature", "Verb"),
+        "∃hasAspect.Self + domain=Verb ⟹ ⊑ Verb (saturation)"
     );
     assert!(
-        sub(&o, "AspectFeature", "Word"),
-        "∃hasAspect.Self + range=Word ⟹ ⊑ Word"
+        sat_sub(&o, "AspectFeature", "Word"),
+        "∃hasAspect.Self + range=Word ⟹ ⊑ Word (saturation)"
+    );
+}
+
+#[test]
+fn self_restriction_propagates_super_role_range() {
+    // ore_ont_4827 pattern: `X ⊑ ∃R.Self`, `R ⊑* S`, `range(S)=C` ⟹ `X ⊑ C`.
+    // The self-loop (x,x)∈R ⊆ S puts x in range(S). The direct-range rule only
+    // read range(hasAspect); this exercises the super-role range hasFeature and
+    // fails at the saturation layer without the `effective_ranges` fix.
+    let o = load();
+    assert!(
+        sat_sub(&o, "AspectFeature", "Feature"),
+        "∃hasAspect.Self + hasAspect⊑hasFeature + range(hasFeature)=Feature ⟹ ⊑ Feature (saturation)"
     );
 }
 
 #[test]
 fn self_restriction_no_spurious_subsumption() {
-    // FP guard: Animal has no self-restriction ⟹ not a Verb.
+    // FP guard: Animal has no self-restriction ⟹ not a Verb, not a Feature.
     let o = load();
     assert!(
-        !sub(&o, "Animal", "Verb"),
+        !sat_sub(&o, "Animal", "Verb"),
         "Animal ⋢ Verb (no ∃hasAspect.Self)"
+    );
+    assert!(
+        !sat_sub(&o, "Animal", "Feature"),
+        "Animal ⋢ Feature (no ∃hasAspect.Self)"
+    );
+    // FP guard: `unrelated` is NOT a super-role of hasAspect, so its range (Bogus)
+    // must not leak into AspectFeature's effective range (only R⊑*S ranges apply).
+    assert!(
+        !sat_sub(&o, "AspectFeature", "Bogus"),
+        "AspectFeature ⋢ Bogus (unrelated is not a super-role of hasAspect)"
     );
 }

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -3109,11 +3109,20 @@ fn lower_sub_class_of(
             // lowering, so reading them here is complete. Subclasses inherit via
             // the atomic-subsumption closure (Y ⊑ X ⟹ Y ⊑ domain(R)).
             for r in self_restriction_roles_on_right(sup, pool) {
+                // The self-loop `(x,x) ∈ R` is also an `S`-edge for every super-role
+                // `R ⊑* S`, so `x` lies in `range(S)` for all such `S` — i.e. the
+                // *effective* (super-role-closed) range, not just `range(R)`. Using
+                // `effective_ranges` here closes the ore_ont_4827 pattern
+                // (`ClusivityFeature ⊑ ∃hasClusivity.Self`, `hasClusivity ⊑ hasFeature`,
+                // `range(hasFeature)=Feature` ⟹ `ClusivityFeature ⊑ Feature`). Sound:
+                // the successor coincides with `x`, so the range obligation lands on
+                // `x` itself (unlike general range propagation, deliberately omitted
+                // above — there the range target is a distinct existential body).
                 let heads: Vec<ClassId> = rules
                     .role_domains
                     .get(&r)
                     .into_iter()
-                    .chain(rules.role_ranges.get(&r))
+                    .chain(effective_ranges.get(&r))
                     .flatten()
                     .copied()
                     .collect();

--- a/docs/ore-sweep-2026-07-01.md
+++ b/docs/ore-sweep-2026-07-01.md
@@ -1,0 +1,86 @@
+# ORE completeness sweep — 2026-07-01
+
+**Status:** findings (durable). Re-ran the ORE-2015 pilot frontier on current `main` and
+adjudicated the surviving silent MISSED clusters per-pair.
+
+## Method
+
+- Corpus/oracles: `/data/dumontier/ore-run/pilot` (232 stratified ORE-2015 onts, cached
+  Konclude `kon.owx` + HermiT `hermit.txt` oracles; oracle = Konclude ∩ HermiT agreement).
+- The 2026-06-20 `rerun_results.jsonl` was **stale** — later completeness merges shifted the
+  frontier. Re-diffed the 20 prior-MISSED onts on current `main` (completeness levers only
+  *add* entailments, so MISSED=0 onts can't regress → re-diffing the prior-MISSED set is
+  sufficient). Binary: release build at `main` (dba39e8).
+
+## Result — soundness holds, frontier shrank
+
+- **FP_strict = 0 across all diffed onts** (soundness intact at scale; snapshot-cache
+  default-off, so the old output-FP does not recur).
+- Two prior-MISSED onts are now **MISSED=0** on current main (`7339` was 13, `394` (Horn)
+  was 4) — closed by post-2026-06-20 merges. The stale jsonl would have mis-targeted them.
+- Surviving silent clusters (all FP=0): `4827` (79), `778` (59), `9786` (55), `15167` (42),
+  then a small tail (`12698` 11, `5303` 5, ≤3 each).
+
+## Per-pair adjudication (the target selector, not MISSED count)
+
+- **`4827` (OLIA linguistics) — VERIFIABLE classify_gap, ObjectHasSelf+subrole+range.**
+  `explain` completes instantly and returns *yes — answered by tableau* for the missed pairs;
+  the oracle independently agrees. Not a label-heuristic prune (flag-off unchanged), not a
+  same-tier gap (`RUSTDL_CLASSIFY_SAME_TIER=1` unchanged). It is a **trust_sat MISS**: the EL
+  saturator/wedge don't derive it, return `Sat`, and trust_sat trusts that without consulting
+  the tableau. The calculus pattern:
+
+  ```
+  ClusivityFeature ⊑ ObjectHasSelf(hasClusivity)      (X ⊑ ∃R.Self)
+  SubObjectPropertyOf(hasClusivity, hasFeature)        (R ⊑* S)
+  ObjectPropertyRange(hasFeature, Feature)             (range(S) = C)
+  ⟹  ClusivityFeature ⊑ Feature                        (X ⊑ C)   [+ Feature ⊑ LinguisticAnnotation]
+  ```
+
+  **Sound** (special case of the deliberately-omitted general range propagation, `lib.rs:1409`):
+  the general `A ⊑ ∃R.B` + `range(R)=C` ⟹ `B ⊑ C` is unsound (a `B` that is nobody's
+  R-successor escapes). Here the `∃R.Self` self-loop makes the R/S-successor **be `x` itself**,
+  so `range(S)=C` forces `x ∈ C` directly — no escaping type. Proof: `x∈X ⟹ (x,x)∈R ⊆ S ⟹
+  x ∈ range(S) = C`. All 79 `4827` misses are this one pattern (Clusivity/Evaluative/Modality…
+  Feature ⊑ Feature/LinguisticAnnotation).
+
+  Breadth: ObjectHasSelf appears in 7/234 pilot onts (30 uses in `4827`, 1 in `9786`, 0 in the
+  other top clusters) — narrow, but `4827`'s 79 pairs are a clean sound win.
+
+- **`778` / `9786` / `15167` — scoped OUT (unverifiable).** `explain` DNFs (>2 min per pair);
+  `778`'s `OmnivoreAnimal` is a deeply nested SROIQ definition (`bearerOf`∘`hasRealization`∘
+  (`∀`+`∃`+`⊔`)+Disposition). Cannot adjudicate category or **verify a fix** → not a viable
+  lever target under measure-first discipline. Genuinely-hard SROIQ / query_err bucket.
+
+## Recommended lever
+
+Add the sound rule to the EL saturator (so `classify` emits it directly at saturation speed,
+bypassing the trust_sat gap):
+
+> `X ⊑ ∃R.Self`, `R ⊑* S`, `ObjectPropertyRange(S)=C` ⟹ `X ⊑ C`.
+
+Negatives-first canary (fires only with BOTH the subrole/self chain AND the range; no-range or
+no-self control must NOT fire), then the FP=0 corpus gate (galen/notgalen/sio/wine/ore-10908/
+ore-15672/pizza/alehif/shoiq-knowledge + `4827` recovers 79→0).
+
+## SHIPPED (2026-07-01)
+
+One-line extension of the existing `SelfRestriction` rule in the EL saturator
+(`crates/owl-dl-saturation/src/lib.rs`): the self-loop rule now reads the
+super-role-closed `effective_ranges[R]` (already built in Pass 2) instead of the
+direct `role_ranges[R]`. The `∃R.Self` loop is an `S`-edge for every `R ⊑* S`, so
+`x ∈ range(S)`; sound because the successor coincides with `x` (the general range
+propagation, unsound and dropped at `lib.rs:1409`, has a *distinct* range target).
+
+- **Canary** (`crates/owl-dl-reasoner/tests/object_has_self_domain.rs`): asserts at
+  the **saturation-closure** layer (`owl_dl_saturation::saturate` + `subsumers.contains`,
+  NOT `is_subclass_of` — the tableau masks the gap). TDD red/green confirmed (fails on
+  the direct-range variant). FP guards: no-self class ⋢ range; non-super-role's range
+  must not leak.
+- **FP gate**: FP=0 / MISSED=0 across the corpus (ro 247, ore-10908 6001, ore-15672 142,
+  alehif 158, sio 8904, wine 653, bibtex 16 — the two ObjectHasSelf carriers `ro` and
+  `ore-10908` clean; galen/notgalen/others have 0 ObjectHasSelf ⟹ byte-identical by
+  construction, the rule loop is empty). ORE ObjectHasSelf onts: `4827` **MISSED 79→0**,
+  the other six FP=0 / MISSED unchanged.
+- **Not built**: super-role *domain* closure (symmetric + sound, but no measured target —
+  `4827` is range-driven). `778`/`9786`/`15167` remain (unverifiable SROIQ, scoped out).


### PR DESCRIPTION
Found + closed via the ORE-2015 completeness sweep (`docs/ore-sweep-2026-07-01.md`).

## Gap

`ore_ont_4827` (OLIA) had 79 silent MISSED, all one pattern. The EL saturator's `ObjectHasSelf` rule (`X ⊑ ∃R.Self ⟹ X ⊑ domain(R) ⊓ range(R)`) read only the **direct** role range, missing super-role ranges:

```
ClusivityFeature ⊑ ∃hasClusivity.Self ,  hasClusivity ⊑ hasFeature ,  range(hasFeature)=Feature
⟹  ClusivityFeature ⊑ Feature
```

## Fix

One line: read the super-role-closed `effective_ranges[R]` (already built in Pass 2) instead of the direct `role_ranges[R]`. The self-loop `(x,x)∈R ⊆ S` puts `x` in `range(S)`.

**Sound** — the successor coincides with `x`, so `range(S)` lands on `x` itself. This is the special case where range propagation *is* sound (the general form `A ⊑ ∃R.B` + `range(R)=C ⟹ B ⊑ C` is deliberately dropped at `lib.rs:1409` — distinct range target, caused 38 SIO FPs).

## Verification

- **`ore_ont_4827` MISSED 79 → 0.**
- **FP=0 / MISSED=0 corpus-wide** — ObjectHasSelf carriers `ro` (247) and `ore-10908` (6001) clean; sio/wine/ore-15672/alehif/bibtex unchanged; galen/notgalen have no ObjectHasSelf → byte-identical (rule loop empty).
- Canary (`object_has_self_domain.rs`) rewritten to assert at the **saturation-closure** layer (`saturate` + `subsumers.contains`, not `is_subclass_of` — the tableau masks the gap). TDD red/green confirmed. FP guards: no-self class; non-super-role range must not leak.
- Full workspace green (72 groups), fmt/clippy clean.

Not built: super-role *domain* closure (symmetric + sound, but no measured target — `4827` is range-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSzon7V2wkhrudxBNAJduh