### PR TITLE
fix(saturation): handle ∃R.⊤ on the RHS (EL-completeness gap)

### DIFF
--- a/crates/owl-dl-reasoner/tests/exists_top_filler.rs
+++ b/crates/owl-dl-reasoner/tests/exists_top_filler.rs
@@ -1,0 +1,84 @@
+//! EL-completeness canary: `∃R.⊤` (ObjectSomeValuesFrom(R, owl:Thing)) on the RHS.
+//!
+//! `∃R.⊤` means "has some R-successor". A class `A ⊑ ∃R.⊤` must get an R-marker so
+//! the domain rule (`∃R.⊤ ⊑ C` = domain(R)=C) fires — in particular two classes
+//! defined `≡ ∃R.⊤` are equivalent. The saturator dropped `∃R.⊤` on the RHS (the
+//! ⊤ filler has no atomic/Tseitin body), so `A ≡ ∃R.⊤`, `B ≡ ∃R.⊤` did not yield
+//! `A ≡ B` — a real EL-incompleteness discovered by the whelk-rs EL sweep
+//! (`ore_ont_7216`: rustdl 64990 vs whelk/Konclude 74374). Fix: emit a fact to an
+//! opaque ⊤-witness for `∃R.⊤`. Asserted at the saturation-closure layer.
+
+#![allow(clippy::unwrap_used, clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_core::convert::convert_ontology;
+use std::io::Cursor;
+
+fn sat_sub(ont: &str, x: &str, y: &str) -> bool {
+    let (o, _): (SetOntology<RcStr>, _) = read_ofn(
+        &mut Cursor::new(ont.to_string()),
+        ParserConfiguration::default(),
+    )
+    .expect("parse");
+    let internal = convert_ontology(&o).expect("lower");
+    let subsumers = owl_dl_saturation::saturate(&internal);
+    let xid = internal.vocabulary.class_id(x).expect("x");
+    let yid = internal.vocabulary.class_id(y).expect("y");
+    subsumers.contains(xid, yid)
+}
+
+const EQ: &str = r"Prefix(:=<http://t/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://t/o>
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:U)) Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))
+  EquivalentClasses(:A ObjectSomeValuesFrom(:r owl:Thing))
+  EquivalentClasses(:B ObjectSomeValuesFrom(:r owl:Thing))
+  EquivalentClasses(:U ObjectSomeValuesFrom(:s owl:Thing))
+)";
+
+#[test]
+fn exists_top_same_role_classes_are_equivalent() {
+    // A ≡ ∃r.⊤ and B ≡ ∃r.⊤ ⟹ A ≡ B.
+    assert!(
+        sat_sub(EQ, "http://t/A", "http://t/B"),
+        "A ⊑ B (both ≡ ∃r.⊤)"
+    );
+    assert!(
+        sat_sub(EQ, "http://t/B", "http://t/A"),
+        "B ⊑ A (both ≡ ∃r.⊤)"
+    );
+}
+
+#[test]
+fn exists_top_different_role_no_subsumption() {
+    // FP guard: U ≡ ∃s.⊤ is a DIFFERENT role — must not subsume/be-subsumed by A (∃r.⊤).
+    assert!(
+        !sat_sub(EQ, "http://t/A", "http://t/U"),
+        "A ⋢ U (different roles r vs s)"
+    );
+    assert!(
+        !sat_sub(EQ, "http://t/U", "http://t/A"),
+        "U ⋢ A (different roles)"
+    );
+}
+
+#[test]
+fn exists_top_domain_inference() {
+    // ∃r.⊤ ⊑ C (domain) + X ⊑ ∃r.⊤ ⟹ X ⊑ C.
+    let ont = r"Prefix(:=<http://t/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://t/o>
+  Declaration(Class(:C)) Declaration(Class(:X)) Declaration(Class(:Z)) Declaration(ObjectProperty(:r))
+  SubClassOf(ObjectSomeValuesFrom(:r owl:Thing) :C)
+  SubClassOf(:X ObjectSomeValuesFrom(:r owl:Thing))
+)";
+    assert!(
+        sat_sub(ont, "http://t/X", "http://t/C"),
+        "X ⊑ ∃r.⊤ ⊑ C (domain)"
+    );
+    // FP guard: Z with no r-successor must not be a C.
+    assert!(!sat_sub(ont, "http://t/Z", "http://t/C"), "Z ⋢ C (no ∃r.⊤)");
+}

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -2256,6 +2256,14 @@ struct TseitinAllocator {
     /// key. Told monotonicity edges `ForallAtomicKey(R,K) ⊑ ForallAtomicKey(R,L)` for
     /// `K ⊑ L` give `∀R.K ⊑ ∀R.L` (sound, non-inverse). Keyed on `(R, K)` identity.
     forall_atomic_key_by_role: HashMap<(RoleId, ClassId), ClassId>,
+    /// Stable synthetic ⊤-witness class per role, used as the fact target for a
+    /// `∃R.⊤` existential (`ObjectSomeValuesFrom(R, owl:Thing)` on the RHS). ⊤ has
+    /// no `atomic_or_tseitin_body` representation, so `A ⊑ ∃R.⊤` previously created
+    /// no fact — A never got an R-marker, so the domain rule (`∃R.⊤ ⊑ C`, i.e.
+    /// domain(R)=C) never fired on A. The witness is an opaque atom (no subsumers →
+    /// ⊤-equivalent), so it only ever triggers domain(R); sound. Keyed per role so
+    /// all `∃R.⊤` facts share one witness (they mean the same thing).
+    top_witness_by_role: HashMap<RoleId, ClassId>,
 }
 
 impl TseitinAllocator {
@@ -2269,7 +2277,20 @@ impl TseitinAllocator {
             max_key_by_role: HashMap::new(),
             forall_key_by_role: HashMap::new(),
             forall_atomic_key_by_role: HashMap::new(),
+            top_witness_by_role: HashMap::new(),
         }
+    }
+
+    /// Get-or-allocate the opaque ⊤-witness synthetic for `∃R.⊤`. See
+    /// `top_witness_by_role`.
+    fn introduce_top_witness(&mut self, role: RoleId) -> ClassId {
+        if let Some(&existing) = self.top_witness_by_role.get(&role) {
+            return existing;
+        }
+        let synthetic = ClassId::new(self.next_id);
+        self.next_id = self.next_id.checked_add(1).expect("synthetic id overflow");
+        self.top_witness_by_role.insert(role, synthetic);
+        synthetic
     }
 
     /// SP-B2b: get-or-allocate the opaque synthetic class for `∀R.Atomic(K)`.
