### PR TITLE
docs: reflect #40 / #43 / #44–#48 in CLAUDE.md + README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,31 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   flamegraphs. **GALEN classify wall: 24.8 min → 12.2 min (~50%
   reduction)** — this reclaims Phase 2b's full wall regression.
   FP=0 + verdicts unchanged. See `docs/phase3c-results.md`.
+  **DisjointUnion covering in the wedge (2026-07-25, #40).** `clause.rs`'s
+  `DisjointUnion` arm now also emits the covering clause
+  `C(X) → D1(X) ∨ … ∨ Dn(X)` (it previously emitted only the pairwise-disjoint
+  + `member ⊑ class` halves, deferring the covering `C ⊑ ⊔Di`). The tableau
+  (`absorb.rs`) already had it; this closes the wedge/classify gap so
+  covering-dependent subsumptions (`C ⊑ ⊔Di ⊑ E ⟹ C ⊑ E`) are no longer MISSED
+  under default `trust_sat`. Sound (genuine DisjointUnion semantics — only adds
+  entailed subsumptions); byte-identical where no DisjointUnion covering applies.
+  NOTE: covering-dependent **same-tier** subsumptions still need
+  `RUSTDL_CLASSIFY_SAME_TIER=1` (the separate tier-walk limitation). Spec
+  `docs/superpowers/specs/2026-07-25-disjointunion-wedge-covering-design.md`.
+  **Graceful degradation + surfaced drops (2026-07-26, #43).** `convert_ontology`
+  no longer aborts on an unsupported construct: `ce_or_skip!` propagates the
+  error and the conversion loop RECORDS it on `InternalOntology.dropped:
+  DroppedAxioms` (`kind → count`) and continues, reasoning over the supported
+  fragment. `Ok(None)` is now benign-only (metadata / annotations / bare
+  declarations); every unrepresentable CONTENT axiom — unsupported data ranges,
+  `HasKey`, SWRL, and (under `RUSTDL_DATA_PROPERTIES=0`) data-property axioms —
+  returns `Err` → recorded. Surfaced via `owl_dl_reasoner::dropped_axioms(&onto)`,
+  a `dropped` block in `classify`/`consistent`/`realize --json`, a default stderr
+  warning, and Python `dropped_axioms(path)`. Sound under-approximation (weaker
+  KB ⇒ only missed entailments, never a false one); inert when nothing is dropped
+  (empty map ⇒ byte-identical). **`HasKey` and unsupported axioms no longer
+  hard-error** — they degrade. Spec
+  `docs/superpowers/specs/2026-07-25-surface-dropped-axioms-design.md`.
 
 - **`crates/owl-dl-reasoner`** — public API + orchestrator (`lib.rs`,
   `classify.rs`, `realize.rs`). Every entry point that issues a tableau query
@@ -456,6 +481,40 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `rustdl.debug()` returns a `Diagnosis` dataclass (with `Root`/`Derived`/`Inconsistency`) —
   attribute access + `Mapping` dict-compat + `to_dict()`. See
   `docs/superpowers/specs/2026-06-21-python-result-objects-design.md`.
+  **Inferred query surface (2026-07-24/25, issues #44–#48).** The reasoner-API →
+  Python → CLI `--json` surface for the OWLReasoner queries beyond class
+  classification, all sound (FP=0) by reduction to the existing
+  (un)sat/consistency engines (never from a satisfying model), each running the
+  mandatory inconsistent-KB guard first and reporting an `incomplete` signal
+  (trusted-`Sat` / budget):
+  - #47 `disjoint_classes` (entailment: `C ⊓ D` unsat, told-disjoint seed) +
+    `disjoint_{object,data}_properties` (structural told closure). CLI `disjoint --json`.
+  - #44 `classify_{object,data}_property_hierarchy` → `PropertyClassification`
+    (equiv groups + Hasse `direct_subsumptions`, from the told+equiv+inverse
+    property closure). CLI `property-hierarchy --json`.
+  - #46 `same_individuals` (asserted + functional-forced `derived_same` seed +
+    augment-recheck `KB∪{a≠b}` inconsistent) / `different_individuals`
+    (`{a}⊓{b}` unsat). CLI `individuals --json`.
+  - #45 `inferred_{object,data}_property_values` (materialize seed + budgeted
+    entailment extension via a `KB∪{¬R(a,b)}` recheck; data = structural). CLI
+    `property-values --json`.
+  - #48 `class_expression_{satisfiable,entailed_subclass,instances}` — accept an
+    anonymous **Manchester** class expression, reduced by injecting a fresh
+    `EquivalentClasses(Q, CE)` probe and querying the named `Q` (the
+    `justify::entails` probe pattern generalized; front-end parses via horned-owl
+    `parse_class_expression`). CLI `sat-expr`/`subclass-expr`/`instances-expr`.
+  Shared infra: `PreparedOntology` now carries `vocabulary` +
+  `pair_disjoint_with_deadline` / `pair_individuals_disjoint_with_deadline`
+  (`C⊓D` / `{a}⊓{b}` sat probes over the frozen snapshot via `decide`) +
+  `consistent_with_extra` (snapshot-preserving augment-and-recheck: injects one
+  extra distinct-pair / negative-property fact into the per-probe tableau seed,
+  no rebuild). `SaturationResult.derived_same` records functional/inverse-
+  functional-forced equalities. Python query wrappers emit `IncompleteQueryWarning`.
+  HermiT/ROBOT oracle FP=0 gates (`disjoint_classes`, property values; hand-
+  verified for same/different — ROBOT has no such generator; probe-trick oracle
+  for class expressions). Specs
+  `docs/superpowers/specs/2026-07-24-inferred-query-surface-44-47-design.md`,
+  `docs/superpowers/specs/2026-07-25-complex-class-expression-queries-design.md`.
   Phase 4b (commit e31439c) added a `FragmentClassification`
   diagnostic surfaced as `# fragment: …` in the CLI banner and
   `ClassificationStats::fragment` programmatically; it tells users whether

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ rustdl consistent ontology.ofn
 rustdl subclass  ontology.ofn <sub> <sup>
 rustdl instances ontology.ofn <class>
 rustdl realize   ontology.ofn [--properties] # per-individual types (+ inferred object & data property assertions)
+
+# inferred queries (each also available as `--json` and in the Python API):
+rustdl disjoint          ontology.ofn                  # disjoint classes + disjoint object/data properties
+rustdl individuals       ontology.ofn                  # inferred same / different individuals
+rustdl property-hierarchy ontology.ofn                 # inferred object/data property hierarchy
+rustdl property-values   ontology.ofn                  # inferred object/data property values
+rustdl sat-expr          ontology.ofn '<CE>'           # satisfiability of a Manchester class expression
+rustdl subclass-expr     ontology.ofn '<sub>' '<sup>'  # is SubClassOf(ce1, ce2) entailed
+rustdl instances-expr    ontology.ofn '<CE>'           # instances of a Manchester class expression
+
 rustdl justify   ontology.ofn <query…>      # minimal responsible-axiom set (why it holds)
 rustdl justify --laconic ontology.ofn <query…>  # pinpoint the responsible PART of each axiom
 rustdl repair    ontology.ofn <query…>      # minimal axiom removals to break an entailment

--- a/README.md
+++ b/README.md
@@ -53,13 +53,20 @@ with first-class data properties.
   `DataUnionOf` / `DataIntersectionOf` / `DataComplementOf`, and bounded data
   cardinality.
 
-**Sound under-approximation (silently dropped, never an error):** the narrow
-datatype tail outside that recognized set — nested composite ranges (e.g.
-`DataComplementOf(DataUnionOf(…))`), `∀` / range / cardinality *over* a union or
-complement, and lexically-unparseable or cross-datatype literals. Positives
-depending on them may be missed, never falsely asserted.
+**Inferred queries beyond classification** (reasoner API + CLI `--json` + Python):
+object/data **property hierarchy**, **property values**, **same / different
+individuals**, **disjointness**, and complex (anonymous **Manchester**)
+**class-expression** satisfiability / entailment / instances — all sound, each
+reporting an `incomplete` flag.
 
-**Unsupported (errors):** `HasKey`. SWRL rules are skipped (see `convert.rs`).
+**Sound under-approximation (dropped *and reported*, never an error):** any axiom
+the conversion can't represent — the narrow datatype tail (nested composite
+ranges like `DataComplementOf(DataUnionOf(…))`, `∀` / range / cardinality *over* a
+union or complement, unparseable / cross-datatype literals), plus `HasKey`, SWRL
+rules, and other unsupported constructs. Reasoning proceeds over the supported
+fragment; the dropped axioms are surfaced as a count-by-kind diagnostic
+(`dropped_axioms`, a `dropped` block in `--json`, a stderr warning). Positives
+depending on them may be missed, never falsely asserted.
 
 ## Crates
 


