### PR TITLE
DisjointUnion covering direction in the wedge clausifier (#40)

### DIFF
--- a/crates/owl-dl-core/src/clause.rs
+++ b/crates/owl-dl-core/src/clause.rs
@@ -273,14 +273,10 @@ impl Clausifier {
                 }
             }
             Axiom::DisjointUnion { class, members } => {
-                // class ≡ ⊔members, plus pairwise disjoint members.
-                let cls_concept_eq = members; // handled below via gci on the union
-                let _ = cls_concept_eq;
-                // class ⊑ ⊔members and each member ⊑ class:
-                // approximate via the union concept if present is
-                // complex; defer the equivalence half, emit the
-                // pairwise disjointness which is the load-bearing
-                // part for unsat detection.
+                // class ≡ ⊔members: pairwise disjoint members, each
+                // member ⊑ class (Horn), and the covering half
+                // class ⊑ ⊔members (a genuine disjunctive-head
+                // clause — see the design doc for #40).
                 for i in 0..members.len() {
                     for j in (i + 1)..members.len() {
                         self.next_var = X + 1;
@@ -314,6 +310,35 @@ impl Clausifier {
                     } else {
                         self.defer("disjoint-union-member");
                     }
+                }
+                // class ⊑ ⊔members (the previously-deferred covering
+                // half): C(X) → D1(X) ∨ … ∨ Dn(X). Sound — a genuine
+                // DisjointUnion entailment, so it can only add true
+                // subsumptions, never an FP.
+                self.next_var = X + 1;
+                let mut head = Vec::with_capacity(members.len());
+                let mut all_atomic = true;
+                for &m in members {
+                    if let Some(cid) = self.class_id_of(m) {
+                        head.push(Atom::Class(cid, X));
+                    } else {
+                        // Complex member: sound under-approximation —
+                        // defer the covering clause rather than emit
+                        // it with a missing disjunct (which would be
+                        // an unsound *narrower* union).
+                        all_atomic = false;
+                        break;
+                    }
+                }
+                if all_atomic {
+                    // Empty members ⇒ head == [] ⇒ `C ⊑ ⊥` (empty
+                    // union), matching the ⊥-clause convention.
+                    self.clauses.push(DlClause {
+                        body: vec![Atom::Class(*class, X)],
+                        head,
+                    });
+                } else {
+                    self.defer("disjoint-union-covering");
                 }
             }
             Axiom::ObjectPropertyDomain { role, domain } => {

--- a/crates/owl-dl-reasoner/tests/disjoint_union_covering.rs
+++ b/crates/owl-dl-reasoner/tests/disjoint_union_covering.rs
@@ -1,0 +1,154 @@
+//! Canaries for issue #40: the wedge clausifier's `Axiom::DisjointUnion` arm
+//! emitted pairwise disjointness + `member ⊑ class` (Horn) but explicitly
+//! DEFERRED the covering half `class ⊑ ⊔members`. `classify()` (which the
+//! Protégé plugin's class hierarchy uses) routes through the wedge, so it
+//! MISSED covering-dependent subsumptions that the direct tableau
+//! (`is_subclass_of`/`explain`) already derived. See
+//! `docs/superpowers/specs/2026-07-25-disjointunion-wedge-covering-design.md`.
+//!
+//! NOTE on the main canary's fixture: `classify()`'s default top-down
+//! tier-walk has a pre-existing, orthogonal "same-tier siblings" blind spot
+//! — two classes placed in the same closure-subsumer-count tier never test
+//! each other directly (see `find_direct_parents_top_down` /
+//! `classify.rs`'s tier-grouping comment). In the *minimal* `DisjointUnion`
+//! fixture (`C`, `D1`, `D2`, `E` with no other axioms), `C` and `E` land in
+//! the same tier (both have a told-subsumer count of 1: themselves), so the
+//! walk never probes the `(C, E)` pair at all — independent of whether the
+//! covering clause is emitted. `classify_n2` (full `n²` pairwise) and
+//! `is_subclass_of` (direct tableau) both already confirm the fix is
+//! correct at the engine level regardless of this. To exercise the fix
+//! through the *default* `classify()` entry point specifically (as the task
+//! requires), the canary below adds one inert axiom (`SubClassOf(:C :Q)`)
+//! that bumps `C`'s subsumer count so it lands in a *later* tier than `E` —
+//! at which point the walk's frontier includes `E` (already placed
+//! top-level) and the pair is genuinely probed. Confirmed empirically: this
+//! fixture reproduces the RED (classify default: C⊑E = false pre-fix) and
+//! GREEN (true post-fix) via `RUSTDL_DEBUG_TIERS=1` tier tracing (temporary,
+//! not shipped).
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify;
+
+fn load(src: &str) -> SetOntology<RcStr> {
+    let mut cur = std::io::Cursor::new(src.to_string());
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut cur, ParserConfiguration::default()).expect("parse OFN");
+    onto
+}
+
+const HEADER: &str = "Prefix(:=<http://ex/#>)\n\
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n";
+
+/// RED→GREEN: `DisjointUnion(:C :D1 :D2)` + `D1 ⊑ E` + `D2 ⊑ E` entails
+/// `C ⊑ E` (since `C ⊑ D1⊔D2 ⊑ E` via the covering direction). Before the
+/// fix, `classify()` misses this — the wedge clausifier deferred the
+/// covering clause `C(X) → D1(X) ∨ D2(X)`. `SubClassOf(:C :Q)` is an inert
+/// axiom (see the module doc) that shifts `C` into a tier processed after
+/// `E`, so the default top-down walk actually probes the `(C, E)` pair
+/// instead of hitting the unrelated same-tier blind spot.
+#[test]
+fn disjoint_union_covering_entails_superclass_subsumption() {
+    let src = format!(
+        "{HEADER}Ontology(\n\
+Declaration(Class(:C))\nDeclaration(Class(:D1))\nDeclaration(Class(:D2))\n\
+Declaration(Class(:E))\nDeclaration(Class(:Q))\n\
+DisjointUnion(:C :D1 :D2)\n\
+SubClassOf(:D1 :E)\nSubClassOf(:D2 :E)\nSubClassOf(:C :Q)\n)\n"
+    );
+    let onto = load(&src);
+    let c = classify(&onto).expect("classify");
+    assert!(
+        c.is_subclass("http://ex/#C", "http://ex/#E"),
+        "expected C ⊑ E via the DisjointUnion covering direction \
+         (C ⊑ D1⊔D2 ⊑ E)"
+    );
+}
+
+/// The literal minimal fixture from the design doc (no tier-shifting
+/// filler): confirms the fix is correct at the ENGINE level via
+/// `classify_n2` (full pairwise) and `is_subclass_of` (direct tableau),
+/// decoupled from the default `classify()` top-down walk's unrelated
+/// same-tier blind spot documented above.
+#[test]
+fn disjoint_union_covering_entails_superclass_subsumption_engine_level() {
+    let src = format!(
+        "{HEADER}Ontology(\n\
+Declaration(Class(:C))\nDeclaration(Class(:D1))\nDeclaration(Class(:D2))\n\
+Declaration(Class(:E))\n\
+DisjointUnion(:C :D1 :D2)\n\
+SubClassOf(:D1 :E)\nSubClassOf(:D2 :E)\n)\n"
+    );
+    let onto = load(&src);
+    let c_n2 = owl_dl_reasoner::classify_n2(&onto).expect("classify_n2");
+    assert!(
+        c_n2.is_subclass("http://ex/#C", "http://ex/#E"),
+        "expected C ⊑ E via classify_n2 (full pairwise)"
+    );
+    let direct = owl_dl_reasoner::is_subclass_of(&onto, "http://ex/#C", "http://ex/#E")
+        .expect("is_subclass_of");
+    assert!(direct, "expected C ⊑ E via the direct tableau probe");
+}
+
+/// Regression (a): a covering-dependent UNSAT case. `DisjointUnion(:C :D1
+/// :D2)` + `D1 ⊑ ⊥` + `D2 ⊑ ⊥` ⟹ `C` is unsatisfiable (C ⊑ D1⊔D2 ⊑ ⊥⊔⊥ = ⊥).
+#[test]
+fn disjoint_union_covering_empty_members_makes_class_unsatisfiable() {
+    let src = format!(
+        "{HEADER}Ontology(\n\
+Declaration(Class(:C))\nDeclaration(Class(:D1))\nDeclaration(Class(:D2))\n\
+DisjointUnion(:C :D1 :D2)\n\
+SubClassOf(:D1 owl:Nothing)\nSubClassOf(:D2 owl:Nothing)\n)\n"
+    );
+    let onto = load(&src);
+    let c = classify(&onto).expect("classify");
+    assert!(
+        c.unsatisfiable_classes().contains(&"http://ex/#C"),
+        "expected C unsatisfiable (D1 and D2 both empty ⟹ their union is \
+         empty, and C is covered by that union); unsatisfiable classes: {:?}",
+        c.unsatisfiable_classes()
+    );
+}
+
+/// Regression (b): retain the pairwise-disjoint half — a class forced into
+/// `D1 ⊓ D2` is unsatisfiable regardless of the covering fix.
+#[test]
+fn disjoint_union_pairwise_disjoint_still_fires() {
+    let src = format!(
+        "{HEADER}Ontology(\n\
+Declaration(Class(:C))\nDeclaration(Class(:D1))\nDeclaration(Class(:D2))\n\
+Declaration(Class(:G))\n\
+DisjointUnion(:C :D1 :D2)\n\
+SubClassOf(:G ObjectIntersectionOf(:D1 :D2))\n)\n"
+    );
+    let onto = load(&src);
+    let c = classify(&onto).expect("classify");
+    assert!(
+        c.unsatisfiable_classes().contains(&"http://ex/#G"),
+        "expected G unsatisfiable (G ⊑ D1 ⊓ D2, and D1/D2 are pairwise \
+         disjoint members of the DisjointUnion); unsatisfiable classes: {:?}",
+        c.unsatisfiable_classes()
+    );
+}
+
+/// Regression (c): a `DisjointUnion` with a non-atomic member (an
+/// `ObjectSomeValuesFrom`) must classify without panicking — `class_id_of`
+/// returns `None` for it, so the covering clause is soundly deferred rather
+/// than emitted with a bogus atom.
+#[test]
+fn disjoint_union_complex_member_defers_without_panic() {
+    let src = format!(
+        "{HEADER}Ontology(\n\
+Declaration(Class(:C))\nDeclaration(Class(:D1))\nDeclaration(Class(:F))\n\
+Declaration(ObjectProperty(:r))\n\
+DisjointUnion(:C :D1 ObjectSomeValuesFrom(:r :F))\n)\n"
+    );
+    let onto = load(&src);
+    let c = classify(&onto).expect("classify should not panic on a complex DisjointUnion member");
+    // No specific entailment asserted here — just soundness (no panic) and
+    // that classify still produces a usable result.
+    assert!(!c.classes().is_empty());
+}

--- a/docs/superpowers/specs/2026-07-25-disjointunion-wedge-covering-design.md
+++ b/docs/superpowers/specs/2026-07-25-disjointunion-wedge-covering-design.md
@@ -1,0 +1,106 @@
+# Design + plan: DisjointUnion covering direction in the wedge clausifier (#40)
+
+**Date:** 2026-07-25
+**Status:** design confirmed (empirical gap reproduced); ready to implement.
+**Author:** Claude + Michel.
+**Issue:** #40 (partial). Most of #40 was already implemented before the issue was
+filed (2026-07-24): `convert.rs:1824` produces `Axiom::DisjointUnion` (not dropped),
+and `absorb.rs` fully handles it (covering `C ≡ ⊔members` + pairwise disjoint) for
+the tableau. The **only** residual is in the **wedge clausifier** (`clause.rs`).
+
+## The confirmed gap
+
+The `clause.rs` `Axiom::DisjointUnion` arm emits the pairwise disjointness **and**
+`member ⊑ class` (Horn), but **explicitly defers** the covering half
+`class ⊑ ⊔members`. Empirically reproduced (default config):
+
+Fixture: `DisjointUnion(C, D1, D2)` + `SubClassOf(D1, E)` + `SubClassOf(D2, E)`.
+Expected entailment: `C ⊑ E` (since `C ⊑ D1⊔D2 ⊑ E`).
+
+| Path | `C ⊑ E` |
+|------|---------|
+| `classify` (default, trust_sat ON) | **MISSED** |
+| `classify` (trust_sat OFF) | **MISSED** (Phase-7 label heuristic prunes the candidate — the wedge's covering-deferred model of `C` doesn't include `E`) |
+| `is_subclass_of` / `explain` (direct tableau) | ✅ derived |
+
+So `classify` — which the Protégé plugin's class hierarchy uses — misses covering-
+dependent subsumptions, while the direct subclass query already gets them. `Dᵢ ⊑ C`
+is not the gap (told tables + the arm's own `member ⊑ class` supply it); only
+`C ⊑ ⊔Dᵢ` is missing.
+
+## The fix (surgical, no pool mutation)
+
+In the `clause.rs` `Axiom::DisjointUnion` arm, additionally emit the covering
+clause `C(X) → D1(X) ∨ … ∨ Dn(X)`:
+
+```rust
+// class ⊑ ⊔members : C(X) → D1(X) ∨ … ∨ Dn(X)  (the previously-deferred covering half)
+let mut head = Vec::with_capacity(members.len());
+let mut all_atomic = true;
+for &m in members {
+    match self.class_id_of(m) {
+        Some(cid) => head.push(Atom::Class(cid, X)),
+        None => { all_atomic = false; break; }   // complex member ⇒ defer (sound under-approx)
+    }
+}
+if all_atomic {
+    // empty members ⇒ head == [] ⇒ `C ⊑ ⊥` (empty union), matching the ⊥-clause convention.
+    self.clauses.push(DlClause { body: vec![Atom::Class(*class, X)], head });
+} else {
+    self.defer("disjoint-union-covering");
+}
+```
+
+Set `self.next_var = X + 1;` before, consistent with the arm's other blocks. Replace
+the stale "defer the equivalence half" comment. `class` is a `ClassId` (atomic body);
+`members` are `ConceptId`s — `class_id_of` yields the atomic/nominal `ClassId` or
+`None` for a compound member (deferred, as the arm already defers complex antecedents).
+
+**Soundness:** the covering GCI is the genuine DisjointUnion semantics — an entailed
+axiom, so it can only *add* true subsumptions, never an FP. The head disjunction is a
+standard non-Horn clause the hypertableau already branches on. Risk is limited to
+perturbing wedge clausification for DisjointUnion-bearing ontologies → gated by a
+**corpus FP=0 closure-diff**.
+
+## Plan (single task, TDD, subagent-driven with review)
+
+### Task 1: emit the covering clause + canaries
+**Files:**
+- Modify: `crates/owl-dl-core/src/clause.rs` (the `Axiom::DisjointUnion` arm, ~line 275).
+- Test: `crates/owl-dl-core/src/clause.rs` `#[cfg(test)]` and/or a reasoner-level
+  integration test in `crates/owl-dl-reasoner/tests/` (classify-level, the level the
+  gap manifests at).
+
+- [ ] **Step 1 — RED (classify-level canary):** add a test that classifies
+  `DisjointUnion(C, D1, D2)` + `D1 ⊑ E` + `D2 ⊑ E` and asserts `C ⊑ E` is entailed
+  (`is_subclass(C, E)` on the `Classification`, or the direct-subsumption closure).
+  Run; confirm it FAILS today (`C ⊑ E` missing).
+- [ ] **Step 2 — GREEN:** apply the covering-clause emission above. Run; canary passes.
+- [ ] **Step 3 — regression canaries:** (a) a covering-dependent **unsat** case —
+  `DisjointUnion(C, D1, D2)` + `D1 ⊑ ⊥` + `D2 ⊑ ⊥` ⇒ `C ⊑ ⊥` (C unsatisfiable);
+  (b) retain a **pairwise-disjoint** case — `DisjointUnion(C, D1, D2)` + an individual
+  or class forced into `D1 ⊓ D2` ⇒ unsat, confirming the disjoint half still fires;
+  (c) a **complex-member defer** case (a DisjointUnion with a non-atomic member) still
+  behaves soundly (no panic; covering deferred). Run all; pass.
+- [ ] **Step 4 — FP=0 corpus gate (the soundness gate):** run the closure-diff /
+  classify on the curated fixtures that contain DisjointUnion (e.g. `pizza`, and any
+  in `ontologies/real` — fetch via `scripts/fetch-real-ontologies.sh` if needed) and
+  confirm **no new FP** vs the pre-change baseline (a new subsumption is acceptable
+  ONLY if it is genuinely entailed — verify any delta is a true covering-derived
+  subsumption, not an FP). If a Konclude/HermiT oracle run is easy on the affected
+  fixtures, use it; otherwise closure-diff + manual check of any delta.
+- [ ] **Step 5 — full checks:** `RUSTUP_TOOLCHAIN=stable cargo test -p owl-dl-core -p owl-dl-reasoner`,
+  `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all`.
+- [ ] **Step 6 — commit:** `fix(clause): emit DisjointUnion covering clause in the wedge clausifier (#40)`.
+
+## Global constraints
+- Build/test `RUSTUP_TOOLCHAIN=stable cargo …`. Clippy pedantic `-D warnings`;
+  `unwrap`/`dbg` only under `#[cfg(test)]`; rustfmt max_width=100.
+- **FP=0 is the cardinal gate** (this touches wedge clausification).
+- Isolated worktree `rustdl-wt/expressivity-fills`, branch `feat/expressivity-fills-40-42`
+  (a concurrent agent works elsewhere in the repo — do not leave this worktree).
+
+## Out of scope / #42
+Non-string `DataOneOf` is already implemented; nested composite data ranges and
+general range-size cardinality counting are documented ~0-corpus-value sound
+under-approximations. #42 handled separately (document/close), not here.


### PR DESCRIPTION
## DisjointUnion covering direction in the wedge clausifier

Closes #40. Design: `docs/superpowers/specs/2026-07-25-disjointunion-wedge-covering-design.md`.

### Context — #40 was mostly already implemented

`DisjointUnion` is **not** dropped (the issue's premise was stale by the time it was filed): `convert.rs:1824` produces `Axiom::DisjointUnion`, and `absorb.rs` fully handles it for the tableau — both the covering half (`C ≡ ⊔members`) and pairwise disjointness. The `told` table also supplies `Dᵢ ⊑ C`. The **only** residual was in the **wedge clausifier** (`clause.rs`), which emitted the pairwise-disjoint and `member ⊑ class` clauses but **explicitly deferred the covering half** `C ⊑ ⊔members`.

### The gap (empirically confirmed)

Fixture: `DisjointUnion(C, D1, D2)` + `D1 ⊑ E` + `D2 ⊑ E` ⟹ `C ⊑ E` (via `C ⊑ D1⊔D2 ⊑ E`).

| Path | `C ⊑ E` |
|------|---------|
| `classify` (default) | **MISSED** (wedge covering deferred) |
| `is_subclass_of` / `explain` (direct tableau) | ✅ derived |

Since the Protégé plugin's class hierarchy comes from `classify`, this was a real (if narrow) completeness gap.

### The fix

In the `clause.rs` `DisjointUnion` arm, emit the covering clause `C(X) → D1(X) ∨ … ∨ Dn(X)` when all members are atomic (via `class_id_of`), else `defer` (sound under-approx); empty members ⟹ `C ⊑ ⊥`. Correct polarity verified against `absorb.rs`'s `absorb_sub_sup(class, ⊔members)`. Sound by construction — the covering GCI is genuine DisjointUnion semantics, so it can only add truly-entailed subsumptions, never an FP.

### Validation

- **Canaries** (`crates/owl-dl-reasoner/tests/disjoint_union_covering.rs`): covering-dependent subsumption (RED→GREEN), covering-dependent unsat, retained pairwise-disjoint, complex-member defer.
- **FP=0 closure-diff (pre/post, release binary):** **byte-identical** on every reachable fixture — `pizza`/`sio` (no DisjointUnion, inert), **`sulo` (2 real DisjointUnion axioms)**, and the synthetic `30_disjoint_union_member_sat` bench fixture. Zero new edges anywhere reachable → no FP.
- `cargo test -p owl-dl-core -p owl-dl-reasoner` (0 failures), `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo fmt --all` clean.

### ⚠️ Pre-merge gate (please run on Linux/corpus)

The CLAUDE.md **cardinal full-corpus FP=0 closure-diff** could not run in the authoring sandbox (the `scripts/fetch-real-ontologies.sh` fetch is macOS-incompatible: `stat -c`), and `DisjointUnion` is rare in the reachable curated fixtures — so no covering-*non*-redundant real ontology exercised a new covering-derived edge here. The change is additive and empirically inert on all reachable fixtures, but before merge please run the standard corpus bake-off (galen/notgalen/wine/ore-*/shoiq-knowledge/alehif) pre-vs-post and confirm **FP=0 / any delta genuinely covering-entailed**.

### Orthogonal caveat (not in scope)

Covering-dependent **same-tier** subsumptions still require `RUSTDL_CLASSIFY_SAME_TIER=1` (default OFF) for `classify` to probe the pair — the separate, pre-existing tier-walk limitation (`docs/.../2026-06-19-classify-completeness-sp1.1-design.md`). This fix is necessary-but-not-sufficient for that sub-case; the direct `is_subclass_of` query is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
