### PR TITLE
fix(realize): saturation fast path — end the issue #35 realization hang

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,33 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   **once** so the O(n²) pairwise classify loop reuses it across pairs; the loop
   runs in parallel via rayon. `is_subclass_of` reduces to satisfiability of
   `sub ⊓ ¬sup`.
+  **Realize saturation fast path (2026-07-21, `RUSTDL_REALIZE_SATURATION`,
+  default ON) — fixes the issue-#35 realization hang.** `realize` /
+  `is_instance_of` / `instances_of` previously ran the full `{a} ⊓ ¬C` tableau
+  probe for *every* (individual, class) pair; on an EL/Horn ontology with a
+  defined class (`≡` + `∃`) + property domain + a property assertion the
+  ⊔-search explodes (100k+ branches over a blocked ~134-node graph) and never
+  terminates — a >300 s hang, while `classify` on the same file is instant
+  (saturation fast path). Now realize mirrors `classify`'s gate: on the
+  saturator-complete fragment (`realize_saturation_eligible`: TBox in
+  `is_pure_el`/`saturator_complete_fragment`/`tbox_only_saturator_eligible`
+  **and** every ABox axiom a shape the seeding captures — atomic/⊓
+  `ClassAssertion`, non-inverse `ObjectPropertyAssertion`; `SameIndividual` /
+  inverse assertions fall back) it realizes via
+  `owl_dl_saturation::saturate_for_realize`, which materializes each named
+  individual as a nominal class `N_a` and seeds `N_a ⊑ C` (ClassAssertion),
+  `N_a ⊑ ∃r.N_b` (ground edge ⟹ domain-of-`r` + existential-LHS firing) and
+  `N_b ⊑ Rng` (ground range); `types(a) = subsumers_of(N_a) ∩ named classes`.
+  **Complete == the tableau on the fragment** (incl. the conjunctive-LHS
+  `x:D1, x:D2, D1 ⊓ D2 ⊑ E ⊨ x:E` case both saturation engines otherwise drop),
+  **sound by construction**, and TERMINATING (no tableau). Off-fragment realize
+  keeps the tableau (identical prior logic) plus an opt-in per-pair deadline
+  `RUSTDL_REALIZE_PAIR_TIMEOUT_MS` (default UNSET ⟹ no bound; restores the
+  caller-side bound removed in 0.3.18 — bounds each pair, not total wall).
+  `RUSTDL_REALIZE_SATURATION=0` reverts to the tableau path. Correctness gate:
+  `realize::tests::fast_path_matches_tableau_on_terminating_fixture` (byte-
+  identity) + conjunctive/existential/domain-range/termination unit tests. See
+  `docs/2026-07-21-realize-saturation-fast-path.md`.
   `materialize_object_property_assertions` (reasoner) / `materialize_inferred_property_assertions`
   (Python) / `realize --properties` (CLI) surface inferred OBJECT property assertions over named
   individuals, reusing the ABox saturator's derived edges (sound under-approximation: no

--- a/crates/owl-dl-reasoner/src/realize.rs
+++ b/crates/owl-dl-reasoner/src/realize.rs
@@ -20,12 +20,17 @@ use horned_owl::ontology::set::SetOntology;
 use rayon::prelude::*;
 
 use owl_dl_core::convert::convert_ontology;
-use owl_dl_core::{Axiom, ClassId, ConceptExpr, IndividualId, InternalOntology};
-use owl_dl_saturation::{Subsumers, saturate};
+use owl_dl_core::{
+    Axiom, ClassId, ConceptExpr, ConceptId, ConceptPool, IndividualId, InternalOntology,
+};
+use owl_dl_saturation::{Subsumers, saturate, saturate_for_realize};
 
 use crate::PreparedOntology;
 use crate::ReasonError;
-use crate::classify::{classify_saturation_only_internal, classify_top_down_internal};
+use crate::classify::{
+    classify_saturation_only_internal, classify_top_down_internal, is_pure_el,
+    saturator_complete_fragment, tbox_only_saturator_eligible,
+};
 
 /// `(entailed_types, hasse_leaves)` for one individual — returned
 /// by the parallel realisation worker so the outer loop can stitch