### PR DESCRIPTION
## Docs: reflect #40 / #43 / #44–#48 (merged)

Documentation-only follow-up to the recently-merged inferred-query surface (#44–#48), DisjointUnion wedge covering (#40), and graceful degradation (#43). No code changes.

### CLAUDE.md
- **owl-dl-reasoner:** new "Inferred query surface (#44–#48)" block — `disjoint_classes` / `disjoint_{object,data}_properties` (#47), `classify_{object,data}_property_hierarchy` (#44), `same_individuals` / `different_individuals` (#46), `inferred_{object,data}_property_values` (#45), `class_expression_{satisfiable,entailed_subclass,instances}` (#48), the shared infra (`PreparedOntology.vocabulary` + pair-disjoint probes + `consistent_with_extra`, `SaturationResult.derived_same`), the `incomplete` posture, and the oracle FP=0 gates.
- **owl-dl-core:** notes for the DisjointUnion covering clause in `clause.rs` (#40, incl. the same-tier caveat) and graceful degradation in `convert.rs` (#43: `DroppedAxioms`, `Ok(None)`=benign / content→`Err`-recorded, `HasKey`/SWRL no longer hard-error).

### README.md
- **Coverage** — the "silently dropped … / Unsupported (errors): `HasKey`" wording was factually wrong after #43: unsupported constructs are now **dropped *and reported*** (not silent) and **no longer error** (graceful degradation over the supported fragment). Merged/rewrote those two paragraphs.
- Added an **"Inferred queries beyond classification"** paragraph for the #44–#48 surface.

### Not touched (flagged separately)
The **Protégé plugin ▸ Computes (v1)** paragraph still says property hierarchies/values, same/different, disjointness, and complex-class-expression queries "return empty for now." The reasoner/CLI now support all of these via `--json`, but wiring them into the Java plugin is the plugin author's call — left for whoever owns `protege/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