@@ -3459,6 +3480,18 @@ fn atomic_existential_rhs(
     // nominal fold needs only the NomKey identity.
     if let ConceptExpr::Nominal(ind) = pool.get(*body) {
         return Some((role.role_id(), tseitin.introduce_nominal(*ind)));
+    }
+    // `∃R.⊤` (ObjectSomeValuesFrom(R, owl:Thing)): the ⊤ filler has no
+    // atomic_or_tseitin body, so previously this made no fact and the subject never
+    // got an R-marker — the domain rule (`∃R.⊤ ⊑ C` = domain(R)=C) then never fired
+    // on it. Emit a fact to an opaque ⊤-witness so the domain inference fires (e.g.
+    // `A ≡ ∃R.⊤`, `B ≡ ∃R.⊤` ⟹ A ≡ B via domain(R) ⊒ {A,B}). Sound: the witness has
+    // no subsumers (⊤-equivalent), so it only ever triggers domain(R).
+    if matches!(pool.get(*body), ConceptExpr::Top) {
+        return Some((
+            role.role_id(),
+            tseitin.introduce_top_witness(role.role_id()),
+        ));
     }
     let extras = effective_ranges
         .get(&role.role_id())

--- a/docs/whelk-rs-comparison-2026-07-08.md
+++ b/docs/whelk-rs-comparison-2026-07-08.md
@@ -94,12 +94,22 @@ whelk-rs (base ELK, EL-sound-and-complete) is the oracle for the EL closure.
 exercised — its whole point:**
 1. **`⊤ ⊑ NamedClass`** (`ore_ont_11522`): FIXED (commit on `fix/top-subsumes-all-el`;
    `top_subsumers` broadcast). 11522 522 → 1490 = whelk.
-2. **Defined-class conjunctive trigger with an `∃` over a sub-property** — RESIDUAL,
-   3 onts. Pattern: `GOCHE_37527 ≡ ∃GOCHEREL_0000004.CHEBI_37527 ⊓ CHEBI_24431`,
-   `GOCHEREL_0000004 ⊑ RO_0000087`; rustdl's saturator doesn't fire the trigger for
-   many CHEBI subclasses (claims PureEl-complete, isn't). Chemistry (CHEBI/GOCHE) onts.
-   Not yet fixed — needs saturator debugging of why the conjunctive `∃`-over-subproperty
-   trigger misses.
+2. **`∃R.⊤` (ObjectSomeValuesFrom(R, owl:Thing)) on the RHS** — FIXED (`exists_top_filler.rs`).
+   The ⊤ filler has no atomic/Tseitin body, so `A ⊑ ∃R.⊤` made no fact → the domain
+   rule never fired → `A ≡ ∃R.⊤`, `B ≡ ∃R.⊤` didn't give `A ≡ B`. Fix: emit a fact to
+   an opaque ⊤-witness. `ore_ont_7216` 64990 → **74374 = whelk = Konclude** (symdiff 0).
+
+**The other 2 "gaps" (`ore_ont_3406`, `13224`) were NOT rustdl bugs — whelk-rs OVER-DERIVES
+there (unsound port).** Konclude-verified: on `3406`, `CHEBI_100147 ⊑ GOCHE_37527` is
+`False` in Konclude (Konclude closure = rustdl, NOT whelk); whelk-rs incorrectly matches a
+super-property existential to a sub-property in the `GOCHE ≡ ∃subprop.X ⊓ Y` conjunctive
+trigger. So on those onts **rustdl is correct and whelk-rs is unsound** — a notable result
+(measure-first: I verified each disagreement against an independent Konclude oracle rather
+than trusting whelk).
+
+**Post-fix status vs the Konclude oracle: rustdl matches Konclude on all diffed ORE EL onts**
+(⊤⊑C + ∃R.⊤ fixed; 3406/13224 are whelk-unsoundness). The "PureEl ⟹ complete" premise now
+holds on the measured EL corpus.
 
 **Correction to §3:** the "strict superset" claim held on galen/notgalen/go-basic but is
 FALSE in general — pre-fix rustdl was a subset on the ⊤⊑C onts, and remains a subset on


### PR DESCRIPTION
Found by the whelk-rs EL sweep + Konclude adjudication (`docs/whelk-rs-comparison-2026-07-08.md`).

## Bug

`∃R.⊤` (`ObjectSomeValuesFrom(R, owl:Thing)`) on the RHS was **dropped**: the ⊤ filler has no
`atomic_or_tseitin` body, so `A ⊑ ∃R.⊤` created no existential fact → A never got an R-marker →
the domain rule (`∃R.⊤ ⊑ C` = domain(R)=C) never fired on A. So `A ≡ ∃R.⊤`, `B ≡ ∃R.⊤` did not
yield `A ≡ B`. Real EL-incompleteness.

`ore_ont_7216`: rustdl 64990 vs whelk **and Konclude** 74374 — a genuine rustdl gap (verified
against Konclude, unlike `ore_ont_3406/13224` where whelk-rs over-derives and Konclude sides with
rustdl).

## Fix

`atomic_existential_rhs` emits a fact to an opaque per-role ⊤-witness for `∃R.⊤`. **Sound** — the
witness has no subsumers (⊤-equivalent), so it only ever triggers domain(R). No-op unless the
ontology has an `∃R.⊤`.

## Validation

- `ore_ont_7216` now 74374 = whelk = Konclude (symdiff 0); minimal `A≡∃r.⊤,B≡∃r.⊤ ⟹ A≡B`.
- Canary `exists_top_filler.rs` (equivalence + domain inference + FP guards, saturation-closure layer).
- **FP=0/MISSED=0 byte-identical corpus-wide** (galen/notgalen/sio/wine/ro/bibtex/ore-10908/ore-15672/alehif); workspace green (76 groups); fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSzon7V2wkhrudxBNAJduh