@@ -72,9 +77,30 @@ pub fn is_instance_of_internal(
         .vocabulary
         .individual_id(individual_iri)
         .ok_or_else(|| ReasonError::UnknownClass(individual_iri.to_owned()))?;
+    // Fast path: on the saturator-complete fragment answer completely via
+    // saturation — `a : C` iff `C` subsumes `a`'s nominal class. Avoids the
+    // `{a} ⊓ ¬C` tableau probe that explodes on issue-#35-style inputs.
+    if realize_saturation_eligible(internal) {
+        let (subsumers, nominal_by_ind) = saturate_for_realize(internal);
+        return Ok(nominal_by_ind
+            .get(&individual_id)
+            .is_some_and(|&nom| subsumers.contains(nom, class_id)));
+    }
     let closure = saturate(internal);
     let prepared = PreparedOntology::from_internal(internal.clone())?;
-    instance_check_with_closure(internal, &closure, &prepared, class_id, individual_id)
+    let pair_deadline = std::env::var("RUSTDL_REALIZE_PAIR_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&ms| ms > 0)
+        .map(|ms| std::time::Instant::now() + std::time::Duration::from_millis(ms));
+    instance_check_with_closure(
+        internal,
+        &closure,
+        &prepared,
+        class_id,
+        individual_id,
+        pair_deadline,
+    )
 }
 
 /// Saturation-only counterpart of [`is_instance_of`]. Reports
@@ -145,6 +171,7 @@ fn instance_check_with_closure(
     prepared: &PreparedOntology,
     class_id: ClassId,
     individual_id: IndividualId,
+    pair_deadline: Option<std::time::Instant>,
 ) -> Result<bool, ReasonError> {
     for told in told_classes_of(internal, individual_id) {
         if closure.contains(told, class_id) {
@@ -152,13 +179,24 @@ fn instance_check_with_closure(
         }
     }
     // KB ⊨ C(a) iff `{a} ⊓ ¬C` is unsatisfiable.
-    let sat = prepared.decide(move |pool| {
+    let build = move |pool: &mut ConceptPool| {
         let cls = pool.atomic(class_id);
         let not_cls = pool.not(cls);
         let nom = pool.nominal(individual_id);
         pool.and(vec![nom, not_cls])
-    })?;
-    Ok(!sat)
+    };
+    match pair_deadline {
+        // Bounded probe: a deadline hit yields no verdict, which we treat
+        // as "not an instance" — a SOUND under-approximation (a MISS at
+        // worst, never a false membership). This restores the caller's
+        // ability to bound realize (the per-call timeout removed in 0.3.18)
+        // for genuinely out-of-fragment inputs, so realize can never hang
+        // unbounded.
+        Some(deadline) => Ok(!prepared
+            .decide_with_deadline(deadline, build)?
+            .unwrap_or(true)),
+        None => Ok(!prepared.decide(build)?),
+    }
 }
 
 /// Saturation-only counterpart to [`instance_check_with_closure`].
@@ -278,13 +316,45 @@ pub fn instances_of_internal(
         .vocabulary
         .class_id(class_iri)
         .ok_or_else(|| ReasonError::UnknownClass(class_iri.to_owned()))?;
+    // Fast path: on the saturator-complete fragment, `a ∈ C` iff `C` subsumes
+    // `a`'s nominal class (complete + terminating; no tableau).
+    if realize_saturation_eligible(internal) {
+        let (subsumers, nominal_by_ind) = saturate_for_realize(internal);
+        let mut out = Vec::new();
+        for idx in 0..internal.vocabulary.num_individuals() {
+            let ind = IndividualId::new(u32::try_from(idx).expect("individual count fits in u32"));
+            if nominal_by_ind
+                .get(&ind)
+                .is_some_and(|&nom| subsumers.contains(nom, class_id))
+            {
+                let iri = internal.vocabulary.individual_iri(ind);
+                if !iri.starts_with(owl_dl_core::convert::ANON_IRI_PREFIX) {
+                    out.push(iri.to_owned());
+                }
+            }
+        }
+        return Ok(out);
+    }
     let closure = saturate(internal);
     let prepared = PreparedOntology::from_internal(internal.clone())?;
+    let pair_deadline_ms: Option<u64> = std::env::var("RUSTDL_REALIZE_PAIR_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&ms| ms > 0);
     let mut out = Vec::new();
     for idx in 0..internal.vocabulary.num_individuals() {
         let individual_id =
             IndividualId::new(u32::try_from(idx).expect("individual count fits in u32"));
-        if instance_check_with_closure(internal, &closure, &prepared, class_id, individual_id)? {
+        let pair_deadline = pair_deadline_ms
+            .map(|ms| std::time::Instant::now() + std::time::Duration::from_millis(ms));
+        if instance_check_with_closure(
+            internal,
+            &closure,
+            &prepared,
+            class_id,
+            individual_id,
+            pair_deadline,
+        )? {
             let iri = internal.vocabulary.individual_iri(individual_id);
             if !iri.starts_with(owl_dl_core::convert::ANON_IRI_PREFIX) {
                 out.push(iri.to_owned());
@@ -505,12 +575,163 @@ pub fn realize_saturation_only_internal(
     })
 }
 
+/// True iff `class` (a `ClassAssertion` body) is captured EXACTLY by
+/// [`saturate_for_realize`]'s atomic-operand seeding — i.e. it is atomic,
+/// `⊤`, or a conjunction thereof. A body carrying `∃`/`∀`/nominal/cardinality/
+/// `¬` would be under-captured (the seeding drops the non-atomic operands), so
+/// such inputs must fall back to the complete tableau path.
+fn class_body_realize_safe(class: ConceptId, pool: &ConceptPool) -> bool {
+    match pool.get(class) {
+        ConceptExpr::Atomic(_) | ConceptExpr::Top => true,
+        ConceptExpr::And(ops) => ops.iter().all(|op| class_body_realize_safe(*op, pool)),
+        _ => false,
+    }
+}
+
+/// Is `internal` realized COMPLETELY (== the tableau) by the saturation fast
+/// path? Two conditions:
+///
+/// 1. The `TBox` is in the saturator-complete fragment — reusing `classify`'s
+///    proven gates (`is_pure_el` / `saturator_complete_fragment` for the no-`ABox`
+///    case, or the `ABox`-admitting Lever-1 `tbox_only_saturator_eligible`, which
+///    also excludes nominals).
+/// 2. Every `ABox` axiom is a shape [`saturate_for_realize`] captures exactly:
+///    atomic/⊓ `ClassAssertion` and non-inverse `ObjectPropertyAssertion`.
+///    `NegativeObjectPropertyAssertion` / `DifferentIndividuals` add no types
+///    (an inconsistency they cause is caught by the classify/abox pre-checks),
+///    so they are permitted. `SameIndividual` (needs type-merge across
+///    individuals) and inverse-role assertions are NOT captured ⟹ fall back.
+///
+/// Unlike `classify`, realize CANNOT admit arbitrary `ABox` shapes: the `ABox` is
+/// load-bearing for individual types, whereas it is irrelevant to class
+/// subsumption.
+fn realize_saturation_eligible(internal: &InternalOntology) -> bool {
+    // RUSTDL_REALIZE_SATURATION=0 forces the tableau path (A/B isolation).
+    if std::env::var_os("RUSTDL_REALIZE_SATURATION").is_some_and(|v| v == "0") {
+        return false;
+    }
+    let tbox_ok = is_pure_el(internal)
+        || (crate::horn_shortcircuit_enabled() && saturator_complete_fragment(internal))
+        || tbox_only_saturator_eligible(internal);
+    if !tbox_ok {
+        return false;
+    }
+    internal.axioms.iter().all(|ax| match ax {
+        Axiom::ClassAssertion { class, .. } => class_body_realize_safe(*class, &internal.concepts),
+        Axiom::ObjectPropertyAssertion { role, .. } => !role.is_inverse(),
+        Axiom::SameIndividual(_) => false,
+        // Everything else is either a type-irrelevant ABox form
+        // (NegativeObjectPropertyAssertion / DifferentIndividuals) or a TBox
+        // axiom already vetted by `tbox_ok`.
+        _ => true,
+    })
+}
+
+/// Saturation fast-path realization — complete == the tableau on the
+/// [`realize_saturation_eligible`] fragment, and TERMINATING (no tableau, no
+/// disjunctive search). Materializes each named individual as a nominal class
+/// via [`saturate_for_realize`] and reads its entailed named types off the
+/// subsumer closure. This is the fix for the issue-#35 realize hang: the
+/// exploding `{a} ⊓ ¬C` tableau probe is never invoked on the EL/Horn fragment.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub(crate) fn realize_via_saturation_internal(
+    internal: &InternalOntology,
+) -> Result<Realization, ReasonError> {
+    // Complete class hierarchy on this fragment (for Hasse-leaf pruning and the
+    // unsatisfiable-class filter).
+    let hierarchy = classify_saturation_only_internal(internal)?;
+    let unsat: HashSet<&str> = hierarchy.unsatisfiable_classes().into_iter().collect();
+    let num_user_classes = internal.vocabulary.num_classes();
+
+    let (subsumers, nominal_by_ind) = saturate_for_realize(internal);
+
+    let mut entailed_types: HashMap<String, Vec<String>> = HashMap::new();
+    let mut most_specific_types: HashMap<String, Vec<String>> = HashMap::new();
+    let mut named_individual_iris: Vec<String> = Vec::new();
+
+    for idx in 0..internal.vocabulary.num_individuals() {
+        let ind = IndividualId::new(u32::try_from(idx).expect("individual count fits in u32"));
+        let iri = internal.vocabulary.individual_iri(ind).to_owned();
+        if iri.starts_with(owl_dl_core::convert::ANON_IRI_PREFIX) {
+            continue;
+        }
+        // Entailed named types = subsumers of the individual's nominal class,
+        // restricted to declared user classes (synthetic Tseitin / nominal ids
+        // are ≥ num_user_classes) and to satisfiable classes.
+        let types: Vec<String> = nominal_by_ind
+            .get(&ind)
+            .map(|&nom| {
+                subsumers
+                    .subsumers_of(nom)
+                    .into_iter()
+                    .filter(|c| (c.index() as usize) < num_user_classes)
+                    .map(|c| internal.vocabulary.class_iri(c).to_owned())
+                    .filter(|iri| !unsat.contains(iri.as_str()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        // Filter to Hasse leaves under the classification relation.
+        let leaves: Vec<String> = types
+            .iter()
+            .filter(|cls| {
+                !types.iter().any(|other| {
+                    other != *cls
+                        && hierarchy.is_subclass(other, cls)
+                        && !hierarchy.is_subclass(cls, other)
+                })
+            })
+            .cloned()
+            .collect();
+        named_individual_iris.push(iri.clone());
+        entailed_types.insert(iri.clone(), types);
+        most_specific_types.insert(iri, leaves);
+    }
+
+    Ok(Realization {
+        individuals: named_individual_iris,
+        entailed_types,
+        most_specific_types,
+    })
+}
+
 /// Internal entry point.
 ///
 /// # Errors
 ///
 /// See [`ReasonError`].
 pub fn realize_internal(internal: &InternalOntology) -> Result<Realization, ReasonError> {
+    // Fast path: on the saturator-complete fragment (EL/Horn TBox + simple
+    // ABox) realize completely via saturation, never touching the tableau —
+    // whose `{a} ⊓ ¬C` disjunctive search can explode on defined-class +
+    // property-domain + property-assertion inputs (issue #35).
+    if realize_saturation_eligible(internal) {
+        return realize_via_saturation_internal(internal);
+    }
+    realize_tableau_internal(internal)
+}
+
+/// The sound+complete tableau realization path — one `{a} ⊓ ¬C` satisfiability
+/// probe per (individual, satisfiable-class) pair. Used off the saturation
+/// fast-path fragment (and directly in the fast-path-vs-tableau identity test).
+/// Optionally bounds each per-pair probe via `RUSTDL_REALIZE_PAIR_TIMEOUT_MS`
+/// so a genuinely-hard SROIQ input degrades to a sound under-approximation
+/// instead of hanging (restores the caller-side bound removed in 0.3.18). Unset
+/// ⟹ no bound (verdict-preserving default).
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub(crate) fn realize_tableau_internal(
+    internal: &InternalOntology,
+) -> Result<Realization, ReasonError> {
+    let pair_deadline_ms: Option<u64> = std::env::var("RUSTDL_REALIZE_PAIR_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&ms| ms > 0);
+
     // Use the top-down classifier — the same default as the public
     // `classify` entry. The N² pair-sweep that this previously
     // called (`classify_internal`) DNFs on real ontologies and
@@ -565,12 +786,15 @@ pub fn realize_internal(internal: &InternalOntology) -> Result<Realization, Reas
             let mut types: Vec<&str> = Vec::new();
             for (class_idx, class_iri) in &satisfiable {
                 let class_id = ClassId::new(u32::try_from(*class_idx).expect("class fits in u32"));
+                let pair_deadline = pair_deadline_ms
+                    .map(|ms| std::time::Instant::now() + std::time::Duration::from_millis(ms));
                 if instance_check_with_closure(
                     internal,
                     &closure,
                     &prepared,
                     class_id,
                     individual_id,
+                    pair_deadline,
                 )? {
                     types.push(class_iri);
                 }
@@ -820,5 +1044,199 @@ Ontology(<http://rustdl.test/test>\n\
             sat.most_specific_types(alice),
             vec!["http://rustdl.test/A".to_owned()],
         );
+    }
+
+    /// Tier B fast-path realize must be COMPLETE on the EL fragment,
+    /// including conjunctive-LHS instance entailments that the old
+    /// closure-only `realize_saturation_only` drops:
+    /// `x:D1, x:D2, D1 ⊓ D2 ⊑ E ⊨ x:E`.
+    #[test]
+    fn saturation_realize_derives_conjunctive_lhs() {
+        let onto = parse(&format!(
+            "{HEADER}\
+Ontology(<http://rustdl.test/test>\n\
+    Declaration(Class(:D1)) Declaration(Class(:D2)) Declaration(Class(:E))\n\
+    Declaration(NamedIndividual(:x))\n\
+    SubClassOf(ObjectIntersectionOf(:D1 :D2) :E)\n\
+    ClassAssertion(:D1 :x)\n\
+    ClassAssertion(:D2 :x)\n\
+)\n"
+        ));
+        let internal = convert_ontology(&onto).expect("convert");
+        let r = realize_via_saturation_internal(&internal).expect("realize");
+        let x = "http://rustdl.test/x";
+        let types: HashSet<&str> = r.entailed_types(x).iter().map(String::as_str).collect();
+        assert!(types.contains("http://rustdl.test/D1"));
+        assert!(types.contains("http://rustdl.test/D2"));
+        assert!(
+            types.contains("http://rustdl.test/E"),
+            "conjunctive-LHS entailment x:E missed; got {types:?}",
+        );
+    }
+
+    /// Tier B fast-path realize must handle existential-filler LHS
+    /// (the family shape): `Person(a), hasSex(a,b), Male(b),
+    /// Person ⊓ ∃hasSex.Male ⊑ Man ⊨ a:Man` — the pattern that makes
+    /// the tableau path diverge on issue #35.
+    #[test]
+    fn saturation_realize_derives_existential_lhs() {
+        let onto = parse(&format!(
+            "{HEADER}\
+Ontology(<http://rustdl.test/test>\n\
+    Declaration(Class(:Person)) Declaration(Class(:Man)) Declaration(Class(:Male))\n\
+    Declaration(ObjectProperty(:hasSex))\n\
+    Declaration(NamedIndividual(:a)) Declaration(NamedIndividual(:b))\n\
+    EquivalentClasses(:Man ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Male)))\n\
+    ClassAssertion(:Person :a)\n\
+    ClassAssertion(:Male :b)\n\
+    ObjectPropertyAssertion(:hasSex :a :b)\n\
+)\n"
+        ));
+        let internal = convert_ontology(&onto).expect("convert");
+        let r = realize_via_saturation_internal(&internal).expect("realize");
+        let a = "http://rustdl.test/a";
+        let types: HashSet<&str> = r.entailed_types(a).iter().map(String::as_str).collect();
+        assert!(types.contains("http://rustdl.test/Person"));
+        assert!(
+            types.contains("http://rustdl.test/Man"),
+            "existential-LHS entailment a:Man missed; got {types:?}",
+        );
+    }
+
+    /// Tier B fast-path realize derives domain (subject) and range
+    /// (object) types from a property assertion, matching the tableau.
+    #[test]
+    fn saturation_realize_domain_and_range() {
+        let onto = parse(&format!(
+            "{HEADER}\
+Ontology(<http://rustdl.test/test>\n\
+    Declaration(Class(:Parent)) Declaration(Class(:Person))\n\
+    Declaration(ObjectProperty(:hasParent))\n\
+    Declaration(NamedIndividual(:alice)) Declaration(NamedIndividual(:bob))\n\
+    ObjectPropertyDomain(:hasParent :Parent)\n\
+    ObjectPropertyRange(:hasParent :Person)\n\
+    ObjectPropertyAssertion(:hasParent :alice :bob)\n\
+)\n"
+        ));
+        let internal = convert_ontology(&onto).expect("convert");
+        let r = realize_via_saturation_internal(&internal).expect("realize");
+        let alice: HashSet<&str> = r
+            .entailed_types("http://rustdl.test/alice")
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let bob: HashSet<&str> = r
+            .entailed_types("http://rustdl.test/bob")
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert!(
+            alice.contains("http://rustdl.test/Parent"),
+            "domain type missed on subject; got {alice:?}",
+        );
+        assert!(
+            bob.contains("http://rustdl.test/Person"),
+            "range type missed on object; got {bob:?}",
+        );
+    }
+
+    /// Correctness gate: on a fixture where BOTH paths terminate (no
+    /// defined-class `∃` to explode the tableau), the saturation fast path
+    /// must produce byte-identical entailed types to the sound+complete
+    /// tableau path. Exercises conjunction, subsumption chain, domain and
+    /// range across three individuals. Calls the two internals directly to
+    /// avoid a global-env race with the parallel test runner.
+    #[test]
+    fn fast_path_matches_tableau_on_terminating_fixture() {
+        let onto = parse(&format!(
+            "{HEADER}\
+Ontology(<http://rustdl.test/test>\n\
+    Declaration(Class(:D1)) Declaration(Class(:D2)) Declaration(Class(:E)) Declaration(Class(:F))\n\
+    Declaration(Class(:Parent)) Declaration(Class(:Person))\n\
+    Declaration(ObjectProperty(:hasParent))\n\
+    Declaration(NamedIndividual(:x)) Declaration(NamedIndividual(:alice))\n\
+    Declaration(NamedIndividual(:bob))\n\
+    SubClassOf(ObjectIntersectionOf(:D1 :D2) :E)\n\
+    SubClassOf(:E :F)\n\
+    ObjectPropertyDomain(:hasParent :Parent)\n\
+    ObjectPropertyRange(:hasParent :Person)\n\
+    ClassAssertion(:D1 :x)\n\
+    ClassAssertion(:D2 :x)\n\
+    ObjectPropertyAssertion(:hasParent :alice :bob)\n\
+)\n"
+        ));
+        let internal = convert_ontology(&onto).expect("convert");
+        assert!(
+            realize_saturation_eligible(&internal),
+            "fixture must be fast-path eligible for this A/B to be meaningful",
+        );
+        let fast = realize_via_saturation_internal(&internal).expect("fast");
+        let slow = realize_tableau_internal(&internal).expect("tableau");
+        for ind in ["x", "alice", "bob"] {
+            let iri = format!("http://rustdl.test/{ind}");
+            let f: HashSet<&str> = fast
+                .entailed_types(&iri)
+                .iter()
+                .map(String::as_str)
+                .collect();
+            let s: HashSet<&str> = slow
+                .entailed_types(&iri)
+                .iter()
+                .map(String::as_str)
+                .collect();
+            assert_eq!(
+                f, s,
+                "entailed types differ for {ind}: fast={f:?} tableau={s:?}"
+            );
+        }
+    }
+
+    /// Issue #35 regression (single-query path): `is_instance_of` must
+    /// TERMINATE on the reproducer and answer `no` for `a:Male` (a is not
+    /// entailed to be Male).
+    #[test]
+    fn is_instance_of_terminates_on_issue35_reproducer() {
+        let onto = parse(&format!(
+            "{HEADER}\
+Ontology(<http://rustdl.test/test>\n\
+    Declaration(Class(:Person)) Declaration(Class(:Man)) Declaration(Class(:Woman))\n\
+    Declaration(Class(:Male)) Declaration(Class(:Female))\n\
+    Declaration(ObjectProperty(:hasSex)) Declaration(ObjectProperty(:hasParent))\n\
+    Declaration(ObjectProperty(:isMotherOf))\n\
+    Declaration(NamedIndividual(:a)) Declaration(NamedIndividual(:b))\n\
+    EquivalentClasses(:Man ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Male)))\n\
+    EquivalentClasses(:Woman ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Female)))\n\
+    ObjectPropertyDomain(:hasParent :Person)\n\
+    ObjectPropertyAssertion(:isMotherOf :a :b)\n\
+)\n"
+        ));
+        assert!(
+            !is_instance_of(&onto, "http://rustdl.test/Male", "http://rustdl.test/a")
+                .expect("verdict terminates")
+        );
+    }
+
+    /// Issue #35 regression: `realize` must TERMINATE on the 4-axiom
+    /// reproducer (previously a >300s hang via the exploding tableau).
+    /// Neither individual has any entailed named type.
+    #[test]
+    fn realize_terminates_on_issue35_reproducer() {
+        let onto = parse(&format!(
+            "{HEADER}\
+Ontology(<http://rustdl.test/test>\n\
+    Declaration(Class(:Person)) Declaration(Class(:Man)) Declaration(Class(:Woman))\n\
+    Declaration(Class(:Male)) Declaration(Class(:Female))\n\
+    Declaration(ObjectProperty(:hasSex)) Declaration(ObjectProperty(:hasParent))\n\
+    Declaration(ObjectProperty(:isMotherOf))\n\
+    Declaration(NamedIndividual(:a)) Declaration(NamedIndividual(:b))\n\
+    EquivalentClasses(:Man ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Male)))\n\
+    EquivalentClasses(:Woman ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Female)))\n\
+    ObjectPropertyDomain(:hasParent :Person)\n\
+    ObjectPropertyAssertion(:isMotherOf :a :b)\n\
+)\n"
+        ));
+        let r = realize(&onto).expect("realization terminates");
+        assert!(r.entailed_types("http://rustdl.test/a").is_empty());
+        assert!(r.entailed_types("http://rustdl.test/b").is_empty());
     }
 }

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -148,6 +148,115 @@ pub fn saturate_with_exists_facts(
     (engine.subsumers, facts, nom)
 }
 
+/// Realization-oriented saturation.
+///
+/// Materializes **every named individual** `a` as an opaque nominal class
+/// `N_a` (via `introduce_nominal`) and seeds its `ABox` constraints:
+///
+/// - `N_a ⊑ C` for each `ClassAssertion(C, a)` (atomic operands of `C`),
+/// - `N_a ⊑ ∃r.N_b` for each `ObjectPropertyAssertion(r, a, b)` — a **ground**
+///   edge. This gives `Domain(r)` on `a` for free (fact-time domain propagation
+///   walks the super-role closure) and lets existential-LHS GCIs fire (e.g.
+///   `Person ⊓ ∃hasSex.Male ⊑ Man` with `Male(b)` ⟹ `a:Man`),
+/// - `N_b ⊑ Rng` for each such edge and each effective `Range(r)`. The saturator
+///   deliberately omits range propagation through `∃`-facts (unsound for
+///   *anonymous* witnesses — a `B` that is nobody's successor escapes the range
+///   obligation), but for a **ground** nominal successor `b` the obligation
+///   genuinely holds, so we seed it explicitly.
+///
+/// Runs to fixpoint and returns the subsumer closure plus the `individual → N_a`
+/// map. The entailed named types of `a` are then
+/// `subsumers_of(N_a) ∩ named-user-classes`.
+///
+/// **Sound by construction on any input** (every seeded axiom is entailed).
+/// **Complete == the tableau only on the saturator-complete EL/Horn fragment**
+/// (the fragment `classify` trusts) with `ABox` axioms restricted to atomic/⊓
+/// `ClassAssertion` + non-inverse `ObjectPropertyAssertion`; callers must gate
+/// accordingly. Off that fragment the saturator is incomplete (`∀`, `≤n`,
+/// disjunction, inverse-role *use*, `SameIndividual`, …).
+#[must_use]
+pub fn saturate_for_realize(
+    internal: &InternalOntology,
+) -> (Subsumers, HashMap<IndividualId, ClassId>) {
+    let n = internal.vocabulary.num_classes();
+    let role_super_map = build_role_super(internal);
+    let (mut rules, mut tseitin, _old_total, _trace) =
+        collect_el_rules_with_provenance(internal, &role_super_map, false);
+
+    // Effective (super-role-closed) ranges: `Range(s)` applies to every `r ⊑ s`,
+    // because an `r`-successor is also an `s`-successor.
+    let mut effective_ranges: HashMap<RoleId, Vec<ClassId>> = HashMap::new();
+    for (&r, supers) in &role_super_map {
+        let mut union: Vec<ClassId> = supers
+            .iter()
+            .flat_map(|s| rules.role_ranges.get(s).into_iter().flatten().copied())
+            .collect();
+        union.sort_unstable_by_key(|c| c.index());
+        union.dedup();
+        if !union.is_empty() {
+            effective_ranges.insert(r, union);
+        }
+    }
+
+    // Materialize a nominal class for every named individual (so the
+    // ClassAssertion/edge seeding below reaches all of them, not just any
+    // TBox-nominal fillers already introduced during `collect_el_rules`).
+    let num_individuals = internal.vocabulary.num_individuals();
+    for i in 0..num_individuals {
+        tseitin.introduce_nominal(IndividualId::new(u32::try_from(i).expect("fits u32")));
+    }
+
+    for ax in &internal.axioms {
+        match ax {
+            Axiom::ClassAssertion { class, individual } => {
+                let nom = tseitin.introduce_nominal(*individual);
+                for sup in atomic_operands_on_right(*class, &internal.concepts) {
+                    rules
+                        .atomic_subsumptions
+                        .push(AtomicSubsumption { sub: nom, sup });
+                }
+            }
+            Axiom::ObjectPropertyAssertion {
+                role,
+                subject,
+                object,
+            } if !role.is_inverse() => {
+                let n_a = tseitin.introduce_nominal(*subject);
+                let n_b = tseitin.introduce_nominal(*object);
+                rules.existential_facts.push(ExistentialFact {
+                    sub: n_a,
+                    role: role.role_id(),
+                    target: n_b,
+                });
+                if let Some(ranges) = effective_ranges.get(&role.role_id()) {
+                    for &rng in ranges {
+                        rules
+                            .atomic_subsumptions
+                            .push(AtomicSubsumption { sub: n_b, sup: rng });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let nominal_by_ind = tseitin.nominal_by_ind.clone();
+    let num_total_classes = tseitin.next_id as usize;
+    let role_super = freeze_role_super(&role_super_map);
+    let mut engine = WorklistEngine::new(
+        n,
+        num_total_classes,
+        rules,
+        tseitin,
+        role_super,
+        false,
+        None,
+    );
+    engine.seed(internal);
+    engine.run();
+    (engine.subsumers, nominal_by_ind)
+}
+
 /// Like [`saturate`] but also supports optional proof recording.
 ///
 /// Returns `(Subsumers, Some(ProofTrace))` when `cfg.record_proofs` is `true`,

--- a/docs/2026-07-21-realize-saturation-fast-path.md
+++ b/docs/2026-07-21-realize-saturation-fast-path.md
@@ -1,0 +1,94 @@
+# Realize saturation fast path — fixes the issue-#35 realization hang (2026-07-21)
+
+## Symptom
+
+`materialize_inferred_class_assertions` / CLI `realize` (and `instance` /
+`instances`) **did not terminate** (>300 s) on a tiny satisfiable 4-axiom
+ontology, while `classify` and `materialize_inferred_property_assertions` on the
+same file returned instantly (GitHub issue #35). Minimal reproducer:
+
+```
+EquivalentClasses(:Man   ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Male)))
+EquivalentClasses(:Woman ObjectIntersectionOf(:Person ObjectSomeValuesFrom(:hasSex :Female)))
+ObjectPropertyDomain(:hasParent :Person)
+ObjectPropertyAssertion(:isMotherOf :a :b)
+```
+
+## Root cause
+
+`realize_internal` ran the full SROIQ tableau (`prepared.decide`, the
+`{a} ⊓ ¬C` probe) for **every** (individual, satisfiable-class) pair. On this
+EL/Horn ontology the two non-absorbable GCIs from the `≡` definitions
+(`Person ⊓ ∃hasSex.Male ⊑ Man`, likewise `Woman`) let every node speculatively
+pick `Man`/`Woman` → generate a `∃hasSex` successor → recurse. Blocking capped
+the live graph at ~134 nodes but the ⊔-backtracking search burned 100 000+
+branches and never finished. **Every** `{x} ⊓ ¬C` probe diverged (even
+`¬Male`, no existentials) — the blow-up is model construction, not the query.
+
+`classify` never hits this: it dispatches EL/Horn ontologies to the saturation
+fast path (`is_pure_el` / `saturator_complete_fragment` / Lever-1
+`tbox_only_saturator_eligible`) and never builds a tableau. `realize` had **no
+such gate**.
+
+## Fix (Tier B: nominal-materialization saturation, complete on the fragment)
+
+Two independent, default-ON parts.
+
+### 1. Fast path — `owl_dl_saturation::saturate_for_realize`
+
+Materializes **every named individual** `a` as an opaque nominal class `N_a`
+(reusing the existing `introduce_nominal`) and seeds its ABox constraints into
+the EL saturator:
+
+- `N_a ⊑ C` for each `ClassAssertion(C, a)` (atomic operands of `C`);
+- `N_a ⊑ ∃r.N_b` for each `ObjectPropertyAssertion(r, a, b)` — a **ground**
+  edge. Gives `Domain(r)` on `a` for free (fact-time domain propagation walks
+  the super-role closure) and lets existential-LHS GCIs fire
+  (`Person ⊓ ∃hasSex.Male ⊑ Man` with `Male(b)` ⟹ `a:Man`);
+- `N_b ⊑ Rng` for each such edge and each effective `Range(r)`. The saturator
+  deliberately omits range propagation through `∃`-facts (unsound for
+  *anonymous* witnesses), but for a **ground** nominal successor `b` the range
+  obligation genuinely holds, so it is seeded explicitly.
+
+Runs to fixpoint; entailed named types of `a` = `subsumers_of(N_a)` restricted
+to declared user classes and satisfiable classes. **Complete == the tableau**
+on the saturator-complete EL/Horn fragment — including the conjunctive-LHS case
+`x:D1, x:D2, D1 ⊓ D2 ⊑ E ⊨ x:E` that the old closure-only
+`realize_saturation_only` (and `abox_saturation`) both drop. **Sound by
+construction** (every seeded axiom is entailed).
+
+`realize` / `is_instance_of` / `instances_of` take this path when
+`realize_saturation_eligible` holds: the **TBox** is in the saturator-complete
+fragment **and** every ABox axiom is a shape the seeding captures exactly
+(atomic/⊓ `ClassAssertion`, non-inverse `ObjectPropertyAssertion`;
+`NegativeObjectPropertyAssertion` / `DifferentIndividuals` are type-irrelevant
+and allowed; `SameIndividual` and inverse-role assertions fall back). Unlike
+`classify`, realize **cannot** admit arbitrary ABox shapes — the ABox is
+load-bearing for individual types. `RUSTDL_REALIZE_SATURATION=0` forces the
+tableau path (A/B isolation).
+
+### 2. Off-fragment backstop — per-pair tableau deadline
+
+`RUSTDL_REALIZE_PAIR_TIMEOUT_MS` (default UNSET ⟹ no bound, verdict-preserving)
+bounds each `{a} ⊓ ¬C` probe on the off-fragment tableau path; a deadline hit
+yields "not an instance" — a sound under-approximation. Restores the
+caller-side bound removed in 0.3.18 so a genuinely-hard SROIQ *pair* can no
+longer hang unbounded. (It bounds each pair, not the total wall of a large
+individual×class product — off-fragment ABox-heavy inputs like `wine` remain
+slow, as before.)
+
+## Result
+
+- Issue-#35 reproducer: `realize` / `instance` / `instances` terminate
+  instantly with correct answers (`a`, `b` have no entailed named type).
+- FP=0 preserved; fast path complete == tableau on the fragment (byte-identical
+  A/B on a terminating fixture).
+- `classify` untouched; off-fragment realize is the identical prior logic plus
+  the optional deadline.
+
+## Tests
+
+`crates/owl-dl-reasoner/src/realize.rs` (unit): conjunctive-LHS, existential-LHS
+(family shape), domain+range, issue-#35 termination (realize + is_instance_of),
+and `fast_path_matches_tableau_on_terminating_fixture` (fast-path == tableau
+byte-identity).


### PR DESCRIPTION
## Summary

Fixes #35 — `materialize_inferred_class_assertions` / `realize` (and `instance` / `instances`) hung (>300s) on a tiny satisfiable EL/Horn ontology while `classify` and `materialize_inferred_property_assertions` on the same file returned instantly.

> **Note on base branch:** this branch was cut from a local `feat/render-manchester` line that is ahead of `origin/main` and not yet pushed, so this PR against `main` shows that lineage too. The realize fix itself is the single commit `fix(realize): saturation fast path …` (4 files: `crates/owl-dl-saturation/src/lib.rs`, `crates/owl-dl-reasoner/src/realize.rs`, `CLAUDE.md`, `docs/2026-07-21-realize-saturation-fast-path.md`).

## Root cause

`realize` ran the full SROIQ tableau (`{a} ⊓ ¬C` probe) for **every** (individual, class) pair. On the reproducer the two non-absorbable GCIs from the `≡` definitions (`Person ⊓ ∃hasSex.Male ⊑ Man`, likewise `Woman`) let every node speculatively pick the defined class → generate a `∃hasSex` successor → recurse. Blocking capped the live graph at ~134 nodes, but the ⊔-backtracking search burned 100k+ branches and never terminated — every probe diverged, even `¬Male` (no existentials), so it's model construction that explodes, not the query. `classify` sidesteps this via its saturation fast path; `realize` had no such gate.

## Fix (Tier B + deadline, default ON)

- **`owl_dl_saturation::saturate_for_realize`** — materializes each named individual as a nominal class `N_a` and seeds `N_a ⊑ C` (ClassAssertion), `N_a ⊑ ∃r.N_b` (ground edge ⇒ domain + existential-LHS firing), `N_b ⊑ Rng` (ground range); `types(a) = subsumers_of(N_a) ∩ named classes`. **Complete == the tableau** on the saturator-complete EL/Horn fragment — incl. the conjunctive-LHS case `x:D1, x:D2, D1 ⊓ D2 ⊑ E ⊨ x:E` both saturation engines otherwise drop — **sound by construction**, and terminating (no tableau).
- **`realize_saturation_eligible`** gates `realize` / `is_instance_of` / `instances_of` onto the fast path — stricter than classify (the ABox is load-bearing for types): TBox in the saturator-complete fragment **and** every ABox axiom a shape the seeding captures (atomic/⊓ `ClassAssertion`, non-inverse `ObjectPropertyAssertion`; `SameIndividual` / inverse fall back).
- Off-fragment keeps the identical tableau path plus an opt-in per-pair deadline `RUSTDL_REALIZE_PAIR_TIMEOUT_MS` (default unset ⇒ no bound; restores the caller-side bound removed in 0.3.18). `RUSTDL_REALIZE_SATURATION=0` reverts to the tableau path.

## Result

Reproducer: `realize` / `instance` / `instances` terminate in <1s with the correct answer (`a`, `b` have no entailed named type). The Python `materialize_inferred_class_assertions` (which calls `realize`) is fixed. For a family KG that asserts types + sex, realize now also derives `a : Man` (existential-LHS) instantly.

## Tests / checks

`owl-dl-reasoner` `realize::tests`: conjunctive-LHS, existential-LHS (family shape), domain+range, issue-#35 termination (realize + is_instance_of), and `fast_path_matches_tableau_on_terminating_fixture` (fast-path == tableau byte-identity). Full reasoner/saturation/core/cli suites pass; clippy `-D warnings` + fmt clean. `classify` untouched.

See `docs/2026-07-21-realize-saturation-fast-path.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
