### PR TITLE
fix(saturation): propagate ⊤ ⊑ C to all classes (EL-completeness gap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/owl-dl-bench/src/main.rs
+++ b/crates/owl-dl-bench/src/main.rs
@@ -11,8 +11,6 @@
 //!   stats + timing. Useful as a baseline for the saturation
 //!   engine without leaning on any external corpus.
 
-use std::fs::File;
-use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -170,12 +168,28 @@ enum Command {
 }
 
 fn parse_ofn(path: &Path) -> Result<SetOntology<RcStr>> {
-    let file =
-        File::open(path).with_context(|| format!("opening ontology file: {}", path.display()))?;
-    let mut reader = BufReader::new(file);
-    let (ontology, _prefixes) = read(&mut reader, ParserConfiguration::default())
-        .map_err(|e| anyhow::anyhow!("parsing OFN ontology {}: {e}", path.display()))?;
-    Ok(ontology)
+    use horned_owl::io::owx::reader::read as read_owx;
+    use horned_owl::io::rdf::reader::read as read_rdf;
+    // Content-sniff so the whelk comparison works on OFN (ORE), OWX (pilot
+    // canon), and RDF/XML (BioPortal) alike — both engines share this parse.
+    let src = std::fs::read_to_string(path)
+        .with_context(|| format!("opening ontology file: {}", path.display()))?;
+    let cfg = ParserConfiguration::default();
+    let mut reader = std::io::Cursor::new(src.as_bytes().to_vec());
+    if src.contains("<rdf:RDF") || src.contains("<rdf:Description") {
+        let (o, _): (horned_owl::ontology::set::SetOntology<RcStr>, _) = read_rdf(&mut reader, cfg)
+            .map(|(o, i)| (o.into(), i))
+            .map_err(|e| anyhow::anyhow!("parsing RDF/XML ontology {}: {e}", path.display()))?;
+        Ok(o)
+    } else if src.trim_start().starts_with('<') {
+        let (o, _) = read_owx(&mut reader, cfg)
+            .map_err(|e| anyhow::anyhow!("parsing OWX ontology {}: {e}", path.display()))?;
+        Ok(o)
+    } else {
+        let (o, _) = read(&mut reader, cfg)
+            .map_err(|e| anyhow::anyhow!("parsing OFN ontology {}: {e}", path.display()))?;
+        Ok(o)
+    }
 }
 
 /// Generate a synthetic EL partonomy:

--- a/crates/owl-dl-reasoner/tests/top_subsumes_all.rs
+++ b/crates/owl-dl-reasoner/tests/top_subsumes_all.rs
@@ -1,0 +1,71 @@
+//! EL-completeness canary: `⊤ ⊑ C` (a named class equivalent to owl:Thing) must
+//! propagate to `X ⊑ C` for EVERY named class X.
+//!
+//! Discovered by the whelk-rs EL sweep (2026-07-08): `ore_ont_11522` (textbook pure
+//! EL — only `⊑` and `∃`) had 8 classes with `SubClassOf(owl:Thing, C)`; rustdl
+//! derived 522 subsumptions vs whelk's complete 1490, missing all 968 Top-equivalent
+//! subsumptions. The saturator's `lower_sub_class_of` had no `Top` arm on the sub
+//! side, so `⊤ ⊑ C` was silently dropped — a genuine EL-incompleteness that also
+//! violated the `completeness_guaranteed()` contract (PureEl + no timeout, yet
+//! MISSED>0). Asserted at the SATURATION-CLOSURE layer (saturate() + contains).
+
+#![allow(clippy::unwrap_used, clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_core::convert::convert_ontology;
+use std::io::Cursor;
+
+const ONT: &str = r"Prefix(:=<http://t/>)
+Ontology(<http://t/o>
+  Declaration(Class(:A)) Declaration(Class(:C)) Declaration(Class(:D)) Declaration(Class(:X)) Declaration(Class(:E))
+  SubClassOf(<http://www.w3.org/2002/07/owl#Thing> :C)
+  SubClassOf(:C :D)
+  SubClassOf(:X :A)
+)";
+
+fn sat_sub(x: &str, y: &str) -> bool {
+    let (o, _): (SetOntology<RcStr>, _) = read_ofn(
+        &mut Cursor::new(ONT.to_string()),
+        ParserConfiguration::default(),
+    )
+    .expect("parse");
+    let internal = convert_ontology(&o).expect("lower");
+    let subsumers = owl_dl_saturation::saturate(&internal);
+    let xid = internal
+        .vocabulary
+        .class_id(&format!("http://t/{x}"))
+        .expect("x declared");
+    let yid = internal
+        .vocabulary
+        .class_id(&format!("http://t/{y}"))
+        .expect("y declared");
+    subsumers.contains(xid, yid)
+}
+
+#[test]
+fn top_subsumer_propagates_to_all_classes() {
+    // ⊤ ⊑ C ⟹ every class ⊑ C.
+    assert!(sat_sub("X", "C"), "⊤ ⊑ C ⟹ X ⊑ C");
+    assert!(sat_sub("A", "C"), "⊤ ⊑ C ⟹ A ⊑ C");
+    assert!(
+        sat_sub("E", "C"),
+        "⊤ ⊑ C ⟹ E ⊑ C (even a class with no other axioms)"
+    );
+    // Transitive: ⊤ ⊑ C ⊑ D ⟹ every class ⊑ D.
+    assert!(sat_sub("X", "D"), "⊤ ⊑ C, C ⊑ D ⟹ X ⊑ D");
+    assert!(sat_sub("E", "D"), "⊤ ⊑ C, C ⊑ D ⟹ E ⊑ D");
+    // C itself ⊑ D (told).
+    assert!(sat_sub("C", "D"), "C ⊑ D (told)");
+}
+
+#[test]
+fn top_subsumer_no_spurious_subsumption() {
+    // FP guard: the ⊤-broadcast must not make unrelated classes subsume each other.
+    // A ⋢ X (A and X share no relationship other than both ⊑ the Top-equiv classes).
+    assert!(!sat_sub("A", "X"), "A ⋢ X (no such subsumption)");
+    assert!(!sat_sub("C", "A"), "C ⋢ A (C is Top-equiv but A is not)");
+    assert!(!sat_sub("D", "A"), "D ⋢ A");
+}

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -637,6 +637,19 @@ impl WorklistEngine {
                 self.todo_subsumer.push_back((rule.sub, rule.sup));
             }
         }
+        // `⊤ ⊑ C` broadcast: C is Top-equivalent ⟹ every named class ⊑ C. Seed
+        // `(X, C)` for every named class X and every top subsumer C; the fixpoint
+        // then closes transitively (X ⊑ C ⊑ D ⟹ X ⊑ D) and fires C's downstream
+        // rules on each X. No-op unless the ontology has a `⊤ ⊑ NamedClass` axiom.
+        if !self.rules.top_subsumers.is_empty() {
+            let tops = self.rules.top_subsumers.clone();
+            for i in 0..self.num_user_classes {
+                let x = ClassId::new(u32::try_from(i).expect("class count fits in u32"));
+                for &c in &tops {
+                    self.todo_subsumer.push_back((x, c));
+                }
+            }
+        }
         // Told existential facts (snapshot first to release the
         // borrow into `self.rules`).
         let told: Vec<ExistentialFact> = self.rules.existential_facts.clone();
@@ -890,9 +903,16 @@ impl WorklistEngine {
         self.facts_by_sub[fact.sub.index() as usize].push(idx);
         self.facts_by_target[fact.target.index() as usize].push(idx);
         self.todo_fact.push_back(idx);
-        // Phase 2d: propagate to every subclass of fact.sub.
-        // subs_of_class returns an owned Vec, so no borrow conflict
-        // with the recursive push_fact_impl mutable borrow.
+        // Phase 2d: propagate the fact to every subclass of fact.sub. subs_of_class
+        // returns an owned Vec, so no borrow conflict with the recursive
+        // push_fact_impl mutable borrow.
+        //
+        // NOTE: gating this on `has_functional_roles` is UNSOUND — although Phase 2d
+        // was introduced to feed the functional witness-merge, the copied facts are
+        // also consumed by the general conjunction/∃ rules on subclasses, so skipping
+        // it drops real EL subsumptions on non-functional TBoxes (e.g. ORE
+        // ore_ont_11522: 522 vs whelk's 1490). go-basic's byte-identical result was a
+        // false reassurance (its structure happens not to need the copies). Do not gate.
         let subs = self.subs_of_class(fact.sub);
         let parent_df = DerivedFact::Exist(fact.sub, fact.role, fact.target);
         for c in subs {
@@ -2030,6 +2050,10 @@ impl Subsumers {
 struct ElRules {
     /// Direct named-to-named `A ⊑ B` facts.
     atomic_subsumptions: Vec<AtomicSubsumption>,
+    /// Atomic subsumers of `⊤` (from `SubClassOf(owl:Thing, C)` / `⊤ ⊑ C⊓…`).
+    /// Every named class ⊑ each of these (C is Top-equivalent). Broadcast to all
+    /// classes in `seed`; empty unless the ontology has a `⊤ ⊑ NamedClass` axiom.
+    top_subsumers: Vec<ClassId>,
     /// Conjunctive triggers: when a class accumulates every `body`
     /// among its subsumers, it gains `head`.
     conjunctive_triggers: Vec<ConjunctiveTrigger>,
@@ -3380,6 +3404,16 @@ fn lower_sub_class_of(
                         head,
                     });
                 }
+            }
+        }
+        // `⊤ ⊑ C` (a named class equivalent to owl:Thing): C subsumes EVERYTHING,
+        // so every named class ⊑ C. Record each atomic sup as a "top subsumer";
+        // `seed` broadcasts these to all classes and the fixpoint closes them
+        // transitively. Without this the axiom was silently dropped here — a real
+        // EL-incompleteness (ORE ore_ont_11522: 522 vs whelk's complete 1490).
+        ConceptExpr::Top => {
+            for c in atomic_operands_on_right(sup, pool) {
+                rules.top_subsumers.push(c);
             }
         }
         _ => {}

--- a/docs/whelk-rs-comparison-2026-07-08.md
+++ b/docs/whelk-rs-comparison-2026-07-08.md
@@ -77,6 +77,35 @@ rustdl extends the same kernel with (a) EL⁺⁺ functional/inverse-functional w
 `DKey` datatype value-membership, ObjectHasSelf+range — and (c) a hybrid hypertableau
 "wedge" + tableau for the rest of SROIQ. whelk-rs stays within EL.
 
+## 5b. At-scale EL sweep (ORE-2015, 205 pure-EL onts) — added 2026-07-08
+
+Ran `compare-whelk` over all ORE-2015 pure-EL ontologies (multi-format harness).
+whelk-rs (base ELK, EL-sound-and-complete) is the oracle for the EL closure.
+
+- **rustdl == whelk (byte-identical EL closure): 201 / 205** — strong mutual
+  cross-validation at scale.
+- **rustdl ⊋ whelk (sound EL⁺⁺ superset): 1** (functional-role witness-merge).
+- **rustdl ⊊ whelk (EL gap): 3** (`ore_ont_3406/7216/13224`).
+- **Performance: rustdl faster on 123 / 144 timed onts (median 1.64×); whelk faster
+  on the largest** (e.g. `ore_ont_10248` 1M pairs: whelk 1.9 s vs rustdl 9.4 s) — the
+  go-basic scaling pattern generalises.
+
+**The sweep found two real rustdl EL-completeness gaps the tuned corpus never
+exercised — its whole point:**
+1. **`⊤ ⊑ NamedClass`** (`ore_ont_11522`): FIXED (commit on `fix/top-subsumes-all-el`;
+   `top_subsumers` broadcast). 11522 522 → 1490 = whelk.
+2. **Defined-class conjunctive trigger with an `∃` over a sub-property** — RESIDUAL,
+   3 onts. Pattern: `GOCHE_37527 ≡ ∃GOCHEREL_0000004.CHEBI_37527 ⊓ CHEBI_24431`,
+   `GOCHEREL_0000004 ⊑ RO_0000087`; rustdl's saturator doesn't fire the trigger for
+   many CHEBI subclasses (claims PureEl-complete, isn't). Chemistry (CHEBI/GOCHE) onts.
+   Not yet fixed — needs saturator debugging of why the conjunctive `∃`-over-subproperty
+   trigger misses.
+
+**Correction to §3:** the "strict superset" claim held on galen/notgalen/go-basic but is
+FALSE in general — pre-fix rustdl was a subset on the ⊤⊑C onts, and remains a subset on
+the 3 defined-class-∃ onts. Post-⊤⊑C-fix: rustdl is ⊇ whelk on 202/205 EL onts, with 3
+residual EL gaps to close before any unqualified EL-completeness claim.
+
 ## 6. Paper takeaway
 
 whelk-rs is the honest "same-class" baseline that isolates rustdl's contribution: **same


### PR DESCRIPTION
Found by the whelk-rs EL sweep (`docs/whelk-rs-comparison-2026-07-08.md`).

## Bug

The saturator's `lower_sub_class_of` had no `Top` arm on the sub side, so
`SubClassOf(owl:Thing, C)` (⊤ ⊑ C — a named class equivalent to owl:Thing) was
**silently dropped**. But ⊤ ⊑ C means C subsumes everything, so every named class ⊑ C.
Missing this is a real EL-**incompleteness** that also violated the newly-added
`completeness_guaranteed()` contract (a PureEl ontology, no timeout, yet MISSED>0).

`ore_ont_11522` (textbook pure EL — only `⊑` and `∃`) had 8 ⊤⊑C classes; rustdl derived
522 subsumptions vs whelk's complete **1490**, missing all 968 Top-equivalent subsumptions.

## Fix

New `ConceptExpr::Top` match arm collects atomic subsumers of ⊤ into `rules.top_subsumers`;
`seed()` broadcasts `(X, C)` for every named class X and top-subsumer C; the fixpoint
closes transitively (`X⊑C⊑D ⟹ X⊑D`) and fires C's downstream rules on each X.

**Sound by construction** — only adds genuine ⊤-equivalence entailments; **no-op unless the
ontology has a `⊤⊑NamedClass` axiom**. `ore_ont_11522` now 1490=1490 (symdiff 0 vs whelk).

Also: `compare-whelk` now content-sniffs OFN/OWX/RDF-XML (was OFN-only), for the BioPortal
comparison.

## Validation

- Canary `top_subsumes_all.rs` (propagation + transitivity + FP guard, saturation-closure layer).
- **FP=0/MISSED=0 byte-identical corpus-wide** (galen/notgalen/sio/wine/ro/bibtex/ore-10908/ore-15672/alehif).
- **ORE-2015 EL sweep: 201/205 pure-EL onts byte-identical to whelk** (was 200 with an ⊤⊑C-cluster gap); workspace green (75 groups); fmt/clippy clean.

Residual (separate follow-up): a defined-class conjunctive-trigger-with-∃-over-subproperty gap on 3 chemistry onts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSzon7V2wkhrudxBNAJduh