### PR TITLE
feat(classify): opt-in defined-sup VERIFY sweep (ORE hard-cluster #15167)

### DIFF
--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -1571,7 +1571,15 @@ pub(crate) fn classify_top_down_internal(
     // sub-second via direct probe but exceed 200 ms under the
     // top-down classifier's tier-parallel load.
     let sweep_budget = per_pair_timeout.unwrap_or(std::time::Duration::from_millis(200));
+    // Opt-in defined-sup VERIFY mode (RUSTDL_CLASSIFY_DEFINED_SWEEP): for a class
+    // defined via a non-EL body, the wedge's label countermodel is an unreliable
+    // counterexample, so the label prune drops true `cand ⊑ D`. When on, bypass the
+    // label gate for these sups and verify via full tableau (trust_sat=false).
+    // Sound (FP=0): only tableau-confirmed edges added. See classify_defined_sweep_enabled.
+    let defined_verify_mode = crate::classify_defined_sweep_enabled();
+    let defined_set: std::collections::HashSet<usize> = defined_sups.iter().copied().collect();
     for &sup in &sweep_sups {
+        let sup_verify = defined_verify_mode && defined_set.contains(&sup);
         let sup_id =
             owl_dl_core::ClassId::new(u32::try_from(sup).expect("class index fits in u32"));
         // Parallel test of candidate subs. Skip pairs already known via
@@ -1619,12 +1627,59 @@ pub(crate) fn classify_top_down_internal(
                 //     verdicts are unchanged). RUSTDL_LABEL_HEURISTIC=0
                 //     makes the cache all-NoVerdict → full fall-through
                 //     (free opt-out, no new flag needed).
-                let subsumed = match label_cache.get(cand) {
-                    Some(crate::LabelOracle::Sat(labels)) => {
-                        if labels.contains(&sup_id) {
-                            // sup_id ∈ labels: might be coincidence of
-                            // model; verify via subsumes_via_tableau.
-                            local_stats.label_cache_pass_through += 1;
+                let subsumed = if sup_verify {
+                    // VERIFY mode (opt-in): the label countermodel is unreliable for
+                    // this non-EL-defined sup, so skip the label prune and verify with
+                    // the full tableau (trust_sat=false). Sound — only a tableau `unsat`
+                    // yields `true`; a spurious wedge `Sat` times out / returns false
+                    // (a MISS, never an FP).
+                    local_stats.label_cache_misses += 1;
+                    subsumes_via_tableau(
+                        &prepared,
+                        cand_id,
+                        sup_id,
+                        Some(sweep_budget),
+                        global_deadline,
+                        false,
+                        &counting_relevant,
+                        &mut local_stats,
+                    )
+                    .ok()
+                    .flatten()
+                    .unwrap_or(false)
+                } else {
+                    match label_cache.get(cand) {
+                        Some(crate::LabelOracle::Sat(labels)) => {
+                            if labels.contains(&sup_id) {
+                                // sup_id ∈ labels: might be coincidence of
+                                // model; verify via subsumes_via_tableau.
+                                local_stats.label_cache_pass_through += 1;
+                                subsumes_via_tableau(
+                                    &prepared,
+                                    cand_id,
+                                    sup_id,
+                                    Some(sweep_budget),
+                                    global_deadline,
+                                    true,
+                                    &counting_relevant,
+                                    &mut local_stats,
+                                )
+                                .ok()
+                                .flatten()
+                                .unwrap_or(false)
+                            } else {
+                                // sup_id ∉ labels: sound non-subsumption.
+                                local_stats.label_cache_pruned += 1;
+                                false
+                            }
+                        }
+                        Some(crate::LabelOracle::Unsat) => {
+                            // cand is unsatisfiable: vacuously subsumed.
+                            true
+                        }
+                        Some(crate::LabelOracle::NoVerdict) | None => {
+                            // Oracle incomplete — fall through to per-pair.
+                            local_stats.label_cache_misses += 1;
                             subsumes_via_tableau(
                                 &prepared,
                                 cand_id,
@@ -1638,32 +1693,7 @@ pub(crate) fn classify_top_down_internal(
                             .ok()
                             .flatten()
                             .unwrap_or(false)
-                        } else {
-                            // sup_id ∉ labels: sound non-subsumption.
-                            local_stats.label_cache_pruned += 1;
-                            false
                         }
-                    }
-                    Some(crate::LabelOracle::Unsat) => {
-                        // cand is unsatisfiable: vacuously subsumed.
-                        true
-                    }
-                    Some(crate::LabelOracle::NoVerdict) | None => {
-                        // Oracle incomplete — fall through to per-pair.
-                        local_stats.label_cache_misses += 1;
-                        subsumes_via_tableau(
-                            &prepared,
-                            cand_id,
-                            sup_id,
-                            Some(sweep_budget),
-                            global_deadline,
-                            true,
-                            &counting_relevant,
-                            &mut local_stats,
-                        )
-                        .ok()
-                        .flatten()
-                        .unwrap_or(false)
                     }
                 };
                 (cand, subsumed, local_stats)

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -1603,6 +1603,24 @@ pub(crate) fn classify_same_tier_enabled() -> bool {
     std::env::var_os("RUSTDL_CLASSIFY_SAME_TIER").is_some_and(|v| v == "1")
 }
 
+/// Defined-sup sweep VERIFY mode. For a class defined via a non-EL body
+/// (`D ≡ … ⊓ ¬… / ⊔ / ∀ …`), the wedge's label countermodel is an unreliable
+/// counterexample: it can satisfy `cand ⊓ ¬D` only because the wedge is
+/// incomplete on complement/disjunction, so the label-heuristic prune drops a
+/// TRUE `cand ⊑ D`. When enabled, the defined-sup sweep bypasses the label prune
+/// for defined sups and verifies each candidate with the full tableau
+/// (`trust_sat=false`). **Sound (FP=0 by construction)** — only edges a tableau
+/// `unsat` confirms are added; a spurious wedge `Sat` can only MISS, never FP.
+/// DEFAULT OFF — closes complement/disjunction-defined subsumptions the closure-
+/// guided walk can't see (ORE `ore_ont_15167`), but corpus-invisible and can hit
+/// the tableau wall on disjunction-heavy inputs, so it is strictly opt-in at the
+/// caller's per-pair budget. Set `RUSTDL_CLASSIFY_DEFINED_SWEEP=1` to enable. See
+/// `docs/ore-sweep-2026-07-01.md`.
+#[must_use]
+pub(crate) fn classify_defined_sweep_enabled() -> bool {
+    std::env::var_os("RUSTDL_CLASSIFY_DEFINED_SWEEP").is_some_and(|v| v == "1")
+}
+
 /// Lever #1: adaptive early-cut of diverging wedge searches. Default OFF until the
 /// corpus MISSED-unchanged gate confirms it. Set `RUSTDL_ADAPTIVE_BUDGET=1`.
 ///

--- a/crates/owl-dl-reasoner/tests/classify_defined_sweep.rs
+++ b/crates/owl-dl-reasoner/tests/classify_defined_sweep.rs
@@ -1,0 +1,183 @@
+//! Canary for the opt-in defined-sup VERIFY sweep (`RUSTDL_CLASSIFY_DEFINED_SWEEP`).
+//!
+//! For a class `D` defined via a non-EL body (`D ≡ A ⊓ ¬B`), the wedge's label
+//! countermodel can be an unreliable counterexample: on a large ontology it may
+//! satisfy `cand ⊓ ¬D` only because the wedge is incomplete on complement /
+//! disjunction, so the label-heuristic prune drops a TRUE `cand ⊑ D`. The
+//! flag makes the defined-sup sweep bypass the label prune for defined sups and
+//! verify each candidate with the full tableau (`trust_sat=false`).
+//!
+//! ## What this file guards (CI, synthetic)
+//! - **Soundness (FP=0 under the flag):** the verify path must not add a
+//!   spurious `cand ⊑ D` — `Y ⊑ A` but not disjoint from `B` ⟹ `Y ⋢ D`.
+//! - **No default-behaviour change:** flag OFF is byte-identical (the verify
+//!   branch is gated unreachable); asserted directly.
+//! - **Plumbing:** the flag drives the verify path without panic and reports the
+//!   genuine `X ⊑ D`.
+//!
+//! ## What this file does NOT (and cannot) guard synthetically
+//! The *recovery* itself — the label prune firing on a TRUE subsumption — is a
+//! large-scale wedge-model-incompleteness phenomenon; the wedge is complete on
+//! tiny inputs, so a small synthetic finds `X ⊑ D` even flag-OFF. The recovery
+//! is measured on the real ORE `ore_ont_15167` (MISSED 42→34, FP=0; see
+//! `docs/ore-sweep-2026-07-01.md`) and by the `#[ignore]`d fixture test below.
+
+#![allow(clippy::unwrap_used, clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::Classification;
+use std::io::Cursor;
+use std::path::Path;
+
+// Serialize env mutation; restore on Drop. Mirrors classify_inverse_domain.rs.
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct SetEnvGuard {
+    key: &'static str,
+    prior: Option<std::ffi::OsString>,
+}
+impl SetEnvGuard {
+    #[allow(unsafe_code)]
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var_os(key);
+        // SAFETY: set_var is unsafe under edition 2024. Serialized via ENV_MUTEX,
+        // restored on Drop.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prior }
+    }
+    #[allow(unsafe_code)]
+    fn remove(key: &'static str) -> Self {
+        let prior = std::env::var_os(key);
+        // SAFETY: see set.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, prior }
+    }
+}
+impl Drop for SetEnvGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        // SAFETY: see set.
+        unsafe {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn has(c: &Classification, sub: &str, sup: &str) -> bool {
+    c.is_subclass(sub, sup)
+}
+
+// D ≡ A ⊓ ¬B (defined via complement). X ⊑ A and disjoint from B ⟹ X ⊑ D.
+// Y ⊑ A only (may be B) ⟹ Y ⋢ D — the FP guard.
+const SRC: &str = r"Prefix(:=<http://e#>)
+Ontology(
+Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:D)) Declaration(Class(:X)) Declaration(Class(:Y))
+EquivalentClasses(:D ObjectIntersectionOf(:A ObjectComplementOf(:B)))
+SubClassOf(:X :A)
+DisjointClasses(:X :B)
+SubClassOf(:Y :A)
+)
+";
+
+fn load(src: &str) -> SetOntology<RcStr> {
+    let (o, _): (SetOntology<RcStr>, _) = read_ofn(
+        &mut Cursor::new(src.to_string()),
+        ParserConfiguration::default(),
+    )
+    .expect("parse");
+    o
+}
+
+#[test]
+fn defined_sweep_flag_on_sound_and_plumbed() {
+    let _serial = ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _flag = SetEnvGuard::set("RUSTDL_CLASSIFY_DEFINED_SWEEP", "1");
+    let c = owl_dl_reasoner::classify(&load(SRC)).expect("classify");
+    // Positive: the verify path reports the genuine X ⊑ D.
+    assert!(
+        has(&c, "http://e#X", "http://e#D"),
+        "flag ON: X ⊑ D (X ⊑ A, X disjoint B ⟹ X ⊑ A ⊓ ¬B)"
+    );
+    // FP guard (soundness): Y ⊑ A but not disjoint from B ⟹ Y ⋢ D. The verify
+    // path must not add this (tableau confirms Y ⊓ ¬D satisfiable).
+    assert!(
+        !has(&c, "http://e#Y", "http://e#D"),
+        "flag ON: Y ⋢ D — verify sweep must not add a spurious defined-sup edge"
+    );
+}
+
+#[test]
+fn defined_sweep_flag_off_default_unchanged() {
+    let _serial = ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Default OFF: the verify branch is gated unreachable. Y ⋢ D still holds.
+    let _flag = SetEnvGuard::remove("RUSTDL_CLASSIFY_DEFINED_SWEEP");
+    let c = owl_dl_reasoner::classify(&load(SRC)).expect("classify");
+    assert!(
+        !has(&c, "http://e#Y", "http://e#D"),
+        "flag OFF: Y ⋢ D (no spurious edge in default path)"
+    );
+}
+
+/// Recovery isolation on the real ORE `ore_ont_15167` (MONDIAL): flag OFF misses
+/// the complement-defined `AdministrativeArea ⊑ EncompassedArea`
+/// (`EncompassedArea ≡ LargeArea ⊓ ¬Continent ⊓ ¬Sea`) via the label prune; flag
+/// ON recovers it. `#[ignore]`d + skip-if-absent (the ORE corpus is gitignored),
+/// mirroring the `konclude_closure_diff.rs` fixture tests. Run locally with the
+/// fixture placed at `ontologies/real/ore_ont_15167.owx`:
+///   `cargo test -p owl-dl-reasoner --test classify_defined_sweep -- --ignored`
+#[test]
+#[ignore = "needs ontologies/real/ore_ont_15167.owx (gitignored ORE corpus)"]
+fn defined_sweep_recovers_15167_on_real_fixture() {
+    let path = Path::new("../../ontologies/real/ore_ont_15167.owx");
+    if !path.exists() {
+        eprintln!("SKIP: missing {}", path.display());
+        return;
+    }
+    use horned_owl::io::owx::reader::read as read_owx;
+    let load_owx = || {
+        let f = std::fs::File::open(path).unwrap();
+        let (o, _): (SetOntology<RcStr>, _) = read_owx(
+            &mut std::io::BufReader::new(f),
+            ParserConfiguration::default(),
+        )
+        .unwrap();
+        o
+    };
+    const SUB: &str = "f://m#AdministrativeArea";
+    const SUP: &str = "f://m#EncompassedArea";
+    let _serial = ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    {
+        let _flag = SetEnvGuard::remove("RUSTDL_CLASSIFY_DEFINED_SWEEP");
+        let c = owl_dl_reasoner::classify(&load_owx()).expect("classify off");
+        assert!(
+            !has(&c, SUB, SUP),
+            "flag OFF: 15167 misses the label-pruned pair"
+        );
+    }
+    {
+        let _flag = SetEnvGuard::set("RUSTDL_CLASSIFY_DEFINED_SWEEP", "1");
+        let c =
+            owl_dl_reasoner::classify_with_timeout(&load_owx(), std::time::Duration::from_secs(60))
+                .expect("classify on");
+        assert!(
+            has(&c, SUB, SUP),
+            "flag ON: 15167 recovers AdministrativeArea ⊑ EncompassedArea"
+        );
+    }
+}

--- a/docs/ore-sweep-2026-07-01.md
+++ b/docs/ore-sweep-2026-07-01.md
@@ -84,3 +84,67 @@ propagation, unsound and dropped at `lib.rs:1409`, has a *distinct* range target
   the other six FP=0 / MISSED unchanged.
 - **Not built**: super-role *domain* closure (symmetric + sound, but no measured target —
   `4827` is range-driven). `778`/`9786`/`15167` remain (unverifiable SROIQ, scoped out).
+
+## Hard clusters characterized (2026-07-02) — `778` / `9786` / `15167`
+
+Adjudicated the three remaining silent clusters. **All the same mechanism, and it is the
+wine-class architectural frontier — not a calculus gap.**
+
+- **Shared shape:** `primitive ⊑ defined-class` where the defined class uses
+  `¬` / `⊔` / `∀` the EL/wedge closure cannot derive (15167:
+  `EncompassedArea ≡ LargeArea ⊓ ¬Continent ⊓ ¬Sea`; 9786: `SIO_000003 ⊑ ⊔/∀`;
+  778: `OmnivoreAnimal ≡ ∃bearerOf.(∀hasRealization.(…⊔…)⊓Disposition)`).
+- **Tableau-derivable, not a calculus gap:** a heavy single-pair probe
+  (`explain`, 600 s) confirms `15167 AdministrativeArea ⊑ EncompassedArea` = *yes,
+  by tableau*. The calculus has it.
+- **The gap is ORCHESTRATION — candidate generation.** classify's closure-guided
+  top-down walk never generates the `(primitive, defined-class)` candidate because
+  the closure can't *see* the subsumption, so it never reaches any verifying engine.
+  Confirmed on 15167 (0.03 s): banner `tableau=0`; **no** flag combination recovers
+  the pair — `RUSTDL_HYPERTABLEAU_TRUST_SAT=0`, `RUSTDL_LABEL_HEURISTIC=0`,
+  `RUSTDL_CLASSIFY_SAME_TIER=1`, or combinations. So it is "candidate never generated",
+  NOT "wedge-negative taken as final" (the trust_sat_min_ms experiment, already
+  measured out) and NOT a trust_sat short-circuit.
+- **The existing defined-sup sweep (`RUSTDL_CLASSIFY_SAME_TIER`, SP1.1) is buggy:** on
+  15167 it does not recover these pairs AND it *drops* 26 genuine edges (108→82:
+  `City ⊑ Area`, `Continent ⊑ GeographicalThing`, …). Default-OFF, so no shipping harm,
+  but it is completeness-broken and not a usable base.
+- **Only 15167 is verifiable.** 778/9786 `explain`-DNF (>2 min/pair) — the tableau
+  itself hits the wine-class wall there, so a fix cannot be confirmed.
+
+## SHIPPED — opt-in defined-sup VERIFY sweep (2026-07-02)
+
+Built as an opt-in gate: `RUSTDL_CLASSIFY_DEFINED_SWEEP` (**default OFF**). The
+existing defined-sup sweep already tests `(cand, defined-sup)` pairs but the
+**label heuristic prunes** them — for a non-EL-defined sup the wedge's label
+countermodel is unreliable (it can satisfy `cand ⊓ ¬D` only because the wedge is
+incomplete on complement/disjunction), so `D ∉ labels(cand)` drops a TRUE
+`cand ⊑ D`. When the flag is on, the sweep **bypasses the label prune for defined
+sups and verifies each candidate with the full tableau** (`trust_sat=false`).
+
+- **Sound (FP=0 by construction):** only edges a tableau `unsat` confirms are
+  added; a spurious wedge `Sat` can only MISS, never FP. Empirically FP=0 on the
+  flag-ON gate across the defined-class-heavy onts (pizza 499=499, wine 653=653,
+  both FP=0/MISSED=0; 15167 FP=0).
+- **Recovery:** `ore_ont_15167` MISSED 42→34 (the ~8 complement-defined-sup pairs,
+  e.g. `AdministrativeArea ⊑ EncompassedArea`). **Self-contained at the default
+  per-pair budget** — recovery holds at 200 ms (and no explicit budget); the verify
+  tableau on 15167's defined sups finishes well under it, so enabling the flag needs
+  no companion `--pair-timeout-ms`. The ~2× wall is candidate *volume*, not per-pair
+  time. The residual 34 are **primitive-sup** misses (`X ⊑ MondialThing/Area/LargeArea`)
+  — outside a *defined*-sup sweep's scope (they'd need full O(n²)); explicitly not claimed.
+- **Default OFF because:** corpus-invisible (closes zero tuned-corpus subsumptions);
+  ~2× wall (wine flag-ON = 236 s vs sub-second off); and it hits the tableau wall on
+  the disjunction-heavy `778`/`9786` exactly where a fix can't be verified. Flag-OFF
+  is byte-identical (the verify branch is gated unreachable).
+- **Canary:** `crates/owl-dl-reasoner/tests/classify_defined_sweep.rs` — a CI
+  synthetic guarding the *soundness-critical* properties (FP=0 under the flag; no
+  default-behaviour change; plumbing) plus an `#[ignore]`d real-`15167` fixture test
+  (skip-if-absent, corpus gitignored) that isolates the recovery. The recovery itself
+  is not synthesizable — the label prune is a large-scale wedge-model-incompleteness
+  phenomenon; the wedge is complete on tiny inputs, so a small synthetic finds the
+  pair even flag-OFF.
+
+**Not built:** primitive-sup candidate generation (full O(n²), the residual 34 on
+15167); the SP1.1 `RUSTDL_CLASSIFY_SAME_TIER` edge-drop bug (separate, default-OFF).
+`778`/`9786` remain unverifiable (tableau wall).


### PR DESCRIPTION
Closes the tractable slice of the ORE-2015 hard clusters (`docs/ore-sweep-2026-07-01.md`).

## Finding

The remaining big silent clusters (`778`/`9786`/`15167`) are the **wine-class frontier**, not calculus gaps: `primitive ⊑ defined-class` subsumptions (¬/⊔/∀ bodies) that are tableau-derivable per-pair but closure-invisible. The existing defined-sup sweep *does* test them, but the **label heuristic prunes them** — for a non-EL-defined sup the wedge's label countermodel is unreliable (satisfies `cand ⊓ ¬D` only via wedge incompleteness), so `D ∉ labels(cand)` drops a true `cand ⊑ D`.

## Lever (opt-in, default OFF)

New gate `RUSTDL_CLASSIFY_DEFINED_SWEEP`: for defined sups, bypass the label prune and verify each candidate with the full tableau (`trust_sat=false`).

- **Sound (FP=0 by construction)** — only tableau-`unsat`-confirmed edges; a spurious wedge `Sat` can only MISS, never FP. Confirmed FP=0 flag-ON on pizza (499=499), wine (653=653), 15167.
- **Recovery:** `ore_ont_15167` MISSED **42→34** (complement-defined-sup pairs, e.g. `AdministrativeArea ⊑ EncompassedArea`), **self-contained at the default 200ms budget**. Residual 34 are primitive-sup misses (O(n²), out of scope — not claimed).
- **Flag-OFF byte-identical** (verify branch gated unreachable).

## Why default OFF

Corpus-invisible (closes zero tuned-corpus subsumptions), ~2× wall (wine flag-ON 236s vs sub-second off), and unverifiable on the disjunction-heavy `778`/`9786` (tableau wall). Same not-worth-default bar as SP1.1. Opt-in for DL-heavy workloads that need it.

## Testing

Canary `classify_defined_sweep.rs`: CI synthetic guarding FP=0-under-flag + no-default-change + plumbing, plus an `#[ignore]`d real-15167 fixture isolating the recovery (the label-prune miss isn't synthesizable — the wedge is complete on tiny inputs). Workspace green (73 groups), fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSzon7V2wkhrudxBNAJduh