### PR TITLE
Explanation surface: justifications, laconic & proof trees in Protégé

### DIFF
--- a/crates/owl-dl-cli/src/json_out.rs
+++ b/crates/owl-dl-cli/src/json_out.rs
@@ -3,6 +3,7 @@
 //! determinism; `schema_version` guards drift.
 use std::collections::{BTreeMap, HashMap};
 
+use anyhow::{Result, bail};
 use horned_owl::curie::PrefixMapping;
 use horned_owl::io::ofn::writer::write as write_ofn;
 use horned_owl::model::{
@@ -481,25 +482,34 @@ pub(crate) struct ProofNodeJson {
 /// (mirrors `owl_dl_saturation::proof::render_class_expanded`/
 /// `render_synthetic_def`, but building real model objects instead of a
 /// display string, so the result can be written as OFN).
+///
+/// # Errors
+/// Returns an error if `id` is neither a named-vocabulary class nor has a
+/// `SyntheticDef` record. This should never happen for a proof the saturator
+/// itself produced (every synthetic `ClassId` it can mention is registered in
+/// `synthetic_defs` at construction time), but if a future saturator change
+/// ever broke that invariant, silently fabricating an opaque
+/// `urn:rustdl-synthetic:<idx>` class into user-facing proof JSON would be
+/// far worse than failing loudly — so this fails instead of fabricating.
 fn class_id_to_class_expression(
     id: ClassId,
     vocab: &Vocabulary,
     defs: &HashMap<ClassId, SyntheticDef>,
     build: &Build<RcStr>,
-) -> ClassExpression<RcStr> {
+) -> Result<ClassExpression<RcStr>> {
     let idx = id.index() as usize;
     if idx < vocab.num_classes() {
-        return ClassExpression::Class(build.class(vocab.class_iri(id)));
+        return Ok(ClassExpression::Class(build.class(vocab.class_iri(id))));
     }
     if let Some(def) = defs.get(&id) {
         return synthetic_def_to_class_expression(def, vocab, defs, build);
     }
-    // No user-vocabulary entry and no synthetic-def record. Not expected in
-    // practice (every synthetic `ClassId` the proof trace can mention has a
-    // `synthetic_defs` entry — see `SyntheticDef` construction in
-    // `owl-dl-saturation/src/lib.rs`), but rendered as an opaque marker class
-    // rather than panicking: faithful to the internal id, not fabricated.
-    ClassExpression::Class(build.class(format!("urn:rustdl-synthetic:{idx}")))
+    bail!(
+        "internal error rendering proof JSON: class id {idx} has no vocabulary entry and no \
+         synthetic_defs record (proof-rendering invariant violated — every synthetic ClassId a \
+         saturator proof can mention should be registered in synthetic_defs at construction \
+         time; refusing to fabricate an opaque class into the proof output)"
+    );
 }
 
 fn synthetic_def_to_class_expression(
@@ -507,13 +517,13 @@ fn synthetic_def_to_class_expression(
     vocab: &Vocabulary,
     defs: &HashMap<ClassId, SyntheticDef>,
     build: &Build<RcStr>,
-) -> ClassExpression<RcStr> {
-    match def {
+) -> Result<ClassExpression<RcStr>> {
+    Ok(match def {
         SyntheticDef::TseitinConj(bodies) => {
             let mut parts: Vec<ClassExpression<RcStr>> = bodies
                 .iter()
                 .map(|&b| class_id_to_class_expression(b, vocab, defs, build))
-                .collect();
+                .collect::<Result<Vec<_>>>()?;
             if parts.len() == 1 {
                 parts.remove(0)
             } else {
@@ -523,7 +533,7 @@ fn synthetic_def_to_class_expression(
         SyntheticDef::ExistMarkerOneWay { role, body }
         | SyntheticDef::ExistMarkerEquiv { role, body } => ClassExpression::ObjectSomeValuesFrom {
             ope: role_id_to_ope(*role, vocab, build),
-            bce: Box::new(class_id_to_class_expression(*body, vocab, defs, build)),
+            bce: Box::new(class_id_to_class_expression(*body, vocab, defs, build)?),
         },
         SyntheticDef::NominalKey(ind) => ClassExpression::ObjectOneOf(vec![Individual::Named(
             individual_id_to_named(*ind, vocab, build),
@@ -546,12 +556,16 @@ fn synthetic_def_to_class_expression(
         // Not reached in practice: `DKey` classes are interned as real named
         // vocabulary entries at conversion time (`owl_dl_core::convert`'s
         // `urn:rustdl-dkey:` classes), so they resolve via the `vocab` branch
-        // above, never via `synthetic_defs`. Kept for match exhaustiveness;
-        // rendered as an opaque named class if it ever fires.
+        // above, never via `synthetic_defs`. Kept for match exhaustiveness.
+        // Unlike the fallback in `class_id_to_class_expression`, this arm
+        // renders GENUINE content if it ever fires: `urn:rustdl-dkey:<suffix>`
+        // is the exact IRI convention `owl_dl_core::convert`'s real DKey
+        // vocabulary entries use (Phase D6), not a fabricated marker — so it
+        // is deliberately left as-is rather than hardened into an error.
         SyntheticDef::DKey(iri_suffix) => {
             ClassExpression::Class(build.class(format!("urn:rustdl-dkey:{iri_suffix}")))
         }
-    }
+    })
 }
 
 fn role_id_to_ope(
@@ -581,24 +595,24 @@ fn derived_fact_to_component(
     vocab: &Vocabulary,
     defs: &HashMap<ClassId, SyntheticDef>,
     build: &Build<RcStr>,
-) -> Component<RcStr> {
-    match fact {
+) -> Result<Component<RcStr>> {
+    Ok(match fact {
         owl_dl_reasoner::DerivedFact::Sub(s, p) => Component::SubClassOf(SubClassOf {
-            sub: class_id_to_class_expression(*s, vocab, defs, build),
-            sup: class_id_to_class_expression(*p, vocab, defs, build),
+            sub: class_id_to_class_expression(*s, vocab, defs, build)?,
+            sup: class_id_to_class_expression(*p, vocab, defs, build)?,
         }),
         owl_dl_reasoner::DerivedFact::Exist(s, r, t) => Component::SubClassOf(SubClassOf {
-            sub: class_id_to_class_expression(*s, vocab, defs, build),
+            sub: class_id_to_class_expression(*s, vocab, defs, build)?,
             sup: ClassExpression::ObjectSomeValuesFrom {
                 ope: role_id_to_ope(*r, vocab, build),
-                bce: Box::new(class_id_to_class_expression(*t, vocab, defs, build)),
+                bce: Box::new(class_id_to_class_expression(*t, vocab, defs, build)?),
             },
         }),
         owl_dl_reasoner::DerivedFact::Unsat(c) => Component::SubClassOf(SubClassOf {
-            sub: class_id_to_class_expression(*c, vocab, defs, build),
+            sub: class_id_to_class_expression(*c, vocab, defs, build)?,
             sup: ClassExpression::Class(build.class(OWL_NOTHING)),
         }),
-    }
+    })
 }
 
 /// Recursively build a `ProofNodeJson` from a `ProofNode`: the conclusion
@@ -610,9 +624,9 @@ fn build_proof_node_json(
     defs: &HashMap<ClassId, SyntheticDef>,
     pm: &PrefixMapping,
     build: &Build<RcStr>,
-) -> ProofNodeJson {
+) -> Result<ProofNodeJson> {
     let vocab = &internal.vocabulary;
-    let conclusion_component = derived_fact_to_component(&node.conclusion, vocab, defs, build);
+    let conclusion_component = derived_fact_to_component(&node.conclusion, vocab, defs, build)?;
     let conclusion = axioms_to_ofn_doc(std::slice::from_ref(&conclusion_component), pm);
 
     // `node.axiom_refs` index into `internal.axioms` (the same
@@ -637,30 +651,41 @@ fn build_proof_node_json(
         .premises
         .iter()
         .map(|p| build_proof_node_json(p, internal, defs, pm, build))
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
-    ProofNodeJson {
+    Ok(ProofNodeJson {
         conclusion,
         rule: node.rule.to_string(),
         axioms,
         premises,
-    }
+    })
 }
 
 /// Build the `prove --json` payload. `internal` must be the same ontology
 /// `result` was derived from (re-converted by the caller — see
 /// `prove_entailment_rcstr`'s own internal conversion).
-#[must_use]
+///
+/// # Errors
+/// Returns an error if rendering the proof tree hits the
+/// should-never-happen `ClassId`-resolution invariant violation described on
+/// `class_id_to_class_expression` — propagated here instead of silently
+/// emitting fabricated content, so `prove --json` exits with a real error in
+/// that case.
 pub(crate) fn build_prove_json(
     result: &ProveEntailmentResult,
     internal: &InternalOntology,
     pm: &PrefixMapping,
-) -> ProveJson {
-    match result {
+) -> Result<ProveJson> {
+    Ok(match result {
         ProveEntailmentResult::SaturatorProof(data) => {
             let build: Build<RcStr> = Build::new_rc();
-            let proof =
-                build_proof_node_json(&data.root, internal, &data.trace.synthetic_defs, pm, &build);
+            let proof = build_proof_node_json(
+                &data.root,
+                internal,
+                &data.trace.synthetic_defs,
+                pm,
+                &build,
+            )?;
             ProveJson {
                 schema_version: SCHEMA_VERSION,
                 entailed: true,
@@ -683,7 +708,7 @@ pub(crate) fn build_prove_json(
             proof: None,
             justification_fallback: None,
         },
-    }
+    })
 }
 
 #[cfg(test)]

--- a/crates/owl-dl-cli/src/json_out.rs
+++ b/crates/owl-dl-cli/src/json_out.rs
@@ -1,19 +1,27 @@
 //! Machine-readable JSON output for the CLI (`--json`). The stable bridge
 //! contract consumed by the Protégé plugin. All arrays are sorted for
 //! determinism; `schema_version` guards drift.
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use horned_owl::curie::PrefixMapping;
 use horned_owl::io::ofn::writer::write as write_ofn;
-use horned_owl::model::{Component, MutableOntology, RcStr};
+use horned_owl::model::{
+    Build, ClassExpression, Component, Individual, MutableOntology, NamedIndividual, RcStr,
+    SubClassOf,
+};
 use horned_owl::ontology::component_mapped::RcComponentMappedOntology;
 use horned_owl::ontology::set::SetOntology;
+use owl_dl_core::{ClassId, IndividualId, InternalOntology, RoleId, Vocabulary};
 use owl_dl_reasoner::justify::Justification;
 use owl_dl_reasoner::{
     Classification, DataPropertyValues, DifferentIndividuals, Disjointness, ObjectPropertyValues,
-    PropertyClassification, Realization, SameIndividuals,
+    PropertyClassification, ProveEntailmentResult, Realization, SameIndividuals, SyntheticDef,
 };
 use serde::Serialize;
+
+/// IRI of `owl:Nothing`, used to render a `DerivedFact::Unsat` conclusion as
+/// a plain `SubClassOf(C owl:Nothing)`.
+const OWL_NOTHING: &str = "http://www.w3.org/2002/07/owl#Nothing";
 
 const SCHEMA_VERSION: u32 = 1;
 
@@ -388,11 +396,13 @@ pub(crate) struct JustificationJson {
     pub(crate) ofn: String, // self-contained OFN ontology document
 }
 
-/// Render one justification's axioms as a self-contained OFN ontology
-/// document: a fresh `SetOntology` holding exactly those axioms (no more, no
-/// fewer — anti-fabrication), written with the SOURCE ontology's
-/// `PrefixMapping` so prefixes round-trip on reparse.
-fn justification_ofn_doc(axioms: &[Component<RcStr>], pm: &PrefixMapping) -> String {
+/// Render a set of axioms as a self-contained OFN ontology document: a fresh
+/// `SetOntology` holding exactly those axioms (no more, no fewer —
+/// anti-fabrication), written with the SOURCE ontology's `PrefixMapping` so
+/// prefixes round-trip on reparse. Shared by `justify --json`'s
+/// per-justification rendering and `prove --json`'s per-node/fallback
+/// rendering.
+fn axioms_to_ofn_doc(axioms: &[Component<RcStr>], pm: &PrefixMapping) -> String {
     let mut so: SetOntology<RcStr> = SetOntology::new();
     for ax in axioms {
         so.insert(ax.clone());
@@ -421,7 +431,7 @@ pub(crate) fn build_justify_json(
     let justifications = justs
         .iter()
         .map(|j| JustificationJson {
-            ofn: justification_ofn_doc(&j.axioms, pm),
+            ofn: axioms_to_ofn_doc(&j.axioms, pm),
         })
         .collect();
     JustifyJson {
@@ -436,6 +446,243 @@ pub(crate) fn build_justify_json(
         minimal,
         laconic,
         justifications,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `prove --json`
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub(crate) struct ProveJson {
+    pub(crate) schema_version: u32,
+    pub(crate) entailed: bool,
+    pub(crate) has_proof: bool,
+    pub(crate) proof: Option<ProofNodeJson>,
+    /// OFN ontology document (present iff `has_proof` is `false` and
+    /// `entailed` is `true`).
+    pub(crate) justification_fallback: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ProofNodeJson {
+    /// OFN ontology document containing the single derived axiom this node
+    /// proves.
+    pub(crate) conclusion: String,
+    /// `ElRule` name (its `Display` impl — matches the text renderer).
+    pub(crate) rule: String,
+    /// Source axioms used at this step, each its own OFN ontology document.
+    pub(crate) axioms: Vec<String>,
+    pub(crate) premises: Vec<ProofNodeJson>,
+}
+
+/// Resolve a class id to a horned-owl `ClassExpression`: a named class if
+/// `id` is within the source vocabulary, else its `SyntheticDef` expansion
+/// (mirrors `owl_dl_saturation::proof::render_class_expanded`/
+/// `render_synthetic_def`, but building real model objects instead of a
+/// display string, so the result can be written as OFN).
+fn class_id_to_class_expression(
+    id: ClassId,
+    vocab: &Vocabulary,
+    defs: &HashMap<ClassId, SyntheticDef>,
+    build: &Build<RcStr>,
+) -> ClassExpression<RcStr> {
+    let idx = id.index() as usize;
+    if idx < vocab.num_classes() {
+        return ClassExpression::Class(build.class(vocab.class_iri(id)));
+    }
+    if let Some(def) = defs.get(&id) {
+        return synthetic_def_to_class_expression(def, vocab, defs, build);
+    }
+    // No user-vocabulary entry and no synthetic-def record. Not expected in
+    // practice (every synthetic `ClassId` the proof trace can mention has a
+    // `synthetic_defs` entry — see `SyntheticDef` construction in
+    // `owl-dl-saturation/src/lib.rs`), but rendered as an opaque marker class
+    // rather than panicking: faithful to the internal id, not fabricated.
+    ClassExpression::Class(build.class(format!("urn:rustdl-synthetic:{idx}")))
+}
+
+fn synthetic_def_to_class_expression(
+    def: &SyntheticDef,
+    vocab: &Vocabulary,
+    defs: &HashMap<ClassId, SyntheticDef>,
+    build: &Build<RcStr>,
+) -> ClassExpression<RcStr> {
+    match def {
+        SyntheticDef::TseitinConj(bodies) => {
+            let mut parts: Vec<ClassExpression<RcStr>> = bodies
+                .iter()
+                .map(|&b| class_id_to_class_expression(b, vocab, defs, build))
+                .collect();
+            if parts.len() == 1 {
+                parts.remove(0)
+            } else {
+                ClassExpression::ObjectIntersectionOf(parts)
+            }
+        }
+        SyntheticDef::ExistMarkerOneWay { role, body }
+        | SyntheticDef::ExistMarkerEquiv { role, body } => ClassExpression::ObjectSomeValuesFrom {
+            ope: role_id_to_ope(*role, vocab, build),
+            bce: Box::new(class_id_to_class_expression(*body, vocab, defs, build)),
+        },
+        SyntheticDef::NominalKey(ind) => ClassExpression::ObjectOneOf(vec![Individual::Named(
+            individual_id_to_named(*ind, vocab, build),
+        )]),
+        SyntheticDef::MaxKey { n, role } => ClassExpression::ObjectMaxCardinality {
+            n: *n,
+            ope: role_id_to_ope(*role, vocab, build),
+            bce: Box::new(ClassExpression::ObjectIntersectionOf(vec![])), // unqualified: ⊤
+        },
+        SyntheticDef::ForallKey { role, members } => {
+            let mems: Vec<Individual<RcStr>> = members
+                .iter()
+                .map(|&ind| Individual::Named(individual_id_to_named(ind, vocab, build)))
+                .collect();
+            ClassExpression::ObjectAllValuesFrom {
+                ope: role_id_to_ope(*role, vocab, build),
+                bce: Box::new(ClassExpression::ObjectOneOf(mems)),
+            }
+        }
+        // Not reached in practice: `DKey` classes are interned as real named
+        // vocabulary entries at conversion time (`owl_dl_core::convert`'s
+        // `urn:rustdl-dkey:` classes), so they resolve via the `vocab` branch
+        // above, never via `synthetic_defs`. Kept for match exhaustiveness;
+        // rendered as an opaque named class if it ever fires.
+        SyntheticDef::DKey(iri_suffix) => {
+            ClassExpression::Class(build.class(format!("urn:rustdl-dkey:{iri_suffix}")))
+        }
+    }
+}
+
+fn role_id_to_ope(
+    role: RoleId,
+    vocab: &Vocabulary,
+    build: &Build<RcStr>,
+) -> horned_owl::model::ObjectPropertyExpression<RcStr> {
+    horned_owl::model::ObjectPropertyExpression::ObjectProperty(
+        build.object_property(vocab.role_iri(role)),
+    )
+}
+
+fn individual_id_to_named(
+    id: IndividualId,
+    vocab: &Vocabulary,
+    build: &Build<RcStr>,
+) -> NamedIndividual<RcStr> {
+    build.named_individual(vocab.individual_iri(id))
+}
+
+/// Render a `DerivedFact` (a saturator proof-node conclusion) as the
+/// horned-owl axiom it faithfully represents — always a `SubClassOf`
+/// (`Exist` is `SubClassOf(sub, ObjectSomeValuesFrom(role, target))`,
+/// `Unsat` is `SubClassOf(class, owl:Nothing)`).
+fn derived_fact_to_component(
+    fact: &owl_dl_reasoner::DerivedFact,
+    vocab: &Vocabulary,
+    defs: &HashMap<ClassId, SyntheticDef>,
+    build: &Build<RcStr>,
+) -> Component<RcStr> {
+    match fact {
+        owl_dl_reasoner::DerivedFact::Sub(s, p) => Component::SubClassOf(SubClassOf {
+            sub: class_id_to_class_expression(*s, vocab, defs, build),
+            sup: class_id_to_class_expression(*p, vocab, defs, build),
+        }),
+        owl_dl_reasoner::DerivedFact::Exist(s, r, t) => Component::SubClassOf(SubClassOf {
+            sub: class_id_to_class_expression(*s, vocab, defs, build),
+            sup: ClassExpression::ObjectSomeValuesFrom {
+                ope: role_id_to_ope(*r, vocab, build),
+                bce: Box::new(class_id_to_class_expression(*t, vocab, defs, build)),
+            },
+        }),
+        owl_dl_reasoner::DerivedFact::Unsat(c) => Component::SubClassOf(SubClassOf {
+            sub: class_id_to_class_expression(*c, vocab, defs, build),
+            sup: ClassExpression::Class(build.class(OWL_NOTHING)),
+        }),
+    }
+}
+
+/// Recursively build a `ProofNodeJson` from a `ProofNode`: the conclusion
+/// and each cited source axiom are each rendered as their own self-contained
+/// OFN ontology document.
+fn build_proof_node_json(
+    node: &owl_dl_reasoner::ProofNode,
+    internal: &InternalOntology,
+    defs: &HashMap<ClassId, SyntheticDef>,
+    pm: &PrefixMapping,
+    build: &Build<RcStr>,
+) -> ProofNodeJson {
+    let vocab = &internal.vocabulary;
+    let conclusion_component = derived_fact_to_component(&node.conclusion, vocab, defs, build);
+    let conclusion = axioms_to_ofn_doc(std::slice::from_ref(&conclusion_component), pm);
+
+    // `node.axiom_refs` index into `internal.axioms` (the same
+    // `InternalOntology` `prove_entailment_rcstr` converted the source
+    // ontology into) — resolved via `owl_dl_core::axiom_to_component`, the
+    // same reverse-conversion `owl_dl_core::convert_back` uses to reverse a
+    // whole `InternalOntology`. An out-of-range ref is silently skipped
+    // (mirrors the text renderer's `if let Some(ax) = ...` at the CLI's
+    // axiom-provenance printout); it should not occur for a proof the
+    // saturator itself produced.
+    let axioms: Vec<String> = node
+        .axiom_refs
+        .iter()
+        .filter_map(|r| internal.axioms.get(r.0))
+        .map(|ax| {
+            let component = owl_dl_core::axiom_to_component(ax, internal, build);
+            axioms_to_ofn_doc(std::slice::from_ref(&component), pm)
+        })
+        .collect();
+
+    let premises = node
+        .premises
+        .iter()
+        .map(|p| build_proof_node_json(p, internal, defs, pm, build))
+        .collect();
+
+    ProofNodeJson {
+        conclusion,
+        rule: node.rule.to_string(),
+        axioms,
+        premises,
+    }
+}
+
+/// Build the `prove --json` payload. `internal` must be the same ontology
+/// `result` was derived from (re-converted by the caller — see
+/// `prove_entailment_rcstr`'s own internal conversion).
+#[must_use]
+pub(crate) fn build_prove_json(
+    result: &ProveEntailmentResult,
+    internal: &InternalOntology,
+    pm: &PrefixMapping,
+) -> ProveJson {
+    match result {
+        ProveEntailmentResult::SaturatorProof(data) => {
+            let build: Build<RcStr> = Build::new_rc();
+            let proof =
+                build_proof_node_json(&data.root, internal, &data.trace.synthetic_defs, pm, &build);
+            ProveJson {
+                schema_version: SCHEMA_VERSION,
+                entailed: true,
+                has_proof: true,
+                proof: Some(proof),
+                justification_fallback: None,
+            }
+        }
+        ProveEntailmentResult::JustificationFallback(j) => ProveJson {
+            schema_version: SCHEMA_VERSION,
+            entailed: true,
+            has_proof: false,
+            proof: None,
+            justification_fallback: Some(axioms_to_ofn_doc(&j.axioms, pm)),
+        },
+        ProveEntailmentResult::NotEntailed => ProveJson {
+            schema_version: SCHEMA_VERSION,
+            entailed: false,
+            has_proof: false,
+            proof: None,
+            justification_fallback: None,
+        },
     }
 }
 

--- a/crates/owl-dl-cli/src/json_out.rs
+++ b/crates/owl-dl-cli/src/json_out.rs
@@ -3,8 +3,12 @@
 //! determinism; `schema_version` guards drift.
 use std::collections::BTreeMap;
 
-use horned_owl::model::RcStr;
+use horned_owl::curie::PrefixMapping;
+use horned_owl::io::ofn::writer::write as write_ofn;
+use horned_owl::model::{Component, MutableOntology, RcStr};
+use horned_owl::ontology::component_mapped::RcComponentMappedOntology;
 use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::justify::Justification;
 use owl_dl_reasoner::{
     Classification, DataPropertyValues, DifferentIndividuals, Disjointness, ObjectPropertyValues,
     PropertyClassification, Realization, SameIndividuals,
@@ -366,6 +370,72 @@ pub(crate) fn build_property_values_json(
         incomplete: obj.incomplete() || data.incomplete(),
         object_property_values,
         data_property_values,
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct JustifyJson {
+    pub(crate) schema_version: u32,
+    pub(crate) status: String, // "entailed" | "not-entailed"
+    pub(crate) enumeration_complete: bool,
+    pub(crate) minimal: bool, // all justifications minimal_guaranteed
+    pub(crate) laconic: bool,
+    pub(crate) justifications: Vec<JustificationJson>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct JustificationJson {
+    pub(crate) ofn: String, // self-contained OFN ontology document
+}
+
+/// Render one justification's axioms as a self-contained OFN ontology
+/// document: a fresh `SetOntology` holding exactly those axioms (no more, no
+/// fewer — anti-fabrication), written with the SOURCE ontology's
+/// `PrefixMapping` so prefixes round-trip on reparse.
+fn justification_ofn_doc(axioms: &[Component<RcStr>], pm: &PrefixMapping) -> String {
+    let mut so: SetOntology<RcStr> = SetOntology::new();
+    for ax in axioms {
+        so.insert(ax.clone());
+    }
+    let cmo: RcComponentMappedOntology = so.into();
+    let mut buf: Vec<u8> = Vec::new();
+    write_ofn(&mut buf, &cmo, Some(pm)).expect(
+        "writing a justification's axioms (no OntologyID, single ontology) to an in-memory \
+         buffer cannot fail",
+    );
+    String::from_utf8(buf).expect("horned-owl's OFN writer emits valid UTF-8")
+}
+
+/// Build the `justify --json` payload. `enumeration_complete` reflects
+/// whether `justs` is the FULL set of minimal justifications (always `true`
+/// for the default single-justification query; for `--all`, `false` when the
+/// `--max` cap was hit — see the call site).
+#[must_use]
+pub(crate) fn build_justify_json(
+    justs: &[Justification<RcStr>],
+    pm: &PrefixMapping,
+    laconic: bool,
+    enumeration_complete: bool,
+) -> JustifyJson {
+    let minimal = justs.iter().all(|j| j.minimal_guaranteed);
+    let justifications = justs
+        .iter()
+        .map(|j| JustificationJson {
+            ofn: justification_ofn_doc(&j.axioms, pm),
+        })
+        .collect();
+    JustifyJson {
+        schema_version: SCHEMA_VERSION,
+        status: if justs.is_empty() {
+            "not-entailed"
+        } else {
+            "entailed"
+        }
+        .to_owned(),
+        enumeration_complete,
+        minimal,
+        laconic,
+        justifications,
     }
 }
 

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -351,6 +351,9 @@ enum Command {
         /// Weaken each justification axiom to its responsible fragment (laconic).
         #[arg(long)]
         laconic: bool,
+        /// Emit machine-readable JSON (schema v1) instead of text.
+        #[arg(long)]
+        json: bool,
     },
     /// Suggest minimal axiom removals to break an unwanted entailment.
     Repair {
@@ -1267,10 +1270,46 @@ fn main() -> Result<()> {
             max,
             labels,
             laconic,
+            json,
         } => {
             let (onto, pm) = parse_ofn_with_pm(&file)?;
             let q =
                 owl_dl_reasoner::justify::parse_query(&query).map_err(|e| anyhow::anyhow!(e))?;
+            if json {
+                let (justs, enumeration_complete): (
+                    Vec<owl_dl_reasoner::justify::Justification<RcStr>>,
+                    bool,
+                ) = if all {
+                    let js = if laconic {
+                        owl_dl_reasoner::find_all_laconic_justifications(&onto, &q, max)
+                            .context("find_all_laconic_justifications")?
+                    } else {
+                        owl_dl_reasoner::justify::find_all_justifications(&onto, &q, max)
+                            .context("find_all_justifications")?
+                    };
+                    let enumeration_complete = js.len() < max;
+                    (js, enumeration_complete)
+                } else {
+                    let one = if laconic {
+                        owl_dl_reasoner::find_laconic_justification(&onto, &q)
+                            .context("find_laconic_justification")?
+                    } else {
+                        owl_dl_reasoner::justify::find_one_justification(&onto, &q)
+                            .context("find_one_justification")?
+                    };
+                    (one.into_iter().collect(), true)
+                };
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json_out::build_justify_json(
+                        &justs,
+                        &pm,
+                        laconic,
+                        enumeration_complete,
+                    ))?
+                );
+                return Ok(());
+            }
             let label_map = labels.then(|| build_label_map(&onto));
             let render = |j: &owl_dl_reasoner::justify::Justification<RcStr>| {
                 let note = if j.minimal_guaranteed {

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -387,6 +387,9 @@ enum Command {
         /// semantic definition (slower; for debugging).
         #[arg(long)]
         verify_proof: bool,
+        /// Emit machine-readable JSON (schema v1) instead of text.
+        #[arg(long)]
+        json: bool,
     },
     /// Diagnose a broken ontology: partition unsatisfiable classes into ROOT
     /// (genuine causes) and DERIVED (collateral), justify the roots, and on an
@@ -1454,9 +1457,22 @@ fn main() -> Result<()> {
             sub,
             sup,
             verify_proof,
+            json,
         } => {
             let (onto, pm) = parse_ofn_with_pm(&file)?;
-            match prove_entailment_rcstr(&onto, &sub, &sup).context("prove_entailment")? {
+            let result = prove_entailment_rcstr(&onto, &sub, &sup).context("prove_entailment")?;
+            if json {
+                let internal = owl_dl_core::convert::convert_ontology(&onto)
+                    .context("re-convert for rendering")?;
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json_out::build_prove_json(
+                        &result, &internal, &pm,
+                    ))?
+                );
+                return Ok(());
+            }
+            match result {
                 ProveEntailmentResult::SaturatorProof(data) => {
                     let root = &data.root;
                     // Render using the internal vocabulary and synthetic defs.

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -1280,14 +1280,33 @@ fn main() -> Result<()> {
                     Vec<owl_dl_reasoner::justify::Justification<RcStr>>,
                     bool,
                 ) = if all {
-                    let js = if laconic {
-                        owl_dl_reasoner::find_all_laconic_justifications(&onto, &q, max)
+                    // Probe with `max + 1`: `find_all_*` stops as soon as
+                    // `found.len() >= max`, so a returned count of exactly
+                    // `max` is ambiguous (genuinely capped, or coincidentally
+                    // exhausted). Asking for one more disambiguates: if the
+                    // probe still returns `<= max`, the true set is that
+                    // small and enumeration is complete; if it returns
+                    // `max + 1`, the true set has more and we were capped.
+                    // `saturating_add` guards a `max` already at `usize::MAX`
+                    // — in that degenerate (effectively-unbounded) case the
+                    // probe can't add headroom, so whatever comes back is,
+                    // by construction, the full set.
+                    let probe_max = max.saturating_add(1);
+                    let mut js = if laconic {
+                        owl_dl_reasoner::find_all_laconic_justifications(&onto, &q, probe_max)
                             .context("find_all_laconic_justifications")?
                     } else {
-                        owl_dl_reasoner::justify::find_all_justifications(&onto, &q, max)
+                        owl_dl_reasoner::justify::find_all_justifications(&onto, &q, probe_max)
                             .context("find_all_justifications")?
                     };
-                    let enumeration_complete = js.len() < max;
+                    let enumeration_complete = if max == usize::MAX {
+                        true
+                    } else if js.len() > max {
+                        js.truncate(max);
+                        false
+                    } else {
+                        true
+                    };
                     (js, enumeration_complete)
                 } else {
                     let one = if laconic {

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -1464,12 +1464,9 @@ fn main() -> Result<()> {
             if json {
                 let internal = owl_dl_core::convert::convert_ontology(&onto)
                     .context("re-convert for rendering")?;
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&json_out::build_prove_json(
-                        &result, &internal, &pm,
-                    ))?
-                );
+                let prove_json = json_out::build_prove_json(&result, &internal, &pm)
+                    .context("rendering prove --json proof tree")?;
+                println!("{}", serde_json::to_string_pretty(&prove_json)?);
                 return Ok(());
             }
             match result {

--- a/crates/owl-dl-cli/tests/fixtures/json/justify_el_chain.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/justify_el_chain.ofn
@@ -1,0 +1,4 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))
+  SubClassOf(:A :B) SubClassOf(:B :C))

--- a/crates/owl-dl-cli/tests/fixtures/json/justify_sroiq.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/justify_sroiq.ofn
@@ -1,0 +1,5 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))
+  SubClassOf(:B :A)
+  SubClassOf(:C ObjectUnionOf(:B :A)))

--- a/crates/owl-dl-cli/tests/fixtures/json/justify_two_paths.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/justify_two_paths.ofn
@@ -1,0 +1,6 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+  Declaration(Class(:A)) Declaration(Class(:B))
+  Declaration(Class(:C)) Declaration(Class(:D))
+  SubClassOf(:A :B) SubClassOf(:B :C)
+  SubClassOf(:A :D) SubClassOf(:D :C))

--- a/crates/owl-dl-cli/tests/fixtures/json/prove_tableau_cardinality.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/prove_tableau_cardinality.ofn
@@ -1,0 +1,8 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C)) Declaration(Class(:D))
+  Declaration(ObjectProperty(:r))
+  SubClassOf(:C ObjectMaxCardinality(1 :r))
+  SubClassOf(:C ObjectSomeValuesFrom(:r :A))
+  SubClassOf(:C ObjectSomeValuesFrom(:r :B))
+  DisjointClasses(:A :B))

--- a/crates/owl-dl-cli/tests/fixtures/json/prove_tseitin_conjunction.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/prove_tseitin_conjunction.ofn
@@ -1,0 +1,10 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+Declaration(Class(:A))
+Declaration(Class(:C))
+Declaration(Class(:D))
+Declaration(Class(:E))
+Declaration(ObjectProperty(:r))
+SubClassOf(:A ObjectSomeValuesFrom(:r ObjectIntersectionOf(:C :D)))
+SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:C :D)) :E)
+)

--- a/crates/owl-dl-cli/tests/json_output.rs
+++ b/crates/owl-dl-cli/tests/json_output.rs
@@ -415,6 +415,66 @@ fn justify_json_all_reports_two_justifications_complete() {
 }
 
 #[test]
+fn justify_json_all_max_equal_to_true_count_is_complete() {
+    // justify_two_paths has exactly 2 minimal justifications (A-B-C, A-D-C).
+    // `--max 2` == the true count: the max+1 probe should find no third
+    // justification, so this is exhaustion, not capping.
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            "--all",
+            "--max",
+            "2",
+            justify_two_paths(),
+            "subclass",
+            "http://ex/#A",
+            "http://ex/#C",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "entailed");
+    assert_eq!(
+        v["enumeration_complete"], true,
+        "max == true count must not be reported as capped"
+    );
+    assert_eq!(v["justifications"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn justify_json_all_max_one_below_true_count_is_capped() {
+    // `--max 1` is one less than the true count of 2: the max+1 probe (2)
+    // finds both, so the cap is genuine and enumeration_complete must be
+    // false, with exactly `max` justifications returned.
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            "--all",
+            "--max",
+            "1",
+            justify_two_paths(),
+            "subclass",
+            "http://ex/#A",
+            "http://ex/#C",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "entailed");
+    assert_eq!(
+        v["enumeration_complete"], false,
+        "max one below true count must be reported as capped"
+    );
+    assert_eq!(v["justifications"].as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn justify_json_laconic_flag_is_set() {
     let out = rustdl()
         .args([

--- a/crates/owl-dl-cli/tests/json_output.rs
+++ b/crates/owl-dl-cli/tests/json_output.rs
@@ -106,6 +106,13 @@ fn justify_sroiq() -> &'static str {
     )
 }
 
+fn prove_tableau_cardinality() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/prove_tableau_cardinality.ofn"
+    )
+}
+
 #[test]
 fn classify_json_parses_and_reports_consistent() {
     let out = rustdl()
@@ -597,4 +604,134 @@ fn instances_expr_json_lists_instances() {
         .map(|s| s.as_str().unwrap())
         .collect();
     assert!(insts.contains(&"http://ex/#x"));
+}
+
+// ---------------------------------------------------------------------------
+// `prove --json`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prove_json_el_chain_has_multi_step_proof() {
+    // justify_el_chain: A ⊑ B, B ⊑ C ⟹ A ⊑ C via EL saturation
+    // transitivity — a two-premise proof tree.
+    let out = rustdl()
+        .args([
+            "prove",
+            "--json",
+            justify_el_chain(),
+            "http://ex/#A",
+            "http://ex/#C",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["entailed"], true);
+    assert_eq!(v["has_proof"], true);
+    assert!(v["justification_fallback"].is_null());
+    let proof = &v["proof"];
+    assert!(!proof.is_null(), "proof tree must be present");
+
+    // Root conclusion should be a parseable OFN SubClassOf(A C).
+    let concl = proof["conclusion"].as_str().unwrap();
+    let concl_axioms = ofn_doc_axiom_strings(concl);
+    assert!(
+        concl_axioms
+            .iter()
+            .any(|a| a.contains("http://ex/#A") && a.contains("http://ex/#C")),
+        "root conclusion should be SubClassOf(A C); got {concl_axioms:?}"
+    );
+    assert!(!proof["rule"].as_str().unwrap().is_empty());
+
+    // Multi-step: premises non-empty, and each premise's axioms parse as OFN
+    // and trace back to the source axioms (A⊑B / B⊑C).
+    let premises = proof["premises"].as_array().unwrap();
+    assert!(
+        !premises.is_empty(),
+        "A⊑C via transitivity must have premises"
+    );
+    let mut saw_ab = false;
+    let mut saw_bc = false;
+    for premise in premises {
+        let premise_concl = ofn_doc_axiom_strings(premise["conclusion"].as_str().unwrap());
+        if premise_concl
+            .iter()
+            .any(|a| a.contains("http://ex/#A") && a.contains("http://ex/#B"))
+        {
+            saw_ab = true;
+        }
+        if premise_concl
+            .iter()
+            .any(|a| a.contains("http://ex/#B") && a.contains("http://ex/#C"))
+        {
+            saw_bc = true;
+        }
+        // Each premise cites its source axiom, and it parses as OFN.
+        let axioms = premise["axioms"].as_array().unwrap();
+        assert!(
+            !axioms.is_empty(),
+            "ToldSubsumer premise must cite its source axiom"
+        );
+        for ax in axioms {
+            let parsed = ofn_doc_axiom_strings(ax.as_str().unwrap());
+            assert!(!parsed.is_empty(), "axiom fragment must parse as OFN");
+        }
+    }
+    assert!(saw_ab && saw_bc, "expected both A⊑B and B⊑C premises");
+}
+
+#[test]
+fn prove_json_sroiq_falls_back_to_justification() {
+    // prove_tableau_cardinality: C ⊑ ≤1 r, C ⊑ ∃r.A, C ⊑ ∃r.B, Disjoint(A,B).
+    // Without a `Functional(r)` declaration the ≤1-cardinality merge of the
+    // two r-successors is genuine tableau reasoning (no `ElRule` variant
+    // covers unqualified max-cardinality merge), so C is unsatisfiable only
+    // via the tableau — out of the EL saturation fragment. C unsat entails
+    // C ⊑ D for the unrelated declared class D.
+    let out = rustdl()
+        .args([
+            "prove",
+            "--json",
+            prove_tableau_cardinality(),
+            "http://ex/#C",
+            "http://ex/#D",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["entailed"], true);
+    assert_eq!(v["has_proof"], false);
+    assert!(v["proof"].is_null());
+    let fallback = v["justification_fallback"]
+        .as_str()
+        .expect("justification_fallback must be present when has_proof is false");
+    let axioms = ofn_doc_axiom_strings(fallback);
+    assert!(
+        !axioms.is_empty(),
+        "fallback OFN doc should carry the justification's axioms"
+    );
+}
+
+#[test]
+fn prove_json_not_entailed() {
+    let out = rustdl()
+        .args([
+            "prove",
+            "--json",
+            justify_el_chain(),
+            "http://ex/#C",
+            "http://ex/#A",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["entailed"], false);
+    assert_eq!(v["has_proof"], false);
+    assert!(v["proof"].is_null());
+    assert!(v["justification_fallback"].is_null());
 }

--- a/crates/owl-dl-cli/tests/json_output.rs
+++ b/crates/owl-dl-cli/tests/json_output.rs
@@ -113,6 +113,13 @@ fn prove_tableau_cardinality() -> &'static str {
     )
 }
 
+fn prove_tseitin_conjunction() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/prove_tseitin_conjunction.ofn"
+    )
+}
+
 #[test]
 fn classify_json_parses_and_reports_consistent() {
     let out = rustdl()
@@ -679,6 +686,100 @@ fn prove_json_el_chain_has_multi_step_proof() {
         }
     }
     assert!(saw_ab && saw_bc, "expected both A⊑B and B⊑C premises");
+}
+
+/// Recursively walk a `prove --json` proof tree, collecting `(conclusion,
+/// axioms[])` OFN strings from every node, so tests can assert properties
+/// hold tree-wide rather than just at the root.
+fn collect_proof_strings<'a>(node: &'a serde_json::Value, out: &mut Vec<&'a str>) {
+    out.push(node["conclusion"].as_str().unwrap());
+    for ax in node["axioms"].as_array().unwrap() {
+        out.push(ax.as_str().unwrap());
+    }
+    for premise in node["premises"].as_array().unwrap() {
+        collect_proof_strings(premise, out);
+    }
+}
+
+#[test]
+fn prove_json_synthetic_def_tseitin_conjunction_renders_faithfully() {
+    // prove_tseitin_conjunction: A ⊑ ∃r.(C ⊓ D), ∃r.(C ⊓ D) ⊑ E.
+    // The compound existential filler (C ⊓ D) forces the saturator to
+    // allocate a Tseitin synthetic class for it; the proof that A ⊑ E goes
+    // through a `DerivedFact::Exist(A, r, <synthetic>)` node whose
+    // conclusion/axioms must expand that synthetic def back to
+    // `ObjectIntersectionOf(C D)` — this is the SyntheticDef-expansion path
+    // this test locks in as a regression.
+    let out = rustdl()
+        .args([
+            "prove",
+            "--json",
+            prove_tseitin_conjunction(),
+            "http://ex/#A",
+            "http://ex/#E",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["entailed"], true);
+    assert_eq!(v["has_proof"], true);
+    assert!(v["justification_fallback"].is_null());
+    let proof = &v["proof"];
+    assert!(!proof.is_null(), "proof tree must be present");
+
+    // (i) multi-step structure: the root must have at least one premise.
+    let premises = proof["premises"].as_array().unwrap();
+    assert!(
+        !premises.is_empty(),
+        "A ⊑ E via the existential trigger must have at least one premise \
+         (the told A ⊑ ∃r.(C⊓D) fact); got a leaf root"
+    );
+
+    // (ii) every conclusion and every axioms[] entry, tree-wide, must parse
+    // as valid OWL Functional Syntax.
+    let mut strings: Vec<&str> = Vec::new();
+    collect_proof_strings(proof, &mut strings);
+    assert!(
+        strings.len() >= 3,
+        "expected root + premise conclusions/axioms to yield several OFN \
+         documents; got {strings:?}"
+    );
+    let mut all_parsed_axioms: Vec<String> = Vec::new();
+    for s in &strings {
+        let parsed = ofn_doc_axiom_strings(s);
+        assert!(
+            !parsed.is_empty(),
+            "OFN document must parse to ≥1 axiom: {s}"
+        );
+        all_parsed_axioms.extend(parsed);
+    }
+
+    // Meaningful (not vacuous): somewhere in the tree the SyntheticDef for
+    // (C ⊓ D) must have been expanded back to a genuine
+    // `ObjectIntersectionOf` mentioning both C and D — proving the
+    // `∃r.(C⊓D)` filler round-tripped through the Tseitin synthetic, not
+    // just that *some* OFN happened to parse.
+    assert!(
+        all_parsed_axioms.iter().any(|a| {
+            a.contains("ObjectIntersectionOf")
+                && a.contains("http://ex/#C")
+                && a.contains("http://ex/#D")
+        }),
+        "expected a rendered axiom expanding the Tseitin synthetic to \
+         ObjectIntersectionOf(C D); got {all_parsed_axioms:?}"
+    );
+
+    // (iii) none of the rendered strings contains the fabrication marker —
+    // proving the SyntheticDef expansion produced real content, not the
+    // `urn:rustdl-synthetic:` should-never-happen fallback.
+    for s in &strings {
+        assert!(
+            !s.contains("urn:rustdl-synthetic:"),
+            "proof JSON must never contain the fabrication marker: {s}"
+        );
+    }
 }
 
 #[test]

--- a/crates/owl-dl-cli/tests/json_output.rs
+++ b/crates/owl-dl-cli/tests/json_output.rs
@@ -85,6 +85,27 @@ fn dropped_tiny() -> &'static str {
     )
 }
 
+fn justify_el_chain() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/justify_el_chain.ofn"
+    )
+}
+
+fn justify_two_paths() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/justify_two_paths.ofn"
+    )
+}
+
+fn justify_sroiq() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/justify_sroiq.ofn"
+    )
+}
+
 #[test]
 fn classify_json_parses_and_reports_consistent() {
     let out = rustdl()
@@ -313,6 +334,146 @@ fn subclass_expr_json_reports_entailed() {
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
     assert_eq!(v["schema_version"], 1);
     assert_eq!(v["entailed"], true); // A⊓B ⊑ A
+}
+
+/// Parse an OFN document string and return its logical-axiom strings
+/// (Manchester-rendered, prefix-free full IRIs) for containment checks.
+fn ofn_doc_axiom_strings(doc: &str) -> Vec<String> {
+    use horned_owl::io::ParserConfiguration;
+    use horned_owl::io::ofn::reader::read as read_ofn;
+    use horned_owl::model::RcStr;
+    use horned_owl::ontology::set::SetOntology;
+    let (onto, _): (SetOntology<RcStr>, _) = read_ofn(
+        &mut std::io::Cursor::new(doc.to_owned()),
+        ParserConfiguration::default(),
+    )
+    .expect("emitted `ofn` field must be a parseable OFN document");
+    onto.iter()
+        .map(|ac| format!("{:?}", ac.component))
+        .collect()
+}
+
+#[test]
+fn justify_json_entailed_el_chain_is_minimal() {
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            justify_el_chain(),
+            "subclass",
+            "http://ex/#A",
+            "http://ex/#C",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "entailed");
+    assert_eq!(v["minimal"], true);
+    assert_eq!(v["laconic"], false);
+    assert_eq!(v["enumeration_complete"], true);
+    let js = v["justifications"].as_array().unwrap();
+    assert_eq!(js.len(), 1, "exactly one justification for A subclass C");
+    let ofn = js[0]["ofn"].as_str().unwrap();
+    let axioms = ofn_doc_axiom_strings(ofn);
+    assert!(
+        axioms
+            .iter()
+            .any(|a| a.contains("http://ex/#A") && a.contains("http://ex/#B")),
+        "ofn doc should contain SubClassOf(A B); got {axioms:?}"
+    );
+    assert!(
+        axioms
+            .iter()
+            .any(|a| a.contains("http://ex/#B") && a.contains("http://ex/#C")),
+        "ofn doc should contain SubClassOf(B C); got {axioms:?}"
+    );
+}
+
+#[test]
+fn justify_json_all_reports_two_justifications_complete() {
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            "--all",
+            justify_two_paths(),
+            "subclass",
+            "http://ex/#A",
+            "http://ex/#C",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "entailed");
+    assert_eq!(v["enumeration_complete"], true);
+    let js = v["justifications"].as_array().unwrap();
+    assert_eq!(js.len(), 2, "two independent A-B-C / A-D-C paths");
+}
+
+#[test]
+fn justify_json_laconic_flag_is_set() {
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            "--laconic",
+            justify_el_chain(),
+            "subclass",
+            "http://ex/#A",
+            "http://ex/#C",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "entailed");
+    assert_eq!(v["laconic"], true);
+    assert!(!v["justifications"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn justify_json_not_entailed_reports_empty() {
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            justify_el_chain(),
+            "subclass",
+            "http://ex/#C",
+            "http://ex/#A",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "not-entailed");
+    assert!(v["justifications"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn justify_json_sroiq_is_not_minimal() {
+    let out = rustdl()
+        .args([
+            "justify",
+            "--json",
+            justify_sroiq(),
+            "subclass",
+            "http://ex/#C",
+            "http://ex/#A",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["status"], "entailed");
+    assert_eq!(v["minimal"], false);
 }
 
 #[test]

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -145,3 +145,71 @@ that every axiom is in the whitelist AND that the seed alone was returned
 (no extension candidates). Sound under-approximation: a
 reported triple is always genuinely entailed (FP=0); `incomplete` warns real
 edges may be missing.
+
+## `justify --json`
+
+```json
+{ "schema_version": 1, "status": "entailed" | "not-entailed",
+  "enumeration_complete": bool, "minimal": bool, "laconic": bool,
+  "justifications": [ { "ofn": ofn_document } ] }
+```
+
+`status` is `"not-entailed"` iff `justifications` is empty (no query holds
+without at least one justification). `minimal` = every returned
+justification is *guaranteed* minimal (`Justification::minimal_guaranteed`
+across the whole saturator/tableau fragment the query resolved in — some
+SROIQ-only entailments return a sound but not-provably-minimal axiom set,
+e.g. `--all`-independent disjunctive derivations). `laconic` echoes the
+`--laconic` flag (each justification's axioms are weakened to their
+responsible fragment when set). `enumeration_complete` is `true` for the
+default single-justification query; for `--all`, `false` only when the
+`--max` cap genuinely truncated the true set (probed via `max + 1`, so a
+returned count that happens to equal `max` is not conflated with a cap).
+
+Each `justifications[i].ofn` is a **self-contained OFN ontology document** —
+a fresh ontology holding exactly that justification's axioms (no more, no
+fewer), written with the source ontology's prefixes so it re-parses
+standalone. This is the shared rendering `prove --json`'s
+`justification_fallback` and per-node `conclusion`/`axioms` reuse (see
+below).
+
+## `prove --json`
+
+```json
+{ "schema_version": 1, "entailed": bool, "has_proof": bool,
+  "proof": ProofNodeJson | null,
+  "justification_fallback": ofn_document | null }
+```
+
+```json
+// ProofNodeJson
+{ "conclusion": ofn_document, "rule": rule_name,
+  "axioms": [ofn_document, ...], "premises": [ProofNodeJson, ...] }
+```
+
+Three mutually exclusive shapes, mirroring `ProveEntailmentResult`:
+
+- **Step-level EL proof** (entailment held by the EL saturation fragment):
+  `entailed: true, has_proof: true`, `proof` is the recursively-built
+  `ProofNode` tree rooted at the queried `SUB ⊑ SUP`, `justification_fallback:
+  null`. Each node's `conclusion` is a one-axiom OFN document rendering that
+  node's `DerivedFact` (`Sub(s,p)` → `SubClassOf(s p)`; `Exist(s,r,t)` →
+  `SubClassOf(s ObjectSomeValuesFrom(r t))`; `Unsat(c)` → `SubClassOf(c
+  owl:Nothing)`) — classes beyond the source vocabulary (Tseitin/marker/
+  nominal-key/cardinality-key synthetics the saturator introduced) are
+  expanded to their defining expression via the same `SyntheticDef` table the
+  text `prove` renderer (`render_proof_with_defs`) uses, so the OFN is
+  faithful, never fabricated. `rule` is the `ElRule`'s display name (e.g.
+  `"ToldSubsumer"`, `"SubsumerTransitivity(fwd)"`). `axioms` are that step's
+  cited source axioms — each `node.axiom_refs` index resolved against the
+  same `InternalOntology` the query ran over and reverse-converted to a
+  horned-owl axiom, each its own one-axiom OFN document; empty for a pure
+  transitivity/chain step with no direct axiom. `premises` recurses; a leaf
+  step has `premises: []`.
+- **Justification fallback** (entailment holds, but not via the EL
+  saturation fragment — SROIQ-only, e.g. genuine disjunctive/cardinality
+  tableau reasoning): `entailed: true, has_proof: false`, `proof: null`,
+  `justification_fallback` is the axiom-level justification's OFN document
+  (may be empty-axioms if none could be found).
+- **Not entailed**: `entailed: false, has_proof: false`, `proof: null,
+  justification_fallback: null`.

--- a/docs/protege-plugin.md
+++ b/docs/protege-plugin.md
@@ -27,6 +27,54 @@ this is the one remaining empty stub. An `incomplete` result from any
 subprocess (some hard pairs hit the per-pair budget) is logged; results
 stay sound (no false answers, some may be missed).
 
+## Explaining inferences
+
+The plugin also backs Protégé's explanation surface, so a computed hierarchy
+edge isn't just an answer — you can ask why.
+
+**Justifications ("?" dialog).** Click the "?" next to any inferred axiom
+(e.g. a superclass rustdl added to the hierarchy) and the Explanation dialog
+now offers two rustdl entries alongside any other installed explanation
+sources:
+
+- **rustdl** — minimal justifications: each returned explanation is a
+  subset-minimal set of axioms from your ontology that entails the
+  selected axiom (`rustdl justify --json` under the hood).
+- **rustdl (laconic)** — as above, but each justification axiom is further
+  weakened to the fragment actually responsible for the entailment (e.g. one
+  disjunct of a conjunction, one `∃`-filler), which is often easier to read
+  than the full told axiom (`rustdl justify --laconic --json`).
+
+Both sources only ever surface axioms genuinely present in your ontology —
+rustdl cannot fabricate a justification axiom that isn't already there.
+
+**Proof view (step-level proofs).** Where the Explanation dialog shows the
+*minimal axiom set*, the proof view shows the *derivation steps* between
+them — e.g. how two `SubClassOf` axioms combine via transitivity to entail a
+third. For entailments in the EL fragment, rustdl provides a genuine
+step-level proof tree (`rustdl prove --json`); outside that fragment it
+degrades to a single step showing the justification as one "black box"
+inference, rather than refusing to answer.
+
+**Prerequisite — proof-explanation plugin required, like ELK.** The
+step-level proof view is a separate Protégé feature backed by the
+[Protégé proof-explanation plugin](https://github.com/liveontologies/protege-proof-explanation).
+As with ELK, rustdl's proof-tree support only appears once that companion
+plugin is also installed — this plugin's own jar does **not** bundle it (the
+proof-service dependencies are declared optional and are not embedded in the
+`rustdl-protege-<version>.jar`). Without it, rustdl's reasoning, hierarchy
+classification, and both Explanation-dialog justification sources above work
+exactly as normal; only the step-level proof-tree view is unavailable.
+
+**Config knobs** (system property / environment variable, property wins if
+both are set):
+
+- `rustdl.explain.max.justifications` / `RUSTDL_EXPLAIN_MAX_JUSTIFICATIONS` —
+  cap on the number of justifications rustdl enumerates per explanation
+  request (default 8)
+- `rustdl.explain.timeout.seconds` / `RUSTDL_EXPLAIN_TIMEOUT_SECONDS` — per-call
+  timeout for the underlying `justify`/`prove` subprocess (default 600)
+
 ## Config
 
 - `-Drustdl.bin=…` / `RUSTDL_BIN=…` — use a specific binary (default: bundled)

--- a/docs/superpowers/plans/2026-07-26-explanation-surface.md
+++ b/docs/superpowers/plans/2026-07-26-explanation-surface.md
@@ -1,0 +1,147 @@
+# rustdl explanation surface — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Surface rustdl's `justify` (+ `--laconic`) and `prove` in Protégé — justifications in the "?" Explanation dialog and step-level proof trees in the proof view. Design: `docs/superpowers/specs/2026-07-26-explanation-surface-design.md`.
+
+**Architecture:** Two rustdl CLI `--json` subcommands (`justify`, `prove`) bridge to two plugin surfaces: the OWL Explanation API (`ExplanationGeneratorFactory<OWLAxiom>`, mirror km — justifications + laconic) and the liveontologies proof service (`ProofService`, mirror ELK — proof trees). owlexplanation/telemetry are embedded (like km); the proof-service APIs are optional OSGi imports (like ELK).
+
+**Tech Stack:** Rust (serde_json, horned-owl OFN writer); Java 11, owlapi 4.5.29, owlexplanation 2.0.1 + telemetry 2.0.0, puli/owlapi-proof/protege-proof-explanation/protege-proof-justification 0.1.0, maven-bundle-plugin.
+
+## Global Constraints
+
+- rustdl `--json`: `schema_version: 1` (reuse `json_out::SCHEMA_VERSION`); one JSON object on stdout, diagnostics to stderr; additive (the text paths are unchanged, `--json` short-circuits before them). Build Rust with `RUSTUP_TOOLCHAIN=stable`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` + `cargo fmt` clean.
+- Justification/proof axioms are **OWL Functional Syntax**, emitted as self-contained OFN ontology documents (horned-owl `horned_owl::io::ofn::writer::write`), so the plugin parses each with OWLAPI in one shot and reconstructs `OWLAxiom`s.
+- **Soundness/honesty:** every returned axiom is a source axiom (rustdl justifies over the ontology's own logical axioms) — the plugin still verifies each is `.contains()` in the imports closure (anti-fabrication). `minimal` is true only on EL/Horn (`Justification.minimal_guaranteed`); surfaced, never falsely certified. Proof trees are EL-only; outside EL, `prove` returns a justification fallback.
+- Plugin toolchain: `export PATH="/opt/homebrew/bin:$PATH"; export JAVA_HOME="/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"`; all Maven via `mvn -f protege/pom.xml …`.
+- **Dependency strategy (mirror the references exactly):** owlexplanation 2.0.1 + telemetry 2.0.0 → `Embed-Dependency … inline=false` (embedded nested jars, with km's exclusions). puli/owlapi-proof/protege-proof-explanation/protege-proof-justification 0.1.0 → Maven `provided` + OSGi `Import-Package … resolution:=optional;version="[0.1,1)"` (NOT embedded).
+- Reference sources to mirror (read them): km at `…/scratchpad/km/KMExplanation*.java` + the `META-INF/services` file; ELK/puli at `/tmp/ElkProofService.java`, `/tmp/ElkOwlProof.java`, `/tmp/puli_{Proof,Inference,ProofStep}.java`, `…/scratchpad/elk/elk_plugin.xml` + `elk_protege_pom.xml`.
+- Package root `com.github.maastrichtu_ids.rustdl.protege`.
+
+## File Structure
+
+- rustdl: `crates/owl-dl-cli/src/json_out.rs` (+ `JustifyJson`/`ProveJson` builders), `crates/owl-dl-cli/src/main.rs` (`--json` on Justify/Prove), `crates/owl-dl-cli/tests/json_output.rs` (+ fixtures), `docs/json-schema.md`.
+- plugin: new `RustdlExplain*.java` (justify), `RustdlProof*.java` (proofs), `RustdlOfn.java` (parse OFN docs → OWLAxioms + the `.contains()` guard); `RustdlProcess.java` (+ `justify`/`prove` calls + JSON POJOs in `RustdlJson`); `protege/pom.xml` (deps + bundle instructions); `plugin.xml` (proof-service extension); `META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory`; tests + smoke IT; `docs/protege-plugin.md`.
+
+---
+
+### Task 1: `justify --json` (rustdl CLI)
+
+**Files:** `json_out.rs`, `main.rs` (modify); `tests/json_output.rs` + fixtures.
+
+**Interfaces:** Produces `justify --json` per §3a of the spec. `json_out::build_justify_json(&[Justification<RcStr>], laconic, enumeration_complete) -> JustifyJson`.
+
+- [ ] **Step 1: Add `JustifyJson` + builder to `json_out.rs`.**
+```rust
+#[derive(Serialize)]
+pub(crate) struct JustifyJson {
+    pub(crate) schema_version: u32,
+    pub(crate) status: String,               // "entailed" | "not-entailed"
+    pub(crate) enumeration_complete: bool,
+    pub(crate) minimal: bool,                // all justifications minimal_guaranteed
+    pub(crate) laconic: bool,
+    pub(crate) justifications: Vec<JustificationJson>,
+}
+#[derive(Serialize)]
+pub(crate) struct JustificationJson { pub(crate) ofn: String }  // self-contained OFN ontology document
+```
+Builder: render each `Justification`'s `axioms: Vec<Component<RcStr>>` into a **self-contained OFN ontology document** string — build a `SetOntology<RcStr>` (or the ontology type horned-owl's writer takes) containing exactly those components + the source ontology's prefix mapping, and write it with `horned_owl::io::ofn::writer::write(&mut buf, &ont, Some(&prefix_mapping))`. (Read the existing `parse_ofn_with_pm` / how the CLI obtains the `PrefixMapping` `pm`; reuse it so the emitted doc carries the same prefixes.) `status` = `"entailed"` if any justification (or the engine says entailed) else `"not-entailed"` (empty `justifications`). `minimal` = every justification's `minimal_guaranteed`. `enumeration_complete` from the `--all` cap (true unless capped).
+
+- [ ] **Step 2: Wire `--json` into the `Justify` handler in `main.rs`.** Add `#[arg(long)] json: bool` to the `Justify` variant. In the handler, after computing the justifications (use `find_one_justification` for the default, `find_all_justifications` / `find_all_laconic_justifications` / `find_laconic_justification` per `all`/`laconic`), if `json`: `println!("{}", serde_json::to_string_pretty(&json_out::build_justify_json(&justs, laconic, complete))?); return Ok(());` BEFORE the existing text `render` closure. (Confirm the exact reasoner fn names: `owl_dl_reasoner::justify::{find_one_justification, find_all_justifications}` and `owl_dl_reasoner::{find_laconic_justification, find_all_laconic_justifications}`.)
+
+- [ ] **Step 3: Golden tests** (`tests/json_output.rs`, mirror the existing e2e style using `env!("CARGO_BIN_EXE_rustdl")`): (a) an EL fixture entailing `A ⊑ C` → `justify --json subclass A C` yields `status:"entailed"`, `minimal:true`, one justification whose `ofn` parses and contains the responsible source axioms; (b) `--all` on a two-justification fixture → 2 justifications, `enumeration_complete:true`; (c) `--laconic` → `laconic:true`; (d) a not-entailed query → `status:"not-entailed"`, empty; (e) a SROIQ fixture → `minimal:false`. Fixtures under `tests/fixtures/json/`.
+
+- [ ] **Step 4: Commit** (`feat(cli): justify --json`).
+
+---
+
+### Task 2: `prove --json` (rustdl CLI)
+
+**Files:** `json_out.rs`, `main.rs`; `tests/json_output.rs` + fixtures.
+
+**Interfaces:** Produces `prove --json` per §3a. `json_out::build_prove_json(&ProveEntailmentResult, &InternalOntology, &PrefixMapping) -> ProveJson`.
+
+- [ ] **Step 1: Add `ProveJson` + recursive `ProofNodeJson` + builder to `json_out.rs`.**
+```rust
+#[derive(Serialize)]
+pub(crate) struct ProveJson {
+    pub(crate) schema_version: u32,
+    pub(crate) entailed: bool,
+    pub(crate) has_proof: bool,
+    pub(crate) proof: Option<ProofNodeJson>,
+    pub(crate) justification_fallback: Option<String>,  // OFN ontology document
+}
+#[derive(Serialize)]
+pub(crate) struct ProofNodeJson {
+    pub(crate) conclusion: String,      // OFN of the derived axiom
+    pub(crate) rule: String,            // ElRule name (Debug/Display)
+    pub(crate) axioms: Vec<String>,     // source axioms used at this step (OFN fragments)
+    pub(crate) premises: Vec<ProofNodeJson>,
+}
+```
+Builder: match `ProveEntailmentResult`:
+- `SaturatorProof(data)` → `entailed=true, has_proof=true`, recursively map `data.root: ProofNode`. For each node: `rule` = `format!("{:?}", node.rule)` (or a Display if one exists); `axioms` = each `node.axiom_refs` (`AxiomRef(usize)` index into `logical_axioms(onto).1` — read how `render_proof_with_defs`/`check_proof_with_content` resolve `axiom_refs` to the source `Component`) rendered to an OFN fragment; `conclusion` = `node.conclusion: DerivedFact` rendered to an OFN axiom (read `render_proof_with_defs` for how a `DerivedFact` + `synthetic_defs` renders to a subsumption; produce the OFN `SubClassOf(...)` equivalent — reuse the vocabulary + synthetic_defs the CLI passes to `render_proof_with_defs`). `premises` = recurse over `node.premises`.
+- `JustificationFallback(j)` → `entailed=true, has_proof=false`, `justification_fallback` = the OFN ontology document of `j.axioms` (reuse Task 1's OFN-document helper — factor it into a shared `pub(crate) fn axioms_to_ofn_doc(...)`), `proof=None`.
+- `NotEntailed` → `entailed=false, has_proof=false`, both `None`.
+
+> Implementer note: the `DerivedFact`/`AxiomRef` → OFN rendering is the load-bearing risk. Read `crates/owl-dl-saturation/src/proof.rs` (`render_proof`, `render_proof_with_defs`) and `owl_dl_reasoner::justify::logical_axioms` to get the exact resolution of `axiom_refs` and the `DerivedFact` → axiom mapping, then render via horned-owl OFN. If a `DerivedFact` cannot be expressed as a single OFN axiom (e.g. an internal synthetic), render the best-effort SubClassOf using the vocabulary + `synthetic_defs` (same as `render_proof_with_defs` does for text) — the plugin only needs a parseable OFN `SubClassOf`.
+
+- [ ] **Step 2: Wire `--json` into `Prove`** (add `#[arg(long)] json: bool`; on `json`, build the internal ontology (the handler already `convert_ontology`s for rendering), call `build_prove_json`, print, return — before the text path).
+
+- [ ] **Step 3: Golden tests:** (a) an EL fixture with a multi-step `A ⊑ C` proof → `has_proof:true`, a `proof` tree whose `conclusion`/`axioms` parse as OFN, `premises` non-empty; (b) a non-EL entailment → `has_proof:false`, `justification_fallback` present + parseable; (c) not-entailed → `entailed:false`. **Commit** (`feat(cli): prove --json`).
+
+- [ ] **Step 4: Update `docs/json-schema.md`** with the `justify`/`prove --json` schemas. **Commit.**
+
+---
+
+### Task 3: Plugin — justifications + laconic (OWL Explanation API)
+
+**Files:** new `RustdlExplanationGeneratorFactory.java`, `RustdlExplanationGenerator.java`, `RustdlLaconicExplanationGeneratorFactory.java`, `RustdlOfn.java`; `RustdlProcess.java` + `RustdlJson.java` (+ justify call/POJO); `pom.xml` (owlexplanation/telemetry); `META-INF/services/…ExplanationGeneratorFactory`; tests.
+
+**Interfaces:** Consumes `justify --json`. Produces `Set<Explanation<OWLAxiom>>` via the OWL Explanation API. Read km's `KMExplanationGeneratorFactory`/`Generator`/`Configuration`/`Run` (scratchpad) as the structural template — mirror them, applying the deltas below.
+
+- [ ] **Step 1: pom deps + bundle.** Add `net.sourceforge.owlapi:owlexplanation:2.0.1` (with exclusions of `owlapi-osgidistribution` + `telemetry`) and `net.sourceforge.owlapi:telemetry:2.0.0` (excluding the owlapi distributions + slf4j). Bundle: `Embed-Dependency: gson|owlexplanation|telemetry;scope=compile;inline=false`; `Export-Package` adds `org.semanticweb.owl.explanation.api;version="2.0.1"`; `Import-Package` prepends `!org.semanticweb.owl.explanation.telemetry`. Extend the antrun `verify-bundle-contents` to assert `owlexplanation-2.0.1.jar` + `telemetry-2.0.0.jar` are embedded. Verify `mvn -f protege/pom.xml package` builds and both nested jars are present.
+
+- [ ] **Step 2: `RustdlJson` POJO + `RustdlProcess.justify`.** POJOs: `JustifyJson{ int schema_version; String status; boolean enumeration_complete; boolean minimal; boolean laconic; List<JustificationJson> justifications; }`, `JustificationJson{ String ofn; }`. `RustdlProcess.justify(Path ofn, boolean laconic, int maxJustifications, long timeoutSec)` → spawns `rustdl justify --all --json [--laconic] <ofn> <query…>` — but the query args are passed by the generator; refactor `RustdlProcess` to accept an explicit arg list (a package-visible `runCommand`, already present) so the generator can pass `["justify","--all","--json", laconic?"--laconic":…, ofn, query…]`. Parse + `checkVersion`. Unit-test parse on a fixture.
+
+- [ ] **Step 3: `RustdlOfn.java`** — `static Set<OWLAxiom> parse(String ofnDocument)`: load the OFN document via `OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new StringDocumentSource(ofn, IRI…, new FunctionalSyntaxDocumentFormat(), null))` → `getAxioms(Imports.EXCLUDED)`. `static Set<OWLAxiom> verifiedAgainst(Set<OWLAxiom> parsed, OWLOntology source)` drops any axiom not `source.containsAxiom(ax, INCLUDED, …)` (anti-fabrication), logging a warning. Unit-test round-trip on a sample OFN doc.
+
+- [ ] **Step 4: `RustdlExplanationGenerator implements ExplanationGenerator<OWLAxiom>`** (mirror `KMExplanationGenerator`): `queryArguments(OWLAxiom)` maps a named entailment to rustdl `justify` query args — support `SubClassOf(named,named)`→`["subclass",sub,sup]`, `SubClassOf(X,owl:Nothing)`→`["unsat",X]`, `owl:Thing⊑owl:Nothing`/inconsistency→`["inconsistent"]`, `EquivalentClasses`/`DisjointClasses` (pairwise), `ClassAssertion(a,C)`→`["instance",a,C]`, `ObjectPropertyAssertion(a,p,b)`, `SubObjectPropertyOf`, `SameIndividual` — else `UnsupportedEntailmentException`. `getExplanations(entailment[,limit])` → serialize (`FlattenedOntology`), spawn justify (deadline + `progressMonitor.isCancelled()`), parse, `materialize`: for each `JustificationJson.ofn` → `RustdlOfn.parse` → `RustdlOfn.verifiedAgainst(source)` → `new Explanation<>(entailment, axioms)`; `progressMonitor.foundExplanation`. If `minimal==false`, `LOG.warning` (sound, possibly non-minimal). The unbounded `getExplanations(entailment)` caps at the config max and requires `enumeration_complete` (else the km-style "raise the cap" `ExplanationException`).
+
+- [ ] **Step 5: Factories + config + registration.** `RustdlExplanationGeneratorFactory implements ExplanationGeneratorFactory<OWLAxiom>` (four `createExplanationGenerator` overloads → the generator, `laconic=false`); `RustdlLaconicExplanationGeneratorFactory` (same, `laconic=true`, and a distinct `getExplanationGeneratorName()` e.g. "rustdl (laconic)"). `RustdlExplainConfiguration` (max justifications `rustdl.explain.max.justifications`/env default 8; timeout `rustdl.explain.timeout.seconds`/env default 600). `META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory` lists BOTH factory FQNs (one per line).
+
+- [ ] **Step 6: Tests** — entailment→query mapping (canned axioms incl. unsupported→exception); `RustdlOfn` round-trip + `.contains()` guard; `getExplanations` over a canned `JustifyJson` (inject via a seam, no subprocess) → correct `Explanation`s. `mvn -f protege/pom.xml test`. **Commit.**
+
+---
+
+### Task 4: Plugin — proof trees (liveontologies proof service)
+
+**Files:** new `RustdlProofService.java`, `RustdlProof.java` (puli `Proof`/`Inference` impl), `RustdlProcess.prove` + `ProveJson` POJO; `pom.xml` (optional proof deps); `plugin.xml` (proof-service extension); tests. Read ELK's `ElkProofService`/`ElkOwlProof` (`/tmp/…`) + `puli_{Proof,Inference,ProofStep}.java` as the template.
+
+- [ ] **Step 1: pom optional deps + imports.** Add `org.liveontologies:puli:0.1.0`, `:owlapi-proof:0.1.0`, `:protege-proof-explanation:0.1.0`, `io.github.liveontologies:protege-proof-justification:0.1.0` — all `<optional>true</optional>`. Bundle `Import-Package` adds `org.liveontologies.puli;version="[0.1,1)";resolution:=optional, org.liveontologies.owlapi.proof;version="[0.1,1)";resolution:=optional, org.liveontologies.protege.explanation.proof.service;version="[0.1,1)";resolution:=optional` (NOT embedded — mirror ELK). Confirm the bundle still resolves/builds without them present at compile via the Maven deps.
+
+- [ ] **Step 2: `ProveJson` POJO + `RustdlProcess.prove`** (`{schema_version, entailed, has_proof, proof:ProofNodeJson?, justification_fallback:String?}`, `ProofNodeJson{conclusion, rule, axioms:List<String>, premises:List<ProofNodeJson>}`). `prove(Path ofn, String sub, String sup, long timeoutSec)` → `rustdl prove --json <ofn> <sub> <sup>`. Parse + `checkVersion`. Unit-test parse.
+
+- [ ] **Step 3: `RustdlProof` — a `puli` `Proof<Inference<OWLAxiom>>`.** Build from `ProveJson`: recursively convert each `ProofNodeJson` into a puli `Inference<OWLAxiom>` (`getName()`=`rule`; `getConclusion()`=`RustdlOfn.parse(oneAxiom(conclusion))` single axiom; `getPremises()`= the child nodes' conclusions), indexed so `Proof.getInferences(conclusion)` returns the inference(s) deriving that conclusion. `has_proof=false` → a single synthetic one-step inference: conclusion = the entailed axiom, premises = the `justification_fallback` axioms, name = "justification". (Reuse `RustdlOfn.parse` for conclusion + `axioms`.)
+
+- [ ] **Step 4: `RustdlProofService extends ProofService`** (mirror `ElkProofService`): `hasProof(OWLAxiom)` = the axiom maps to a supported prove query (named `SubClassOf`, extend as feasible); `getProof(OWLAxiom)` → serialize + `rustdl prove --json` → `RustdlProof` wrapped in a `DynamicProof` (a minimal `DynamicProof` that re-runs on `dispose`/change is fine — mirror ELK's `DynamicOwlProof` shape; a non-incremental recompute-on-demand is acceptable for v1); `getExample`/`postProcess`/`dispose` per the base. Register in `plugin.xml`: `<extension point="org.liveontologies.protege.explanation.proof.service"><name value="rustdl ${project.version}"/><class value="…RustdlProofService"/></extension>`.
+
+- [ ] **Step 5: Tests** — `ProveJson` parse; `RustdlProof` from a canned proof-tree JSON → a `Proof` whose `getInferences(root)` yields the root inference with correct rule/premises; the `has_proof=false` fallback path → the synthetic justification inference. (These compile against the `optional` puli/proof deps, present at test time.) `mvn -f protege/pom.xml test`. **Commit.**
+
+---
+
+### Task 5: Docs + smoke IT + release
+
+**Files:** `RustdlSmokeIT.java` (extend), `docs/protege-plugin.md`, `CHANGELOG` (release step).
+
+- [ ] **Step 1: Extend `RustdlSmokeIT`** (real binary): on a tiny EL ontology entailing `A ⊑ C`, `new RustdlExplanationGeneratorFactory().createExplanationGenerator(o).getExplanations(SubClassOf(A,C))` → a non-empty `Explanation` whose axioms are source axioms; and (gated additionally on the proof-explanation API being on the classpath) `RustdlProofService.getProof(SubClassOf(A,C))` → a `Proof` with a non-trivial root inference. `assumeTrue` on a reachable binary. Build a binary + run `-Dtest='*Test,*IT' -Drustdl.bin=…`; confirm it RAN (not skipped) and passed.
+
+- [ ] **Step 2: `docs/protege-plugin.md`** — add an "Explaining inferences" section: the "?" Explanation dialog offers **rustdl** (minimal justifications) and **rustdl (laconic)**; the proof view shows rustdl step-level proofs (EL; degrades to a justification otherwise) **and requires Protégé's proof-explanation plugin installed** (state the prerequisite, like ELK). Note the config knobs. **Commit.**
+
+- [ ] **Step 3 (controller, after merge):** release — bump version (patch), CHANGELOG entry (justify/prove `--json` + the plugin explanation surface + the proof-plugin prerequisite), `cargo update -w`, commit, tag, push. The release workflow rebuilds the plugin jar with the explanation surface + refreshes `update.properties`.
+
+## Self-Review
+
+- **Spec coverage:** §3a justify/prove `--json` → Tasks 1–2; §3b(A) Explanation API + (B) laconic → Task 3; §3b(C) proof service → Task 4; §4 deps → Tasks 3–4 poms; §5 config → Task 3; §7 testing → each task + Task 5 smoke IT; §2 prerequisites/honesty → Tasks 4–5 + the `minimal`/`has_proof` flags. ✔
+- **Type consistency:** JSON field names identical across the Rust builders (Task 1–2) and the Java POJOs (Task 3–4): `status/enumeration_complete/minimal/laconic/justifications[].ofn`; `entailed/has_proof/proof/justification_fallback`, `ProofNodeJson{conclusion,rule,axioms,premises}`. Dep versions match the references (owlexplanation 2.0.1, telemetry 2.0.0, puli/owlapi-proof/proof-explanation/proof-justification 0.1.0).
+- **Known risks flagged in-task:** the `DerivedFact`/`AxiomRef`→OFN rendering (Task 2 Step 1 note) and the proof-explanation optional-dep resolution (Task 4 Step 1) are the two load-bearing spots; the plan directs the implementer to the exact reference code (`render_proof_with_defs`, ELK's manifest) rather than guessing.

--- a/docs/superpowers/specs/2026-07-26-explanation-surface-design.md
+++ b/docs/superpowers/specs/2026-07-26-explanation-surface-design.md
@@ -1,0 +1,234 @@
+# Design: rustdl explanation surface in Protégé (justify / laconic / proofs)
+
+**Date:** 2026-07-26
+**Status:** design approved (brainstorming) → pending spec review → implementation plan.
+**Author:** Claude + Michel, session: rdl-m-plugin.
+
+## 1. Goal
+
+Surface rustdl's explanation capabilities in Protégé — the v1.x follow-up the
+plugin design (`2026-07-24-protege-plugin-design.md` §2) explicitly deferred.
+Three surfaces, all driven by the existing reasoner engine:
+
+- **Justifications** — minimal responsible-axiom sets for any entailed axiom,
+  shown in Protégé's standard "?" **Explanation** dialog (`rustdl justify`).
+- **Laconic justifications** — the same, narrowed to the responsible *fragment*
+  of each axiom (`rustdl justify --laconic`), offered as a distinct choice.
+- **Proof trees** — rustdl's step-level DL proof (`rustdl prove`) in Protégé's
+  proof view (the ELK-style proof extension).
+
+Reference precedents (mapped in research): **km** for the OWL Explanation API
+(justifications); **ELK** for the liveontologies proof service (proofs).
+
+## 2. Non-goals (v1)
+
+- **Repair/diagnose UI** — rustdl has `repair`/`diagnose`; surfacing them is a
+  later follow-up, not this spec.
+- **Bundling the proof-explanation plugin** — the proof view relies on Protégé's
+  separately-installed proof-explanation plugin (which *defines* the proof
+  extension point). We import its packages `resolution:=optional` (like ELK), so
+  the rustdl plugin loads fine without it; the proof service simply won't appear.
+  We document the prerequisite; we do not vendor it.
+- **Minimality on SROIQ** — rustdl justifications are subset-minimal on EL/Horn,
+  guaranteed-*entailing* but possibly non-minimal on SROIQ. We surface that
+  honestly; we do not attempt full SROIQ minimization here.
+
+## 3. Architecture — two parts
+
+### 3a. rustdl CLI `--json` (the machine bridge)
+
+Two subcommands gain `--json`, matching the existing `schema_version: 1` contract
+(`docs/json-schema.md`), golden-tested on the rustdl side.
+
+**`justify [--all] [--laconic] --json <file> <query…>`** — mirrors km's report
+shape so the Java side mirrors km's parsing:
+```json
+{ "schema_version": 1,
+  "status": "entailed" | "not-entailed",
+  "enumeration_complete": true,        // all justifications enumerated (not capped)
+  "minimal": true,                     // subset-minimal (EL/Horn) vs guaranteed-entailing (SROIQ)
+  "laconic": false,
+  "prefix_declarations": "Prefix(:=<…>)\n…",   // OFN prefixes for round-trip parsing
+  "justifications": [ { "axioms": ["SubClassOf(:A :B)", "…"] }, … ] }
+```
+- `justify` (default) → one justification; `--all` → all (up to an internal cap;
+  `enumeration_complete=false` when capped). `--laconic` → laconic justifications
+  (`laconic=true`), via `owl_dl_reasoner::{find_laconic_justification,
+  find_all_laconic_justifications}`.
+- Query forms are the existing `justify` CLI grammar (`subclass S T`,
+  `unsat C`, `inconsistent`, `instance I C`, `equivalent`, `disjoint`,
+  property/individual queries — `owl_dl_reasoner::justify::parse_query`).
+- Axioms are **OWL Functional Syntax** fragments (from horned-owl rendering).
+  `minimal` = `Justification.minimal_guaranteed`. `not-entailed` ⇒ empty
+  `justifications`.
+
+**`prove --json <file> <sub> <sup>`** — the EL proof tree, or a justification
+fallback outside EL:
+```json
+{ "schema_version": 1, "entailed": true, "has_proof": true,
+  "prefix_declarations": "…",
+  "proof": {                                       // null when has_proof=false
+    "conclusion": "SubClassOf(:A :C)",             // OFN of the derived axiom
+    "rule": "CR5",                                 // ElRule name
+    "axioms": ["SubClassOf(:A :B)", …],            // source axioms used at this step (OFN)
+    "premises": [ { … recursive node … }, … ] },
+  "justification_fallback": ["SubClassOf(…)", …] }  // null when has_proof=true
+```
+- From `owl_dl_reasoner::prove_entailment_rcstr` → `ProveEntailmentResult`:
+  `SaturatorProof` → the `ProofNode` tree (recursive:
+  `conclusion`/`rule`/`axiom_refs`/`premises`); `JustificationFallback` →
+  `justification_fallback`; `NotEntailed` → `entailed=false`.
+- `ProofNode.conclusion` (a `DerivedFact`) and `axiom_refs` (indices into the
+  ontology's logical axioms) render to OFN via the same machinery `render_proof`
+  uses; the plugin re-parses them with OWLAPI.
+
+Both: one JSON object on **stdout**, diagnostics to **stderr**, fail-closed
+(non-zero exit / parse error / `schema_version` mismatch → throw on the Java
+side). Additive to the existing text output (the text `justify`/`prove` paths
+are unchanged; `--json` short-circuits before them).
+
+### 3b. Plugin integrations (`protege/` module)
+
+Three components, each a focused unit; all reuse the existing `RustdlBinary`
+(binary resolution) and `FlattenedOntology` (imports-closure → OFN) + a new
+JSON-parse layer.
+
+**(A) `RustdlExplanationGeneratorFactory` / `RustdlExplanationGenerator`** —
+`implements org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory<OWLAxiom>`
+/ `ExplanationGenerator<OWLAxiom>` (owlexplanation 2.0.1). Mirrors km's
+`KMExplanationGeneratorFactory`/`Generator`:
+- `getExplanations(OWLAxiom entailment[, int limit])` → `queryArguments(entailment)`
+  maps a **named** entailed axiom to a rustdl `justify` query. Support (superset
+  of km): `SubClassOf(named,named)` → `["subclass",sub,sup]`;
+  `SubClassOf(X, owl:Nothing)` → `["unsat",X]`; `owl:Thing ⊑ owl:Nothing` →
+  `["inconsistent"]`; `EquivalentClasses`/`DisjointClasses` (pairwise);
+  `ClassAssertion(a,C)` → `["instance",a,C]`; `ObjectPropertyAssertion`;
+  `SubObjectPropertyOf`; `SameIndividual`. Anonymous/unsupported →
+  `UnsupportedEntailmentException`.
+- `invoke` → serialise imports closure (`FlattenedOntology`) → spawn
+  `rustdl justify [--all] [--laconic] --json <ofn> <query…>` (deadline + cancel
+  via the progress monitor, like km) → parse JSON → `materialize`: re-parse each
+  functional-syntax axiom via OWLAPI (`OWLManager…loadOntologyFromOntologyDocument`
+  over `Ontology(<prefixes><fragment>)`), assert it `.contains()` in
+  `ontology.getAxioms(Imports.INCLUDED)` (anti-fabrication), build
+  `new Explanation<>(entailment, Set<OWLAxiom>)`; `progressMonitor.foundExplanation`.
+- Honesty: when `minimal=false`, the explanations are still sound (real
+  responsible axioms) but possibly non-minimal — logged; not falsely certified.
+- `META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory`
+  names the factory (the ServiceLoader hook the "?" dialog uses).
+
+**(B) Laconic** — the same generator with `--laconic`, exposed as a **second,
+distinctly-named** explanation service so the user picks it in the dialog. Two
+clean routes (plan picks one): (i) a second `ExplanationGeneratorFactory`
+subclass whose generator sets `laconic=true`; or (ii) km-style native
+`org.protege.editor.owl.explanation` `ExplanationService`s ("rustdl
+justifications" / "rustdl laconic justifications") giving named entries + a
+custom panel. Recommendation: **(i)** for v1 (least UI surface; the OWL
+Explanation API already lists factories by name), revisit the native panel if a
+richer UX is wanted.
+
+**(C) `RustdlProofService extends org.liveontologies.protege.explanation.proof.service.ProofService`**
+— mirrors ELK's `ElkProofService`:
+- `hasProof(OWLAxiom)` = the axiom maps to a supported `prove` query (named
+  `SubClassOf`, primarily; extendable).
+- `getProof(OWLAxiom) → DynamicProof<Inference<? extends OWLAxiom>>` built from
+  `rustdl prove --json`: each JSON proof node → a `puli` `Inference<OWLAxiom>`
+  (`getName()` = `rule`, `getConclusion()` = the re-parsed conclusion axiom,
+  `getPremises()` = the child conclusions), assembled into a `Proof<Inference>`
+  (`getInferences(conclusion)` lookup). When `has_proof=false`, expose the
+  `justification_fallback` as a single one-step inference (conclusion ← the
+  fallback axioms) so the view still shows *something* sound.
+- Registered on `org.liveontologies.protege.explanation.proof.service`. The puli
+  / owlapi-proof / protege-proof-explanation / protege-proof-justification
+  packages are **optional OSGi imports** (`resolution:=optional`, version
+  `[0.1,1)`), compiled against as `provided`/`optional` Maven deps — **not
+  embedded** (mirrors ELK exactly). If Protégé's proof-explanation plugin is
+  absent, the rustdl bundle still resolves; the proof service is simply inactive.
+
+## 4. Dependencies (mirror the two references precisely)
+
+- **Justify (embedded, like km):** `net.sourceforge.owlapi:owlexplanation:2.0.1`
+  + `net.sourceforge.owlapi:telemetry:2.0.0`, embedded as nested jars
+  (`Embed-Dependency … inline=false`), with the km exclusions
+  (owlexplanation excludes owlapi-osgidistribution + telemetry; telemetry
+  excludes the owlapi distributions + slf4j). gson stays embedded (existing).
+- **Proofs (optional imports, like ELK — NOT embedded):**
+  `org.liveontologies:puli:0.1.0`, `org.liveontologies:owlapi-proof:0.1.0`,
+  `org.liveontologies:protege-proof-explanation:0.1.0`,
+  `io.github.liveontologies:protege-proof-justification:0.1.0` — all Maven
+  `provided`/`optional`; OSGi `Import-Package … resolution:=optional; version="[0.1,1)"`.
+- Existing: owlapi-distribution 4.5.29 (provided), protege-editor-owl 5.6.6
+  (provided). Bundle manifest: `Export-Package` re-exports
+  `org.semanticweb.owl.explanation.api` (+ telemetry) so the embedded API is
+  visible; `Import-Package` excludes re-importing the embedded telemetry.
+
+## 5. Config (system property → env → default), mirroring km
+
+- `rustdl.explain.max.justifications` / `RUSTDL_EXPLAIN_MAX_JUSTIFICATIONS` —
+  cap for the unbounded `getExplanations` (default 8).
+- `rustdl.explain.timeout.seconds` / `RUSTDL_EXPLAIN_TIMEOUT_SECONDS` — per-call
+  deadline (default = the existing `rustdl.timeout.seconds`, 600).
+- Reuses the existing `rustdl.bin` / `RUSTDL_BIN` binary resolution.
+
+## 6. Error handling (OWLReasoner/Explanation contracts)
+
+- Binary missing / non-zero exit / timeout / JSON parse / `schema_version`
+  mismatch → `ExplanationException` (justify) / return no proof (proofs), with
+  captured stderr; never hang (deadline + cancel).
+- Unsupported/anonymous entailment → `UnsupportedEntailmentException`
+  (justify) / `hasProof=false` (proofs) — never a silent empty that reads as
+  "no explanation exists".
+- `status:"not-entailed"` (shouldn't happen for a Protégé-derived axiom, but) →
+  no explanations, logged.
+- An axiom that fails the source-`.contains()` check is dropped with a warning
+  (anti-fabrication) — a sound guard, matching km.
+
+## 7. Testing
+
+- **rustdl side:** golden JSON tests for `justify --json` (entailed/not-entailed,
+  `--all`, `--laconic`, `minimal` true/false across EL vs SROIQ fixtures) and
+  `prove --json` (EL proof tree shape + the non-EL justification-fallback path).
+  Schema-version assertion. Reuse the oracle discipline where a HermiT/ROBOT
+  justification oracle is available.
+- **Java side:** unit-test the JSON parse layer (fixtures); the
+  entailment→query mapping (canned axioms → query args, incl. the unsupported
+  cases); the functional-syntax re-parse + `.contains()` guard; the proof-node →
+  puli `Inference` mapping (canned proof JSON → tree). A registration test
+  (`META-INF/services` + plugin.xml proof-service extension present).
+- **Integration smoke IT (real binary):** on a tiny EL ontology entailing
+  `A ⊑ C`, drive `RustdlExplanationGenerator.getExplanations(SubClassOf(A,C))`
+  → non-empty justification of source axioms; and `RustdlProofService.getProof`
+  → a non-trivial proof tree. `assumeTrue`-gated on a reachable binary; the proof
+  test additionally `assumeTrue`-gated on the proof-explanation API being on the
+  classpath.
+
+## 8. Scope summary (v1)
+
+**Wired:** justifications (all supported entailment types) + laconic in the "?"
+Explanation dialog; step-level proof trees (EL) with a justification fallback in
+the proof view. **Honest:** minimality surfaced (EL-minimal vs SROIQ-guaranteed);
+proofs EL-only with graceful fallback; proof view requires Protégé's
+proof-explanation plugin. **Deferred:** repair/diagnose UI; native custom
+explanation panel; SROIQ minimization.
+
+## 9. Ships as
+
+One tag: the rustdl `justify`/`prove --json` (new rustdl version) + the plugin
+explanation jar (built by the existing `release-cli.yml` `build-plugin` job).
+Patch cadence per prior releases. The plan breaks execution into SDD tasks:
+(1) `justify --json`, (2) `prove --json`, (3) plugin justify (Explanation API +
+laconic), (4) plugin proofs (proof service + deps), (5) docs + smoke IT + release.
+
+## 10. Risks / open items for the plan
+
+- **Proof-explanation plugin availability** in the user's Protégé (optional; the
+  plan documents installing it; the smoke IT gates on it).
+- **Functional-syntax round-trip fidelity** — every axiom rustdl emits in a
+  justification must re-parse via OWLAPI to a `.contains()`-equal axiom (prefix
+  handling; blank nodes in property-assertion justifications). Plan includes a
+  round-trip test on a feature-rich justification.
+- **`prove` conclusion/axiom rendering to OFN** — `DerivedFact`/`AxiomRef` must
+  render to parseable OFN axioms; the plan verifies against `render_proof`.
+- **owlexplanation/telemetry OSGi resolution** in stock Protégé 5.6.9 — km's
+  exact pins + embedding are the mitigation; the antrun jar-content check
+  (extended to the two new embedded jars) guards it.

--- a/protege/pom.xml
+++ b/protege/pom.xml
@@ -19,6 +19,8 @@
     <owlapi.version>4.5.29</owlapi.version>
     <protege.version>5.6.6</protege.version>
     <gson.version>2.11.0</gson.version>
+    <owlexplanation.version>2.0.1</owlexplanation.version>
+    <telemetry.version>2.0.0</telemetry.version>
   </properties>
 
   <dependencies>
@@ -38,6 +40,46 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
+    </dependency>
+    <!-- OWL Explanation API ("?" dialog): the standard OWLAPI explanation SPI.
+         Excludes its transitive owlapi-osgidistribution (we already provide
+         owlapi-distribution) and telemetry (declared explicitly below so its
+         own transitives can be pruned too). -->
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlexplanation</artifactId>
+      <version>${owlexplanation.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-osgidistribution</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>telemetry</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Required at runtime by owlexplanation; embedded so the bundle resolves
+         in a stock Protégé installation. -->
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>telemetry</artifactId>
+      <version>${telemetry.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-osgidistribution</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -80,8 +122,12 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
             <Bundle-License>Apache-2.0</Bundle-License>
             <Bundle-Activator>org.protege.editor.core.plugin.DefaultPluginActivator</Bundle-Activator>
-            <Export-Package>com.github.maastrichtu_ids.rustdl.protege;version="${project.version}"</Export-Package>
+            <Export-Package>
+              com.github.maastrichtu_ids.rustdl.protege;version="${project.version}",
+              org.semanticweb.owl.explanation.api;version="${owlexplanation.version}"
+            </Export-Package>
             <Import-Package>
+              !org.semanticweb.owl.explanation.telemetry,
               sun.misc;resolution:=optional,
               org.protege.editor.core.*,
               org.protege.editor.owl.*,
@@ -89,7 +135,7 @@
               org.osgi.framework,
               *
             </Import-Package>
-            <Embed-Dependency>gson;scope=compile;inline=false</Embed-Dependency>
+            <Embed-Dependency>gson|owlexplanation|telemetry;scope=compile;inline=false</Embed-Dependency>
             <Embed-Transitive>false</Embed-Transitive>
             <Include-Resource>{maven-resources}, plugin.xml=${project.build.outputDirectory}/plugin.xml</Include-Resource>
             <!-- Protégé auto-update: the built jar advertises where to find the
@@ -121,6 +167,15 @@
                       <fileset dir="${project.build.directory}/jar-check" includes="gson*.jar"/>
                     </resourcecount>
                   </condition>
+                </fail>
+                <fail message="owlexplanation not embedded (expected a nested owlexplanation-${owlexplanation.version}.jar)">
+                  <condition><not><available file="${project.build.directory}/jar-check/owlexplanation-${owlexplanation.version}.jar"/></not></condition>
+                </fail>
+                <fail message="telemetry not embedded (expected a nested telemetry-${telemetry.version}.jar)">
+                  <condition><not><available file="${project.build.directory}/jar-check/telemetry-${telemetry.version}.jar"/></not></condition>
+                </fail>
+                <fail message="ExplanationGeneratorFactory services file missing from jar">
+                  <condition><not><available file="${project.build.directory}/jar-check/META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory"/></not></condition>
                 </fail>
               </target>
             </configuration>

--- a/protege/pom.xml
+++ b/protege/pom.xml
@@ -21,6 +21,10 @@
     <gson.version>2.11.0</gson.version>
     <owlexplanation.version>2.0.1</owlexplanation.version>
     <telemetry.version>2.0.0</telemetry.version>
+    <puli.version>0.1.0</puli.version>
+    <owlapi-proof.version>0.1.0</owlapi-proof.version>
+    <protege-proof-explanation.version>0.1.0</protege-proof-explanation.version>
+    <protege-proof-justification.version>0.1.0</protege-proof-justification.version>
   </properties>
 
   <dependencies>
@@ -81,6 +85,40 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Proof-service surface (Task 4): the liveontologies proof plugin's own extension point
+         (org.liveontologies.protege.explanation.proof.service.ProofService) and the puli
+         Proof/Inference types it uses. Declared `optional=true` and (in the bundle instructions
+         below) imported with `resolution:=optional` rather than embedded, mirroring ELK's own
+         protege plugin (`/tmp/elk_protege_pom.xml`): Protégé's separately-installed
+         liveontologies proof-explanation plugin supplies these at runtime, so this plugin must
+         build and its bundle must still resolve when they are ABSENT at runtime (a stock
+         Protégé install without that companion plugin). They are on this module's own
+         compile/test classpath regardless — `optional` only affects what a downstream consumer
+         of *this* artifact would transitively pull in, not what maven-bundle-plugin sees here. -->
+    <dependency>
+      <groupId>org.liveontologies</groupId>
+      <artifactId>puli</artifactId>
+      <version>${puli.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.liveontologies</groupId>
+      <artifactId>owlapi-proof</artifactId>
+      <version>${owlapi-proof.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.liveontologies</groupId>
+      <artifactId>protege-proof-explanation</artifactId>
+      <version>${protege-proof-explanation.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.github.liveontologies</groupId>
+      <artifactId>protege-proof-justification</artifactId>
+      <version>${protege-proof-justification.version}</version>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -129,12 +167,22 @@
             <Import-Package>
               !org.semanticweb.owl.explanation.telemetry,
               sun.misc;resolution:=optional,
+              org.liveontologies.puli;version="[0.1,1)";resolution:=optional,
+              org.liveontologies.owlapi.proof;version="[0.1,1)";resolution:=optional,
+              org.liveontologies.protege.explanation.proof.service;version="[0.1,1)";resolution:=optional,
               org.protege.editor.core.*,
               org.protege.editor.owl.*,
               org.semanticweb.owlapi.*,
               org.osgi.framework,
               *
             </Import-Package>
+            <!-- Deliberately NOT embedded (unlike gson/owlexplanation/telemetry above): the
+                 puli/owlapi-proof/protege-proof-explanation/protege-proof-justification jars
+                 back the proof-service extension (RustdlProofService) and are declared
+                 `optional=true` above, plus imported `resolution:=optional` immediately above,
+                 so this bundle resolves in a stock Protégé install that lacks the companion
+                 liveontologies proof-explanation plugin (the reasoner + explanation-dialog
+                 features stay fully functional; only the proof-tree view is then unavailable). -->
             <Embed-Dependency>gson|owlexplanation|telemetry;scope=compile;inline=false</Embed-Dependency>
             <Embed-Transitive>false</Embed-Transitive>
             <Include-Resource>{maven-resources}, plugin.xml=${project.build.outputDirectory}/plugin.xml</Include-Resource>
@@ -176,6 +224,47 @@
                 </fail>
                 <fail message="ExplanationGeneratorFactory services file missing from jar">
                   <condition><not><available file="${project.build.directory}/jar-check/META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory"/></not></condition>
+                </fail>
+                <!-- Task 4: the proof-service optional deps (puli/owlapi-proof/
+                     protege-proof-explanation/protege-proof-justification) must NOT be embedded:
+                     they are Import-Package resolution:=optional, supplied at runtime by
+                     Protégé's separately-installed liveontologies proof-explanation plugin. A
+                     nested jar here would mean they got swept into Embed-Dependency by mistake. -->
+                <fail message="puli must NOT be embedded (Import-Package resolution:=optional; runtime-supplied by the liveontologies proof-explanation plugin)">
+                  <condition>
+                    <resourcecount when="greater" count="0">
+                      <fileset dir="${project.build.directory}/jar-check" includes="puli-*.jar"/>
+                    </resourcecount>
+                  </condition>
+                </fail>
+                <fail message="owlapi-proof must NOT be embedded (Import-Package resolution:=optional; runtime-supplied by the liveontologies proof-explanation plugin)">
+                  <condition>
+                    <resourcecount when="greater" count="0">
+                      <fileset dir="${project.build.directory}/jar-check" includes="owlapi-proof-*.jar"/>
+                    </resourcecount>
+                  </condition>
+                </fail>
+                <fail message="protege-proof-explanation must NOT be embedded (Import-Package resolution:=optional; runtime-supplied by the liveontologies proof-explanation plugin)">
+                  <condition>
+                    <resourcecount when="greater" count="0">
+                      <fileset dir="${project.build.directory}/jar-check" includes="protege-proof-explanation-*.jar"/>
+                    </resourcecount>
+                  </condition>
+                </fail>
+                <fail message="protege-proof-justification must NOT be embedded (Import-Package resolution:=optional; runtime-supplied by the liveontologies proof-explanation plugin)">
+                  <condition>
+                    <resourcecount when="greater" count="0">
+                      <fileset dir="${project.build.directory}/jar-check" includes="protege-proof-justification-*.jar"/>
+                    </resourcecount>
+                  </condition>
+                </fail>
+                <fail message="rustdl proof-service extension missing from plugin.xml">
+                  <condition>
+                    <not>
+                      <resourcecontains resource="${project.build.directory}/jar-check/plugin.xml"
+                                         substring="org.liveontologies.protege.explanation.proof.service"/>
+                    </not>
+                  </condition>
                 </fail>
               </target>
             </configuration>

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplainConfiguration.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplainConfiguration.java
@@ -1,0 +1,76 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+/** Immutable process and safety bounds for the rustdl Explanation-API adapter. */
+public final class RustdlExplainConfiguration {
+
+    public static final int DEFAULT_MAX_JUSTIFICATIONS = 8;
+    public static final long DEFAULT_TIMEOUT_SECONDS = 600L;
+
+    private final long timeoutSeconds;
+    private final int maxJustifications;
+
+    public RustdlExplainConfiguration(long timeoutSeconds, int maxJustifications) {
+        this.timeoutSeconds = requirePositive(timeoutSeconds, "timeoutSeconds");
+        this.maxJustifications = requirePositive(maxJustifications, "maxJustifications");
+    }
+
+    public static RustdlExplainConfiguration fromSystemProperties() {
+        return new RustdlExplainConfiguration(
+            longSetting(
+                "rustdl.explain.timeout.seconds",
+                "RUSTDL_EXPLAIN_TIMEOUT_SECONDS",
+                DEFAULT_TIMEOUT_SECONDS),
+            intSetting(
+                "rustdl.explain.max.justifications",
+                "RUSTDL_EXPLAIN_MAX_JUSTIFICATIONS",
+                DEFAULT_MAX_JUSTIFICATIONS));
+    }
+
+    public long getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public int getMaxJustifications() {
+        return maxJustifications;
+    }
+
+    private static String setting(String property, String environment, String fallback) {
+        String value = System.getProperty(property);
+        if (value == null || value.isEmpty()) {
+            value = System.getenv(environment);
+        }
+        return value == null || value.isEmpty() ? fallback : value;
+    }
+
+    private static int intSetting(String property, String environment, int fallback) {
+        String value = setting(property, environment, Integer.toString(fallback));
+        try {
+            return requirePositive(Integer.parseInt(value), property);
+        } catch (NumberFormatException error) {
+            throw new IllegalArgumentException(property + " must be an integer", error);
+        }
+    }
+
+    private static long longSetting(String property, String environment, long fallback) {
+        String value = setting(property, environment, Long.toString(fallback));
+        try {
+            return requirePositive(Long.parseLong(value), property);
+        } catch (NumberFormatException error) {
+            throw new IllegalArgumentException(property + " must be an integer", error);
+        }
+    }
+
+    private static int requirePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than zero");
+        }
+        return value;
+    }
+
+    private static long requirePositive(long value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than zero");
+        }
+        return value;
+    }
+}

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGenerator.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGenerator.java
@@ -43,7 +43,10 @@ import java.util.logging.Logger;
  * {@link OWLSameIndividualAxiom}. Anything else throws {@link UnsupportedEntailmentException}.
  * Every returned {@link Explanation} contains only axioms verified present in the source
  * ontology's imports closure ({@link RustdlOfn#verifiedAgainst}) — rustdl cannot fabricate
- * an axiom into a displayed justification.</p>
+ * an axiom into a displayed justification. That check is fail-hard: a justification containing
+ * even one axiom absent from the source is rejected in full (never partially surfaced), and —
+ * mirroring km's actual behavior — the resulting {@link ExplanationException} aborts the whole
+ * {@link #getExplanations} call, not just that one justification.</p>
  */
 public final class RustdlExplanationGenerator implements ExplanationGenerator<OWLAxiom> {
     private static final Logger LOG = Logger.getLogger(RustdlExplanationGenerator.class.getName());
@@ -115,8 +118,15 @@ public final class RustdlExplanationGenerator implements ExplanationGenerator<OW
 
             RustdlJson.JustifyJson report;
             try {
+                // Passing progressMonitor::isCancelled makes the wait for the rustdl subprocess
+                // itself responsive to Cancel: RustdlProcess polls it at ~100ms granularity
+                // (mirrors km's KMExplanationGenerator.waitFor) instead of blocking until the
+                // process exits or the full configured timeout elapses.
                 report = RustdlProcess.justify(
-                    source, laconic, limit, configuration.getTimeoutSeconds(), query);
+                    source, laconic, limit, configuration.getTimeoutSeconds(), query,
+                    progressMonitor::isCancelled);
+            } catch (RustdlProcess.CancelledException error) {
+                throw new ExplanationGeneratorInterruptedException();
             } catch (IOException error) {
                 throw new ExplanationException(
                     "rustdl justify failed or timed out: " + error.getMessage(), error);
@@ -158,11 +168,16 @@ public final class RustdlExplanationGenerator implements ExplanationGenerator<OW
                 throw new ExplanationException("rustdl returned a null justification document");
             }
             Set<OWLAxiom> parsed = RustdlOfn.parse(justification.ofn);
+            // Fail-hard: verifiedAgainst throws ExplanationException on the FIRST axiom it finds
+            // absent from the source ontology, rejecting this justification whole rather than
+            // returning a partial (possibly insufficient-to-entail) subset. Nothing here catches
+            // that per-justification, so it propagates out of this whole materialize() call and
+            // aborts every OTHER justification in `report` too -- km's actual whole-attempt-abort
+            // choice (see RustdlOfn.verifiedAgainst javadoc), not a per-justification skip.
             Set<OWLAxiom> verified = RustdlOfn.verifiedAgainst(parsed, ontology);
             if (verified.isEmpty()) {
                 throw new ExplanationException(
-                    "rustdl justification contained no axioms verifiable against the source "
-                        + "ontology (possible fabrication): " + justification.ofn);
+                    "rustdl justification contained no axioms: " + justification.ofn);
             }
             Explanation<OWLAxiom> explanation = new Explanation<>(entailment, verified);
             explanations.add(explanation);

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGenerator.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGenerator.java
@@ -41,12 +41,23 @@ import java.util.logging.Logger;
  * operands), {@link OWLClassAssertionAxiom}, non-negated {@link OWLObjectPropertyAssertionAxiom},
  * named-property {@link OWLSubObjectPropertyOfAxiom}, and (exactly two named individuals)
  * {@link OWLSameIndividualAxiom}. Anything else throws {@link UnsupportedEntailmentException}.
- * Every returned {@link Explanation} contains only axioms verified present in the source
- * ontology's imports closure ({@link RustdlOfn#verifiedAgainst}) — rustdl cannot fabricate
- * an axiom into a displayed justification. That check is fail-hard: a justification containing
- * even one axiom absent from the source is rejected in full (never partially surfaced), and —
- * mirroring km's actual behavior — the resulting {@link ExplanationException} aborts the whole
- * {@link #getExplanations} call, not just that one justification.</p>
+ * Every returned {@link Explanation} is anti-fabrication-protected, but the two supported modes
+ * enforce that guarantee differently:
+ * <ul>
+ *   <li><b>Minimal (non-laconic):</b> every axiom is verified LITERALLY present in the source
+ *   ontology's imports closure ({@link RustdlOfn#verifiedAgainst}) — rustdl cannot fabricate an
+ *   axiom into a displayed justification. That check is fail-hard: a justification containing
+ *   even one axiom absent from the source is rejected in full (never partially surfaced), and —
+ *   mirroring km's actual behavior — the resulting {@link ExplanationException} aborts the whole
+ *   {@link #getExplanations} call, not just that one justification.</li>
+ *   <li><b>Laconic:</b> each justification axiom is, by design, a WEAKENED FRAGMENT of an
+ *   original source axiom (rustdl's {@code justify --laconic}), not the source axiom itself, so
+ *   literal source-membership is the wrong check and is deliberately NOT run on this path — see
+ *   {@link #materialize} for why. The anti-fabrication guarantee instead rests on rustdl's laconic
+ *   weakening being sound by construction (every fragment is provably entailed by an original
+ *   source axiom).</li>
+ * </ul>
+ * </p>
  */
 public final class RustdlExplanationGenerator implements ExplanationGenerator<OWLAxiom> {
     private static final Logger LOG = Logger.getLogger(RustdlExplanationGenerator.class.getName());
@@ -168,13 +179,41 @@ public final class RustdlExplanationGenerator implements ExplanationGenerator<OW
                 throw new ExplanationException("rustdl returned a null justification document");
             }
             Set<OWLAxiom> parsed = RustdlOfn.parse(justification.ofn);
-            // Fail-hard: verifiedAgainst throws ExplanationException on the FIRST axiom it finds
-            // absent from the source ontology, rejecting this justification whole rather than
-            // returning a partial (possibly insufficient-to-entail) subset. Nothing here catches
-            // that per-justification, so it propagates out of this whole materialize() call and
-            // aborts every OTHER justification in `report` too -- km's actual whole-attempt-abort
-            // choice (see RustdlOfn.verifiedAgainst javadoc), not a per-justification skip.
-            Set<OWLAxiom> verified = RustdlOfn.verifiedAgainst(parsed, ontology);
+            Set<OWLAxiom> verified;
+            if (laconic) {
+                // Laconic justifications are, BY DESIGN, WEAKENED FRAGMENTS of a source axiom
+                // (rustdl `justify --laconic`: RHS-conjunction / existential-filler /
+                // equivalence / pairwise-disjoint weakening, re-minimized via QuickXplain -- see
+                // docs/superpowers/specs/2026-06-21-laconic-justifications-design.md). Each
+                // fragment is ENTAILED BY an original source axiom, not literally EQUAL to one
+                // (e.g. source `SubClassOf(:A, ObjectIntersectionOf(:B,:C))` laconic-weakens to
+                // `SubClassOf(:A,:B)`, which is genuinely absent from the source). So
+                // RustdlOfn#verifiedAgainst's literal `source.containsAxiom(...)` check is the
+                // WRONG invariant here: running it would reject every genuinely-weakened laconic
+                // justification as "fabrication" and abort the whole request -- the exact bug
+                // this comment guards a future reader from re-introducing by "restoring" the
+                // guard. We deliberately do NOT call verifiedAgainst on this path. The
+                // anti-fabrication INTENT still holds end-to-end for laconic output: it now rests
+                // on rustdl's laconic weakening being SOUND BY CONSTRUCTION (every emitted
+                // fragment is provably entailed by an original source axiom) rather than on
+                // client-side literal-membership verification.
+                LOG.fine("Skipping literal source-membership verification for a laconic "
+                    + "justification; soundness rests on rustdl's laconic weakening being sound "
+                    + "by construction (each fragment is entailed by an original source axiom), "
+                    + "not on literal membership: " + justification.ofn);
+                verified = parsed;
+            } else {
+                // Fail-hard: verifiedAgainst throws ExplanationException on the FIRST axiom it
+                // finds absent from the source ontology, rejecting this justification whole
+                // rather than returning a partial (possibly insufficient-to-entail) subset.
+                // Nothing here catches that per-justification, so it propagates out of this
+                // whole materialize() call and aborts every OTHER justification in `report` too
+                // -- km's actual whole-attempt-abort choice (see RustdlOfn.verifiedAgainst
+                // javadoc), not a per-justification skip. Minimal justifications ARE genuine
+                // source axioms, so literal-membership verification is the correct anti-
+                // fabrication defense here and must stay fail-hard.
+                verified = RustdlOfn.verifiedAgainst(parsed, ontology);
+            }
             if (verified.isEmpty()) {
                 throw new ExplanationException(
                     "rustdl justification contained no axioms: " + justification.ofn);

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGenerator.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGenerator.java
@@ -1,0 +1,345 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.semanticweb.owl.explanation.api.Explanation;
+import org.semanticweb.owl.explanation.api.ExplanationException;
+import org.semanticweb.owl.explanation.api.ExplanationGenerator;
+import org.semanticweb.owl.explanation.api.ExplanationGeneratorInterruptedException;
+import org.semanticweb.owl.explanation.api.ExplanationProgressMonitor;
+import org.semanticweb.owl.explanation.api.UnsupportedEntailmentException;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLClassExpression;
+import org.semanticweb.owlapi.model.OWLDisjointClassesAxiom;
+import org.semanticweb.owlapi.model.OWLEquivalentClassesAxiom;
+import org.semanticweb.owlapi.model.OWLIndividual;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLObjectPropertyAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLSameIndividualAxiom;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * OWL Explanation API adapter over {@code rustdl justify --json}.
+ *
+ * <p>Supported entailments: named-class {@link OWLSubClassOfAxiom} (incl. the
+ * {@code owl:Nothing}-superclass unsatisfiability shorthand and the
+ * {@code owl:Thing SubClassOf owl:Nothing} inconsistency marker), named-class
+ * {@link OWLEquivalentClassesAxiom}/{@link OWLDisjointClassesAxiom} (exactly two named
+ * operands), {@link OWLClassAssertionAxiom}, non-negated {@link OWLObjectPropertyAssertionAxiom},
+ * named-property {@link OWLSubObjectPropertyOfAxiom}, and (exactly two named individuals)
+ * {@link OWLSameIndividualAxiom}. Anything else throws {@link UnsupportedEntailmentException}.
+ * Every returned {@link Explanation} contains only axioms verified present in the source
+ * ontology's imports closure ({@link RustdlOfn#verifiedAgainst}) — rustdl cannot fabricate
+ * an axiom into a displayed justification.</p>
+ */
+public final class RustdlExplanationGenerator implements ExplanationGenerator<OWLAxiom> {
+    private static final Logger LOG = Logger.getLogger(RustdlExplanationGenerator.class.getName());
+
+    private final OWLOntology ontology;
+    private final ExplanationProgressMonitor<OWLAxiom> progressMonitor;
+    private final RustdlExplainConfiguration configuration;
+    private final boolean laconic;
+
+    RustdlExplanationGenerator(
+            OWLOntology ontology,
+            ExplanationProgressMonitor<OWLAxiom> progressMonitor,
+            RustdlExplainConfiguration configuration,
+            boolean laconic) {
+        this.ontology = ontology;
+        this.progressMonitor = progressMonitor;
+        this.configuration = configuration;
+        this.laconic = laconic;
+    }
+
+    @Override
+    public Set<Explanation<OWLAxiom>> getExplanations(OWLAxiom entailment) throws ExplanationException {
+        Result result = generateBounded(entailment, configuration.getMaxJustifications());
+        if (!result.enumerationComplete) {
+            throw new ExplanationException(
+                "rustdl did not exhaust all justifications within the configured cap ("
+                    + configuration.getMaxJustifications() + "); use getExplanations(entailment, limit) "
+                    + "or raise rustdl.explain.max.justifications/RUSTDL_EXPLAIN_MAX_JUSTIFICATIONS");
+        }
+        return result.explanations;
+    }
+
+    @Override
+    public Set<Explanation<OWLAxiom>> getExplanations(OWLAxiom entailment, int limit)
+            throws ExplanationException {
+        // Validate the advertised entailment surface even when the caller asks for zero
+        // results: an unsupported query must fail explicitly, never masquerade as a valid
+        // query with no explanations.
+        queryArguments(entailment);
+        if (limit <= 0) {
+            return Collections.emptySet();
+        }
+        return generateBounded(entailment, limit).explanations;
+    }
+
+    /** Exact entailment surface advertised to OWLAPI and Protégé callers. */
+    public static boolean supportsEntailment(OWLAxiom entailment) {
+        try {
+            queryArguments(entailment);
+            return true;
+        } catch (UnsupportedEntailmentException error) {
+            return false;
+        }
+    }
+
+    Result generateBounded(OWLAxiom entailment, int limit) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException("justification limit must be positive");
+        }
+        if (progressMonitor.isCancelled()) {
+            throw new ExplanationGeneratorInterruptedException();
+        }
+        List<String> query = queryArguments(entailment);
+
+        Path source = null;
+        try {
+            source = Files.createTempFile("rustdl-explain-", ".ofn");
+            FlattenedOntology.writeOfn(ontology, source);
+
+            RustdlJson.JustifyJson report;
+            try {
+                report = RustdlProcess.justify(
+                    source, laconic, limit, configuration.getTimeoutSeconds(), query);
+            } catch (IOException error) {
+                throw new ExplanationException(
+                    "rustdl justify failed or timed out: " + error.getMessage(), error);
+            }
+            validateReport(report, limit);
+
+            if (progressMonitor.isCancelled()) {
+                throw new ExplanationGeneratorInterruptedException();
+            }
+
+            if (!report.minimal) {
+                LOG.warning("rustdl returned a sound but possibly non-minimal (not subset-minimal "
+                    + "guaranteed) justification set for " + entailment);
+            }
+
+            Set<Explanation<OWLAxiom>> explanations = materialize(entailment, report);
+            return new Result(explanations, report.enumeration_complete);
+        } catch (ExplanationException error) {
+            throw error;
+        } catch (Exception error) {
+            throw new ExplanationException("Could not generate a rustdl explanation", error);
+        } finally {
+            delete(source);
+        }
+    }
+
+    /**
+     * Package-visible test seam: applies the verify-then-wrap pipeline {@link #getExplanations}
+     * uses internally to a CANNED {@link RustdlJson.JustifyJson} report, without spawning a
+     * subprocess. Exercised directly by {@code RustdlExplanationGeneratorTest}.
+     */
+    Set<Explanation<OWLAxiom>> materialize(OWLAxiom entailment, RustdlJson.JustifyJson report) {
+        if ("not-entailed".equals(report.status)) {
+            return Collections.emptySet();
+        }
+        Set<Explanation<OWLAxiom>> explanations = new LinkedHashSet<>();
+        for (RustdlJson.JustificationJson justification : report.justifications) {
+            if (justification == null || justification.ofn == null) {
+                throw new ExplanationException("rustdl returned a null justification document");
+            }
+            Set<OWLAxiom> parsed = RustdlOfn.parse(justification.ofn);
+            Set<OWLAxiom> verified = RustdlOfn.verifiedAgainst(parsed, ontology);
+            if (verified.isEmpty()) {
+                throw new ExplanationException(
+                    "rustdl justification contained no axioms verifiable against the source "
+                        + "ontology (possible fabrication): " + justification.ofn);
+            }
+            Explanation<OWLAxiom> explanation = new Explanation<>(entailment, verified);
+            explanations.add(explanation);
+            progressMonitor.foundExplanation(this, explanation, explanations);
+            if (progressMonitor.isCancelled()) {
+                throw new ExplanationGeneratorInterruptedException();
+            }
+        }
+        return explanations;
+    }
+
+    private static void validateReport(RustdlJson.JustifyJson report, int requestedLimit) {
+        if (report == null) {
+            throw new ExplanationException("rustdl returned no justify result");
+        }
+        if (!"entailed".equals(report.status) && !"not-entailed".equals(report.status)) {
+            throw new ExplanationException("Unknown rustdl justify status: " + report.status);
+        }
+        if ("entailed".equals(report.status)
+                && (report.justifications == null || report.justifications.isEmpty())) {
+            throw new ExplanationException(
+                "rustdl returned an entailed verdict without any justifications");
+        }
+        if ("not-entailed".equals(report.status)
+                && report.justifications != null && !report.justifications.isEmpty()) {
+            throw new ExplanationException(
+                "rustdl returned a not-entailed verdict together with justifications");
+        }
+        if (report.justifications != null && report.justifications.size() > requestedLimit) {
+            throw new ExplanationException(
+                "rustdl returned more justifications than the requested bound");
+        }
+    }
+
+    /**
+     * Maps a supported entailment axiom to {@code rustdl justify} query arguments (full IRIs,
+     * per the {@code owl_dl_reasoner::justify::parse_query} grammar). Throws
+     * {@link UnsupportedEntailmentException} for anything outside the advertised surface.
+     */
+    static List<String> queryArguments(OWLAxiom entailment) {
+        if (entailment instanceof OWLSubClassOfAxiom) {
+            return subClassOfQuery((OWLSubClassOfAxiom) entailment);
+        }
+        if (entailment instanceof OWLEquivalentClassesAxiom) {
+            List<OWLClass> pair = namedPair(
+                ((OWLEquivalentClassesAxiom) entailment).getClassExpressions(),
+                RustdlExplanationGenerator::namedClassOrNull);
+            return args("equivalent", pair.get(0).getIRI().toString(), pair.get(1).getIRI().toString());
+        }
+        if (entailment instanceof OWLDisjointClassesAxiom) {
+            List<OWLClass> pair = namedPair(
+                ((OWLDisjointClassesAxiom) entailment).getClassExpressions(),
+                RustdlExplanationGenerator::namedClassOrNull);
+            return args("disjoint", pair.get(0).getIRI().toString(), pair.get(1).getIRI().toString());
+        }
+        if (entailment instanceof OWLClassAssertionAxiom) {
+            OWLClassAssertionAxiom classAssertion = (OWLClassAssertionAxiom) entailment;
+            OWLNamedIndividual individual = namedIndividualOrNull(classAssertion.getIndividual());
+            OWLClass type = namedClassOrNull(classAssertion.getClassExpression());
+            if (individual == null || type == null) {
+                throw unsupported("ClassAssertion requires a named individual and named class");
+            }
+            return args("instance", individual.getIRI().toString(), type.getIRI().toString());
+        }
+        if (entailment instanceof OWLObjectPropertyAssertionAxiom) {
+            OWLObjectPropertyAssertionAxiom propertyAssertion = (OWLObjectPropertyAssertionAxiom) entailment;
+            OWLNamedIndividual subject = namedIndividualOrNull(propertyAssertion.getSubject());
+            OWLNamedIndividual object = namedIndividualOrNull(propertyAssertion.getObject());
+            OWLObjectPropertyExpression propertyExpression = propertyAssertion.getProperty();
+            if (subject == null || object == null || propertyExpression.isAnonymous()) {
+                throw unsupported(
+                    "ObjectPropertyAssertion requires named subject/object and a named property");
+            }
+            return args("property",
+                subject.getIRI().toString(),
+                propertyExpression.asOWLObjectProperty().getIRI().toString(),
+                object.getIRI().toString());
+        }
+        if (entailment instanceof OWLSubObjectPropertyOfAxiom) {
+            OWLSubObjectPropertyOfAxiom subProperty = (OWLSubObjectPropertyOfAxiom) entailment;
+            OWLObjectPropertyExpression sub = subProperty.getSubProperty();
+            OWLObjectPropertyExpression sup = subProperty.getSuperProperty();
+            if (sub.isAnonymous() || sup.isAnonymous()) {
+                throw unsupported("SubObjectPropertyOf requires named sub- and super-properties");
+            }
+            return args("subproperty",
+                sub.asOWLObjectProperty().getIRI().toString(),
+                sup.asOWLObjectProperty().getIRI().toString());
+        }
+        if (entailment instanceof OWLSameIndividualAxiom) {
+            List<OWLNamedIndividual> pair = namedPair(
+                ((OWLSameIndividualAxiom) entailment).getIndividuals(),
+                RustdlExplanationGenerator::namedIndividualOrNull);
+            return args("same", pair.get(0).getIRI().toString(), pair.get(1).getIRI().toString());
+        }
+        throw unsupported("unsupported entailment type: " + entailment.getClass().getSimpleName());
+    }
+
+    private static List<String> subClassOfQuery(OWLSubClassOfAxiom subClassOf) {
+        OWLClassExpression subExpression = subClassOf.getSubClass();
+        OWLClassExpression superExpression = subClassOf.getSuperClass();
+        if (subExpression.isAnonymous() || superExpression.isAnonymous()) {
+            throw unsupported("SubClassOf requires named subclass and superclass expressions");
+        }
+        OWLClass subClass = subExpression.asOWLClass();
+        OWLClass superClass = superExpression.asOWLClass();
+        if (subClass.isOWLThing() && superClass.isOWLNothing()) {
+            return Collections.singletonList("inconsistent");
+        }
+        if (superClass.isOWLNothing()) {
+            return args("unsat", subClass.getIRI().toString());
+        }
+        return args("subclass", subClass.getIRI().toString(), superClass.getIRI().toString());
+    }
+
+    /**
+     * Requires {@code operands} to reduce (via {@code namer}) to exactly two DISTINCT named
+     * entities, sorted by IRI so the emitted query is deterministic regardless of the source
+     * {@code Set}'s iteration order (equivalence/disjointness/sameness are symmetric, so operand
+     * order doesn't change what is being asked). Anything else (an anonymous operand, or more
+     * than two operands — an n-ary axiom rustdl's binary query grammar can't express as one
+     * query) is out of scope: {@link UnsupportedEntailmentException}.
+     */
+    private static <T, N extends org.semanticweb.owlapi.model.OWLEntity> List<N> namedPair(
+            Set<T> operands, java.util.function.Function<T, N> namer) {
+        List<N> named = new ArrayList<>();
+        for (T operand : operands) {
+            N entity = namer.apply(operand);
+            if (entity == null) {
+                throw unsupported("requires named operands only");
+            }
+            named.add(entity);
+        }
+        if (named.size() != 2) {
+            throw unsupported(
+                "requires exactly two named operands (got " + named.size() + ")");
+        }
+        named.sort((a, b) -> a.getIRI().toString().compareTo(b.getIRI().toString()));
+        return named;
+    }
+
+    private static OWLClass namedClassOrNull(OWLClassExpression expression) {
+        return expression.isAnonymous() ? null : expression.asOWLClass();
+    }
+
+    private static OWLNamedIndividual namedIndividualOrNull(OWLIndividual individual) {
+        return individual.isAnonymous() ? null : individual.asOWLNamedIndividual();
+    }
+
+    private static List<String> args(String... parts) {
+        List<String> list = new ArrayList<>();
+        Collections.addAll(list, parts);
+        return list;
+    }
+
+    private static UnsupportedEntailmentException unsupported(String message) {
+        return new UnsupportedEntailmentException("rustdl explanations: " + message);
+    }
+
+    private static void delete(Path path) {
+        if (path != null) {
+            try {
+                Files.deleteIfExists(path);
+            } catch (Exception ignored) {
+                // Temporary-file cleanup must not mask the explanation result.
+            }
+        }
+    }
+
+    /** Bundles a bounded run's explanations with whether enumeration was complete. */
+    static final class Result {
+        final Set<Explanation<OWLAxiom>> explanations;
+        final boolean enumerationComplete;
+
+        Result(Set<Explanation<OWLAxiom>> explanations, boolean enumerationComplete) {
+            this.explanations = Collections.unmodifiableSet(new LinkedHashSet<>(explanations));
+            this.enumerationComplete = enumerationComplete;
+        }
+    }
+}

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorFactory.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorFactory.java
@@ -1,0 +1,83 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.semanticweb.owl.explanation.api.ExplanationException;
+import org.semanticweb.owl.explanation.api.ExplanationGenerator;
+import org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory;
+import org.semanticweb.owl.explanation.api.ExplanationProgressMonitor;
+import org.semanticweb.owl.explanation.api.NullExplanationProgressMonitor;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLOntology;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Discoverable ({@code META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory})
+ * factory for {@link RustdlExplanationGenerator}s, backing Protégé's Explanation ("?") dialog
+ * with rustdl's non-laconic {@code justify} justifications.
+ */
+public class RustdlExplanationGeneratorFactory implements ExplanationGeneratorFactory<OWLAxiom> {
+
+    private final RustdlExplainConfiguration configuration;
+
+    public RustdlExplanationGeneratorFactory() {
+        this(RustdlExplainConfiguration.fromSystemProperties());
+    }
+
+    public RustdlExplanationGeneratorFactory(RustdlExplainConfiguration configuration) {
+        if (configuration == null) {
+            throw new NullPointerException("configuration");
+        }
+        this.configuration = configuration;
+    }
+
+    /** Display name for this generator; distinguishes it from the laconic variant. */
+    public String getExplanationGeneratorName() {
+        return "rustdl";
+    }
+
+    /** Whether {@link #createExplanationGenerator} produces laconic (structurally weakened) justifications. */
+    boolean isLaconic() {
+        return false;
+    }
+
+    @Override
+    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(OWLOntology ontology) {
+        return createExplanationGenerator(ontology, new NullExplanationProgressMonitor<OWLAxiom>());
+    }
+
+    @Override
+    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(
+            OWLOntology ontology, ExplanationProgressMonitor<OWLAxiom> progressMonitor) {
+        if (ontology == null) {
+            throw new NullPointerException("ontology");
+        }
+        if (progressMonitor == null) {
+            throw new NullPointerException("progressMonitor");
+        }
+        return new RustdlExplanationGenerator(ontology, progressMonitor, configuration, isLaconic());
+    }
+
+    @Override
+    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(Set<? extends OWLAxiom> axioms) {
+        return createExplanationGenerator(axioms, new NullExplanationProgressMonitor<OWLAxiom>());
+    }
+
+    @Override
+    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(
+            Set<? extends OWLAxiom> axioms, ExplanationProgressMonitor<OWLAxiom> progressMonitor) {
+        if (axioms == null) {
+            throw new NullPointerException("axioms");
+        }
+        try {
+            Set<OWLAxiom> copied = new LinkedHashSet<>();
+            copied.addAll(axioms);
+            OWLOntology ontology = OWLManager.createOWLOntologyManager().createOntology(copied);
+            return createExplanationGenerator(ontology, progressMonitor);
+        } catch (Exception error) {
+            throw new ExplanationException(
+                "Could not create an ontology for rustdl explanation axioms", error);
+        }
+    }
+}

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlJson.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlJson.java
@@ -57,4 +57,17 @@ public final class RustdlJson {
         public List<List<String>> object_property_values;   // [subj, prop, obj]
         public List<List<String>> data_property_values;     // [subj, prop, lexical, datatype]
     }
+
+    /** `justify --json` top-level payload (docs/json-schema.md). */
+    public static final class JustifyJson {
+        public int schema_version;
+        public String status;               // "entailed" | "not-entailed"
+        public boolean enumeration_complete;
+        public boolean minimal;             // true iff every justification is subset-minimal-guaranteed
+        public boolean laconic;
+        public List<JustificationJson> justifications;
+    }
+    public static final class JustificationJson {
+        public String ofn; // self-contained OWL Functional Syntax ontology document
+    }
 }

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlJson.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlJson.java
@@ -70,4 +70,36 @@ public final class RustdlJson {
     public static final class JustificationJson {
         public String ofn; // self-contained OWL Functional Syntax ontology document
     }
+
+    /**
+     * `prove --json` top-level payload (docs/json-schema.md). Three mutually exclusive shapes:
+     * <ul>
+     * <li>step-level EL proof: {@code entailed=true, has_proof=true, proof} set,
+     *     {@code justification_fallback=null};</li>
+     * <li>SROIQ-only justification fallback: {@code entailed=true, has_proof=false, proof=null},
+     *     {@code justification_fallback} set (a full OFN ontology document, not a single axiom);</li>
+     * <li>not entailed: {@code entailed=false, has_proof=false}, both {@code proof} and
+     *     {@code justification_fallback} {@code null}.</li>
+     * </ul>
+     */
+    public static final class ProveJson {
+        public int schema_version;
+        public boolean entailed;
+        public boolean has_proof;
+        public ProofNodeJson proof;
+        public String justification_fallback; // self-contained OFN ontology document, or null
+    }
+
+    /**
+     * One node of a {@code prove --json} step-level proof tree. {@code conclusion} is a
+     * self-contained OFN ontology document containing exactly one logical axiom (the fact this
+     * node proves); each entry of {@code axioms} is likewise its own one-axiom OFN document (the
+     * step's cited source axioms -- possibly empty, e.g. a pure transitivity/chain step).
+     */
+    public static final class ProofNodeJson {
+        public String conclusion;
+        public String rule;
+        public List<String> axioms;
+        public List<ProofNodeJson> premises;
+    }
 }

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlLaconicExplanationGeneratorFactory.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlLaconicExplanationGeneratorFactory.java
@@ -1,0 +1,30 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+/**
+ * As {@link RustdlExplanationGeneratorFactory}, but requests LACONIC justifications from
+ * {@code rustdl justify --laconic}: each justification axiom is weakened to the fragment
+ * actually responsible for the entailment (sound structural weakening; see
+ * {@code docs/superpowers/specs/2026-06-21-laconic-justifications-design.md}). Registered
+ * under its own {@code META-INF/services} entry alongside the non-laconic factory so both
+ * appear as distinct choices in Protégé's Explanation ("?") dialog.
+ */
+public final class RustdlLaconicExplanationGeneratorFactory extends RustdlExplanationGeneratorFactory {
+
+    public RustdlLaconicExplanationGeneratorFactory() {
+        super();
+    }
+
+    public RustdlLaconicExplanationGeneratorFactory(RustdlExplainConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public String getExplanationGeneratorName() {
+        return "rustdl (laconic)";
+    }
+
+    @Override
+    boolean isLaconic() {
+        return true;
+    }
+}

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
@@ -1,0 +1,73 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
+import org.semanticweb.owlapi.io.StringDocumentSource;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.parameters.AxiomAnnotations;
+import org.semanticweb.owlapi.model.parameters.Imports;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+/**
+ * Parses the self-contained OWL Functional Syntax ontology DOCUMENTS emitted per-justification
+ * in {@code rustdl justify --json}'s {@code justifications[].ofn} field, and enforces the
+ * anti-fabrication guard that every axiom surfaced to the user genuinely occurs in the source
+ * ontology (mirrors km's {@code materialize}).
+ */
+final class RustdlOfn {
+    private static final Logger LOG = Logger.getLogger(RustdlOfn.class.getName());
+    private static final AtomicLong COUNTER = new AtomicLong();
+
+    private RustdlOfn() {}
+
+    /**
+     * Loads {@code ofnDocument} — a full {@code Prefix(...)}/{@code Ontology(...)} OWL
+     * Functional Syntax document, NOT a bare axiom fragment — as a fresh, throwaway ontology
+     * and returns its own axioms (excluding imports, which a rustdl justification document
+     * never has).
+     */
+    static Set<OWLAxiom> parse(String ofnDocument) {
+        if (ofnDocument == null || ofnDocument.isEmpty()) {
+            throw new IllegalArgumentException("rustdl returned an empty justification document");
+        }
+        try {
+            OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+            IRI documentIri = IRI.create(
+                "urn:rustdl-justification:" + COUNTER.incrementAndGet());
+            StringDocumentSource source = new StringDocumentSource(
+                ofnDocument, documentIri, new FunctionalSyntaxDocumentFormat(), null);
+            OWLOntology parsed = manager.loadOntologyFromOntologyDocument(source);
+            return new LinkedHashSet<>(parsed.getAxioms(Imports.EXCLUDED));
+        } catch (OWLOntologyCreationException error) {
+            throw new IllegalStateException(
+                "rustdl returned an unparseable justification document: " + ofnDocument, error);
+        }
+    }
+
+    /**
+     * Anti-fabrication guard: drops any axiom in {@code parsed} that is not actually present
+     * in {@code source}'s imports closure, logging a warning for each dropped axiom. An
+     * {@code Explanation} handed to the caller must contain only genuine source axioms — never
+     * an axiom rustdl invented or one that survived only because of a parsing/round-trip quirk.
+     */
+    static Set<OWLAxiom> verifiedAgainst(Set<OWLAxiom> parsed, OWLOntology source) {
+        Set<OWLAxiom> verified = new LinkedHashSet<>();
+        for (OWLAxiom axiom : parsed) {
+            if (source.containsAxiom(axiom, Imports.INCLUDED, AxiomAnnotations.IGNORE_AXIOM_ANNOTATIONS)) {
+                verified.add(axiom);
+            } else {
+                LOG.warning("Dropping rustdl justification axiom not found in the source "
+                    + "ontology (possible fabrication): " + axiom);
+            }
+        }
+        return verified;
+    }
+}

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
@@ -54,6 +54,33 @@ final class RustdlOfn {
     }
 
     /**
+     * Parses {@code ofnDocument} (a self-contained OFN ontology document — see {@link #parse})
+     * and returns its single LOGICAL axiom (via {@link OWLAxiom#isLogicalAxiom()}, which excludes
+     * declarations/annotations), for {@code rustdl prove --json}'s per-proof-node
+     * {@code conclusion} and {@code axioms[]} documents (each documented, in
+     * {@code docs/json-schema.md}, to contain exactly one logical axiom). Fails loudly — rather
+     * than silently picking one — if the document does not contain EXACTLY one: an ambiguous
+     * proof node must never be silently resolved into a possibly-wrong axiom.
+     */
+    static OWLAxiom singleLogicalAxiom(String ofnDocument) {
+        Set<OWLAxiom> parsed = parse(ofnDocument);
+        OWLAxiom found = null;
+        int count = 0;
+        for (OWLAxiom axiom : parsed) {
+            if (axiom.isLogicalAxiom()) {
+                found = axiom;
+                count++;
+            }
+        }
+        if (count != 1) {
+            throw new IllegalStateException(
+                "expected exactly one logical axiom in rustdl proof document, found " + count
+                    + ": " + ofnDocument);
+        }
+        return found;
+    }
+
+    /**
      * Fail-hard anti-fabrication guard (mirrors km's {@code KMExplanationGenerator.materialize}):
      * every axiom in {@code parsed} must genuinely occur in {@code source}'s imports closure. If
      * ANY axiom does not, the WHOLE justification is rejected — logging a warning identifying the

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
@@ -1,5 +1,6 @@
 package com.github.maastrichtu_ids.rustdl.protege;
 
+import org.semanticweb.owl.explanation.api.ExplanationException;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
 import org.semanticweb.owlapi.io.StringDocumentSource;
@@ -53,21 +54,30 @@ final class RustdlOfn {
     }
 
     /**
-     * Anti-fabrication guard: drops any axiom in {@code parsed} that is not actually present
-     * in {@code source}'s imports closure, logging a warning for each dropped axiom. An
-     * {@code Explanation} handed to the caller must contain only genuine source axioms — never
-     * an axiom rustdl invented or one that survived only because of a parsing/round-trip quirk.
+     * Fail-hard anti-fabrication guard (mirrors km's {@code KMExplanationGenerator.materialize}):
+     * every axiom in {@code parsed} must genuinely occur in {@code source}'s imports closure. If
+     * ANY axiom does not, the WHOLE justification is rejected — logging a warning identifying the
+     * offending axiom, then throwing {@link ExplanationException} — rather than silently dropping
+     * just that axiom and surfacing the surviving subset. A partial surviving subset can be
+     * genuine-but-INSUFFICIENT to actually entail the target, which would silently produce a
+     * misleading "Explanation"; under correct rustdl operation this is inert (rustdl's
+     * {@code justify} only ever returns genuine source axioms), so this is a soundness safety
+     * net, not a normal code path. Because the caller ({@code
+     * RustdlExplanationGenerator#materialize}) does not catch this per-justification, the thrown
+     * exception also aborts every OTHER justification in the same batch — km's own choice (its
+     * equivalent check throws unguarded from inside the per-justification loop too), which this
+     * mirrors rather than the softer "skip just this one" alternative.
      */
     static Set<OWLAxiom> verifiedAgainst(Set<OWLAxiom> parsed, OWLOntology source) {
-        Set<OWLAxiom> verified = new LinkedHashSet<>();
         for (OWLAxiom axiom : parsed) {
-            if (source.containsAxiom(axiom, Imports.INCLUDED, AxiomAnnotations.IGNORE_AXIOM_ANNOTATIONS)) {
-                verified.add(axiom);
-            } else {
-                LOG.warning("Dropping rustdl justification axiom not found in the source "
-                    + "ontology (possible fabrication): " + axiom);
+            if (!source.containsAxiom(axiom, Imports.INCLUDED, AxiomAnnotations.IGNORE_AXIOM_ANNOTATIONS)) {
+                LOG.warning("Rejecting rustdl justification: axiom not found in the source "
+                    + "ontology's imports closure (possible fabrication): " + axiom);
+                throw new ExplanationException(
+                    "rustdl justification contained an axiom not present in the source ontology "
+                        + "(possible fabrication): " + axiom);
             }
         }
-        return verified;
+        return parsed;
     }
 }

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
@@ -100,6 +100,27 @@ public final class RustdlProcess {
         return j;
     }
 
+    /**
+     * Runs {@code rustdl prove --json <ofn> <sub> <sup>} — a step-level DL proof tree for
+     * {@code SUB ⊑ SUP} (full IRIs), backing {@link RustdlProofService}.
+     */
+    public static RustdlJson.ProveJson prove(Path ofn, String sub, String sup, long timeoutSec)
+            throws IOException {
+        return parseProve(runCommand(buildProveCommand(ofn, sub, sup), "prove", timeoutSec));
+    }
+
+    /** Package-visible so tests can assert on the command list without spawning. */
+    static List<String> buildProveCommand(Path ofn, String sub, String sup) throws IOException {
+        return Arrays.asList(
+            RustdlBinary.resolve().toString(), "prove", "--json", ofn.toString(), sub, sup);
+    }
+
+    static RustdlJson.ProveJson parseProve(String json) {
+        RustdlJson.ProveJson p = fromJson(json, RustdlJson.ProveJson.class);
+        checkVersion(p.schema_version);
+        return p;
+    }
+
     static RustdlJson.ClassifyJson parseClassify(String json) {
         RustdlJson.ClassifyJson c = fromJson(json, RustdlJson.ClassifyJson.class);
         checkVersion(c.schema_version);

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
@@ -89,6 +89,10 @@ public final class RustdlProcess {
         if (laconic) cmd.add("--laconic");
         cmd.add("--max");
         cmd.add(Integer.toString(maxJustifications));
+        // "--" ends option parsing: everything after it (the ontology path and every query
+        // token) is treated by clap as positional, regardless of a leading '-' -- so an entity
+        // IRI/query token that happens to start with '-' can't be misparsed as a flag.
+        cmd.add("--");
         cmd.add(ofn.toString());
         cmd.addAll(query);
         return cmd;
@@ -111,8 +115,10 @@ public final class RustdlProcess {
 
     /** Package-visible so tests can assert on the command list without spawning. */
     static List<String> buildProveCommand(Path ofn, String sub, String sup) throws IOException {
+        // "--" ends option parsing (see buildJustifyCommand): the ontology path and the two
+        // entity IRIs are positionals and must not be misparsed as flags if they start with '-'.
         return Arrays.asList(
-            RustdlBinary.resolve().toString(), "prove", "--json", ofn.toString(), sub, sup);
+            RustdlBinary.resolve().toString(), "prove", "--json", "--", ofn.toString(), sub, sup);
     }
 
     static RustdlJson.ProveJson parseProve(String json) {

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
@@ -53,6 +53,38 @@ public final class RustdlProcess {
         return parsePropertyValues(run("property-values", ofn, timeoutSec));
     }
 
+    /**
+     * Runs {@code rustdl justify --all --json [--laconic] --max <maxJustifications> <ofn> <query...>}.
+     * The query keywords/arity are those of {@code owl_dl_reasoner::justify::parse_query}
+     * (e.g. {@code subclass S T}, {@code unsat C}, {@code inconsistent}, ...); the caller
+     * (the Explanation-API generator) builds {@code query} from the entailment being explained.
+     */
+    public static RustdlJson.JustifyJson justify(
+            Path ofn, boolean laconic, int maxJustifications, long timeoutSec, List<String> query)
+            throws IOException {
+        return parseJustify(runCommand(
+            buildJustifyCommand(ofn, laconic, maxJustifications, query), "justify", timeoutSec));
+    }
+
+    /** Package-visible so tests can assert on the command list without spawning. */
+    static List<String> buildJustifyCommand(
+            Path ofn, boolean laconic, int maxJustifications, List<String> query) throws IOException {
+        List<String> cmd = new java.util.ArrayList<>(Arrays.asList(
+            RustdlBinary.resolve().toString(), "justify", "--all", "--json"));
+        if (laconic) cmd.add("--laconic");
+        cmd.add("--max");
+        cmd.add(Integer.toString(maxJustifications));
+        cmd.add(ofn.toString());
+        cmd.addAll(query);
+        return cmd;
+    }
+
+    static RustdlJson.JustifyJson parseJustify(String json) {
+        RustdlJson.JustifyJson j = fromJson(json, RustdlJson.JustifyJson.class);
+        checkVersion(j.schema_version);
+        return j;
+    }
+
     static RustdlJson.ClassifyJson parseClassify(String json) {
         RustdlJson.ClassifyJson c = fromJson(json, RustdlJson.ClassifyJson.class);
         checkVersion(c.schema_version);

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcess.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 /** Spawns `rustdl <subcmd> --json <ofn>`, enforces a timeout, parses stdout. Fail-closed. */
 public final class RustdlProcess {
@@ -62,8 +63,22 @@ public final class RustdlProcess {
     public static RustdlJson.JustifyJson justify(
             Path ofn, boolean laconic, int maxJustifications, long timeoutSec, List<String> query)
             throws IOException {
+        return justify(ofn, laconic, maxJustifications, timeoutSec, query, () -> false);
+    }
+
+    /**
+     * As {@link #justify(Path, boolean, int, long, List)}, but polls {@code isCancelled} at
+     * ~100ms granularity while waiting for the subprocess (see {@link #runCommand(List, String,
+     * long, BooleanSupplier)}), so a Cancel click in the Explanation dialog kills the subprocess
+     * promptly instead of waiting out the full {@code timeoutSec}.
+     */
+    public static RustdlJson.JustifyJson justify(
+            Path ofn, boolean laconic, int maxJustifications, long timeoutSec, List<String> query,
+            BooleanSupplier isCancelled)
+            throws IOException {
         return parseJustify(runCommand(
-            buildJustifyCommand(ofn, laconic, maxJustifications, query), "justify", timeoutSec));
+            buildJustifyCommand(ofn, laconic, maxJustifications, query), "justify", timeoutSec,
+            isCancelled));
     }
 
     /** Package-visible so tests can assert on the command list without spawning. */
@@ -141,8 +156,31 @@ public final class RustdlProcess {
      * child that hangs before writing/closing either stream cannot block the JVM, and
      * enforcing {@code timeoutSec} via {@code waitFor} independently of those reads
      * (draining alone cannot observe a timeout — a hung child never triggers EOF).
+     *
+     * <p>Delegates to the polling {@link #runCommand(List, String, long, BooleanSupplier)}
+     * with a predicate that never reports cancelled, so callers that don't support
+     * mid-wait cancellation (the reasoner path) see identical behavior to before: a single
+     * effective wait up to {@code timeoutSec}, then {@code destroyForcibly} + {@link IOException}
+     * on timeout.</p>
      */
     static String runCommand(List<String> command, String label, long timeoutSec) throws IOException {
+        return runCommand(command, label, timeoutSec, () -> false);
+    }
+
+    /**
+     * As {@link #runCommand(List, String, long)}, but polls {@code isCancelled} at ~100ms
+     * granularity while waiting for the process (mirrors the km reference plugin's
+     * {@code KMExplanationGenerator.waitFor}), in addition to enforcing the {@code timeoutSec}
+     * deadline. Lets a mid-wait cancellation (e.g. a Cancel click in the Explanation dialog)
+     * {@code destroyForcibly} the subprocess and abort promptly, instead of blocking until the
+     * process finishes or the full timeout elapses. {@code isCancelled} is polled from the
+     * calling thread between 100ms {@code waitFor} ticks, so it must be cheap and safe to call
+     * repeatedly. On cancellation, throws {@link CancelledException} (a distinguishable
+     * {@link IOException} subtype) rather than the plain timeout {@link IOException}, so callers
+     * that care can tell the two apart.
+     */
+    static String runCommand(List<String> command, String label, long timeoutSec,
+            BooleanSupplier isCancelled) throws IOException {
         ProcessBuilder pb = new ProcessBuilder(command);
         pb.redirectErrorStream(false);
         Process proc = pb.start();
@@ -152,17 +190,12 @@ public final class RustdlProcess {
             Future<String> outF = pool.submit(() -> readAll(proc.getInputStream()));
             Future<String> errF = pool.submit(() -> readAll(proc.getErrorStream()));
 
-            boolean finished;
             try {
-                finished = proc.waitFor(timeoutSec, TimeUnit.SECONDS);
+                waitPolling(proc, label, timeoutSec, isCancelled);
             } catch (InterruptedException e) {
                 proc.destroyForcibly();
                 Thread.currentThread().interrupt();
                 throw new IOException("rustdl " + label + " interrupted", e);
-            }
-            if (!finished) {
-                proc.destroyForcibly();
-                throw new IOException("rustdl " + label + " timed out after " + timeoutSec + "s");
             }
 
             String out;
@@ -186,6 +219,43 @@ public final class RustdlProcess {
         } finally {
             pool.shutdownNow();
         }
+    }
+
+    /**
+     * Polls {@code process.waitFor(100, MILLISECONDS)} in a loop until the process finishes,
+     * {@code isCancelled} reports {@code true}, or {@code timeoutSec} elapses. On cancellation
+     * or timeout the process is {@code destroyForcibly}'d before throwing, so callers can rely
+     * on the process being dead the moment this method returns abnormally. Returns normally
+     * (without throwing) once the process has finished on its own.
+     */
+    private static void waitPolling(
+            Process process, String label, long timeoutSec, BooleanSupplier isCancelled)
+            throws InterruptedException, IOException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSec);
+        while (!process.waitFor(100, TimeUnit.MILLISECONDS)) {
+            if (isCancelled.getAsBoolean()) {
+                process.destroyForcibly();
+                throw new CancelledException("rustdl " + label + " cancelled");
+            }
+            if (System.nanoTime() >= deadline) {
+                process.destroyForcibly();
+                throw new IOException("rustdl " + label + " timed out after " + timeoutSec + "s");
+            }
+        }
+    }
+
+    /**
+     * Thrown by the polling {@link #runCommand(List, String, long, BooleanSupplier)} (and, in
+     * turn, {@link #justify(Path, boolean, int, long, List, BooleanSupplier)}) when the supplied
+     * cancellation predicate reports cancelled mid-wait. The process has already been
+     * {@code destroyForcibly}'d by the time this is thrown. Callers that support cancellation
+     * (the Explanation-API generator) catch this specifically and translate it into their own
+     * interruption signal ({@code ExplanationGeneratorInterruptedException}); callers that don't
+     * (the {@code () -> false} predicate used by every other {@code RustdlProcess} entry point)
+     * never see it.
+     */
+    static final class CancelledException extends IOException {
+        CancelledException(String message) { super(message); }
     }
 
     private static final ThreadFactory DAEMON_THREAD_FACTORY = r -> {

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProof.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProof.java
@@ -1,0 +1,137 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.liveontologies.puli.BaseProof;
+import org.liveontologies.puli.Inference;
+import org.semanticweb.owlapi.model.OWLAxiom;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A puli {@link org.liveontologies.puli.Proof} over a {@code rustdl prove --json} result,
+ * mirroring ELK's {@code ElkOwlProof} (which wraps ELK's own internal evidence into the same
+ * puli {@code Proof}/{@code Inference} model). Every {@link RustdlJson.ProofNodeJson} in the
+ * tree becomes one {@link Inference}{@code <OWLAxiom>}, {@link BaseProof#produce produced} into
+ * this proof keyed by its conclusion axiom — so {@link #getInferences(Object)} (inherited from
+ * {@link BaseProof}) answers not just the root conclusion but every intermediate premise in the
+ * tree too, which is what lets Protégé's proof view recurse into nested steps.
+ *
+ * <p><b>Cited source axioms as premises.</b> Each step's {@code axioms} (the source axioms rustdl
+ * cited for that rule application — e.g. the told {@code SubClassOf} a {@code ToldSubsumer} step
+ * applies) are folded in as ADDITIONAL premises alongside the recursively-built child-node
+ * conclusions, and each distinct cited axiom is itself registered as a trivial "asserted" leaf
+ * inference (rule name {@code "asserted"}, zero premises) so it appears in the proof as a
+ * terminal, given fact rather than an unexplained gap. This mirrors how ELK's own proof DAG
+ * represents told axioms as leaf conclusions (via {@code AssertedConclusionInference}) rather
+ * than leaving them implicit in the rule name alone — without folding them in, a leaf
+ * {@code ToldSubsumer} step would show zero premises and hide the very axiom that justifies it,
+ * defeating the point of a step-level proof surface.</p>
+ */
+final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
+
+    /** De-duplicates "asserted" leaf inferences across the whole tree (same axiom may be cited by
+     * more than one step). */
+    private final Set<OWLAxiom> assertedRegistered = new HashSet<>();
+
+    private RustdlProof() {}
+
+    /**
+     * Builds the proof for one {@code rustdl prove --json} result.
+     *
+     * @param json the parsed {@code ProveJson}; must have {@code entailed == true} (the caller —
+     *     {@link RustdlProofService} — only builds a proof for an entailed result).
+     * @param goal the OWLAxiom the caller asked {@link RustdlProofService#getProof} to explain.
+     *     Used directly as the synthetic fallback inference's conclusion when
+     *     {@code has_proof == false} (there is no OFN document representing the goal in that
+     *     branch — {@code justification_fallback} carries only the justification's axioms, not
+     *     the entailment itself). When {@code has_proof == true} the root node's own parsed
+     *     conclusion is used instead (expected — not re-checked here — to be structurally equal
+     *     to {@code goal}, since it renders the same {@code SUB ⊑ SUP} the query asked about).
+     */
+    static RustdlProof fromProveJson(RustdlJson.ProveJson json, OWLAxiom goal) {
+        if (json == null) {
+            throw new IllegalArgumentException("rustdl prove --json returned no result");
+        }
+        RustdlProof proof = new RustdlProof();
+        if (json.has_proof) {
+            if (json.proof == null) {
+                throw new IllegalStateException(
+                    "rustdl prove --json: has_proof=true but proof is null");
+            }
+            proof.buildNode(json.proof);
+        } else {
+            if (json.justification_fallback == null) {
+                throw new IllegalStateException(
+                    "rustdl prove --json: has_proof=false but justification_fallback is null");
+            }
+            List<OWLAxiom> premises = new ArrayList<>(RustdlOfn.parse(json.justification_fallback));
+            proof.produce(new SimpleInference("justification", goal, premises));
+        }
+        return proof;
+    }
+
+    /**
+     * Recursively converts {@code node} — and every node in its subtree — into
+     * {@link Inference}s produced into this proof, returning {@code node}'s own conclusion axiom
+     * so the caller (a parent {@code buildNode} call, or {@link #fromProveJson}) can use it as one
+     * of ITS premises.
+     */
+    private OWLAxiom buildNode(RustdlJson.ProofNodeJson node) {
+        OWLAxiom conclusion = RustdlOfn.singleLogicalAxiom(node.conclusion);
+
+        List<OWLAxiom> premises = new ArrayList<>();
+        if (node.axioms != null) {
+            for (String axiomDoc : node.axioms) {
+                OWLAxiom axiom = RustdlOfn.singleLogicalAxiom(axiomDoc);
+                premises.add(axiom);
+                if (assertedRegistered.add(axiom)) {
+                    produce(new SimpleInference("asserted", axiom, Collections.emptyList()));
+                }
+            }
+        }
+        if (node.premises != null) {
+            for (RustdlJson.ProofNodeJson child : node.premises) {
+                premises.add(buildNode(child));
+            }
+        }
+
+        produce(new SimpleInference(node.rule, conclusion, premises));
+        return conclusion;
+    }
+
+    /** A trivial {@link Inference}{@code <OWLAxiom>} built directly from already-parsed axioms. */
+    private static final class SimpleInference implements Inference<OWLAxiom> {
+        private final String name;
+        private final OWLAxiom conclusion;
+        private final List<OWLAxiom> premises;
+
+        SimpleInference(String name, OWLAxiom conclusion, List<OWLAxiom> premises) {
+            this.name = name;
+            this.conclusion = conclusion;
+            this.premises = Collections.unmodifiableList(new ArrayList<>(premises));
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public OWLAxiom getConclusion() {
+            return conclusion;
+        }
+
+        @Override
+        public List<? extends OWLAxiom> getPremises() {
+            return premises;
+        }
+
+        @Override
+        public String toString() {
+            return name + premises + " => " + conclusion;
+        }
+    }
+}

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProof.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProof.java
@@ -80,6 +80,13 @@ final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
      * of ITS premises.
      */
     private OWLAxiom buildNode(RustdlJson.ProofNodeJson node) {
+        // No conclusion de-dup guard needed here today: rustdl's `ProofNodeJson` tree is an OWNED
+        // tree (each premise belongs to exactly one parent), not a shared DAG, so a shared
+        // sub-conclusion is simply rebuilt (and re-produce()d, harmlessly, into this Proof) once
+        // per occurrence rather than being visited once and reused. If a future rustdl change
+        // makes `ProofNode` DAG-share premises (so the same node object appears under multiple
+        // parents), this recursion would need a visited-conclusion memo to avoid redundant
+        // re-processing (still correct, just wasted work) — see the Task 4 review fold-in M4.2.
         OWLAxiom conclusion = RustdlOfn.singleLogicalAxiom(node.conclusion);
 
         List<OWLAxiom> premises = new ArrayList<>();

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofService.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofService.java
@@ -1,0 +1,175 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.liveontologies.protege.explanation.proof.service.ProofService;
+import org.liveontologies.puli.DynamicProof;
+import org.liveontologies.puli.DynamicProof.ChangeListener;
+import org.liveontologies.puli.Inference;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClassExpression;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owlapi.reasoner.UnsupportedEntailmentTypeException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+
+/**
+ * Exposes {@code rustdl prove --json}'s step-level EL proof trees (falling back to the
+ * axiom-level justification for SROIQ-only entailments) through the liveontologies
+ * {@code org.liveontologies.protege.explanation.proof.service} extension point, mirroring ELK's
+ * {@code ElkProofService}.
+ *
+ * <p>Unlike ELK — whose reasoner instance lives in the JVM and can incrementally notify this
+ * service of changes — {@code rustdl} is an external process rerun per query, so
+ * {@link #getProof(OWLAxiom)} always serializes the CURRENT active ontology and spawns a fresh
+ * {@code rustdl prove --json} at call time; the returned {@link DynamicProof} is a minimal
+ * recompute-on-demand snapshot (no incremental change tracking, no listener notification after
+ * construction) rather than ELK's reactive {@code DynamicOwlProof} — acceptable for v1 per the
+ * task brief. A subsequent ontology edit is picked up the next time Protégé calls
+ * {@link #getProof(OWLAxiom)} again (e.g. re-opening the Explanation dialog), not by this
+ * instance updating itself in place.</p>
+ */
+public final class RustdlProofService extends ProofService {
+
+    /** Overridable via {@code -Drustdl.prove.timeout.seconds} (default matches the reasoner's own
+     * per-query default order of magnitude; prove is a single bounded subprocess call, not a
+     * long-running classify). */
+    private static final long TIMEOUT_SECONDS =
+        Long.getLong("rustdl.prove.timeout.seconds", 60L);
+
+    @Override
+    public void initialise() throws Exception {
+        // No state to set up: getProof (re)computes fresh via a fresh subprocess run every time,
+        // so there is nothing to prime here (contrast ELK's ElkProofService, which caches the
+        // live ElkReasoner instance and listens for reasoner/ontology-change events).
+    }
+
+    @Override
+    public void dispose() {
+        // Nothing held across calls.
+    }
+
+    @Override
+    public boolean hasProof(OWLAxiom entailment) {
+        return isSupported(entailment);
+    }
+
+    @Override
+    public DynamicProof<Inference<? extends OWLAxiom>> getProof(OWLAxiom entailment)
+            throws UnsupportedEntailmentTypeException {
+        if (!isSupported(entailment)) {
+            throw new UnsupportedEntailmentTypeException(entailment);
+        }
+        return new RecomputingProof(entailment);
+    }
+
+    @Override
+    public Inference<? extends OWLAxiom> getExample(Inference<? extends OWLAxiom> inference) {
+        // No canned "worked example" library for rustdl's rules (ELK substitutes a
+        // representative example inference for its own rule names here); nothing to substitute,
+        // so return the inference itself unchanged.
+        return inference;
+    }
+
+    /**
+     * Exact entailment surface: a {@code SubClassOf} between two NAMED class expressions — the
+     * only shape {@code rustdl prove --json <ofn> <sub> <sup>} accepts (it takes two literal
+     * IRIs, not the richer query-keyword grammar {@code justify} supports). Deliberately not
+     * extended beyond this (YAGNI): no unsat/inconsistent/instance/property-assertion proof
+     * queries, since {@code prove} itself has no such forms to run.
+     */
+    private static boolean isSupported(OWLAxiom entailment) {
+        if (!(entailment instanceof OWLSubClassOfAxiom)) {
+            return false;
+        }
+        OWLSubClassOfAxiom subClassOf = (OWLSubClassOfAxiom) entailment;
+        OWLClassExpression sub = subClassOf.getSubClass();
+        OWLClassExpression sup = subClassOf.getSuperClass();
+        return !sub.isAnonymous() && !sup.isAnonymous();
+    }
+
+    /**
+     * Serializes the active ontology and runs {@code rustdl prove --json} exactly once, at
+     * construction time, then answers every {@link #getInferences(Object)} call from that single
+     * snapshot. Mirrors the SHAPE of ELK's {@code ElkProofService.DynamicOwlProof} (an inner
+     * {@link DynamicProof}{@code <Inference<? extends OWLAxiom>>} wrapping a delegate whose
+     * declared type carries the outer wildcard, {@code DynamicProof<? extends Inference<?
+     * extends OWLAxiom>>}, which is what lets a concretely-typed {@code RustdlProof} — a
+     * {@code DynamicProof<Inference<OWLAxiom>>} — satisfy the wildcarded return type this
+     * class's {@link ProofService#getProof} override must produce) without ELK's reactive
+     * reasoner-change listening (see the class-level javadoc).
+     */
+    private final class RecomputingProof implements DynamicProof<Inference<? extends OWLAxiom>> {
+
+        private final DynamicProof<? extends Inference<? extends OWLAxiom>> proof;
+
+        RecomputingProof(OWLAxiom entailment) throws UnsupportedEntailmentTypeException {
+            this.proof = compute(entailment);
+        }
+
+        private DynamicProof<? extends Inference<? extends OWLAxiom>> compute(OWLAxiom entailment)
+                throws UnsupportedEntailmentTypeException {
+            OWLSubClassOfAxiom subClassOf = (OWLSubClassOfAxiom) entailment;
+            String sub = subClassOf.getSubClass().asOWLClass().getIRI().toString();
+            String sup = subClassOf.getSuperClass().asOWLClass().getIRI().toString();
+            OWLOntology ontology = getEditorKit().getOWLModelManager().getActiveOntology();
+
+            Path ofn = null;
+            try {
+                ofn = Files.createTempFile("rustdl-prove-", ".ofn");
+                FlattenedOntology.writeOfn(ontology, ofn);
+                RustdlJson.ProveJson json = RustdlProcess.prove(ofn, sub, sup, TIMEOUT_SECONDS);
+                if (!json.entailed) {
+                    // hasProof() only promises a SUPPORTED query shape, not that the axiom is
+                    // actually entailed; Protégé only calls getProof for entailments it already
+                    // knows hold (e.g. from the class hierarchy or the Explanation dialog), so
+                    // this should not happen in practice -- but if rustdl and the caller ever
+                    // disagree, failing loudly here is safer than fabricating an empty proof.
+                    throw new UnsupportedEntailmentTypeException(entailment);
+                }
+                return RustdlProof.fromProveJson(json, entailment);
+            } catch (IOException error) {
+                throw new IllegalStateException(
+                    "rustdl prove --json failed: " + error.getMessage(), error);
+            } catch (org.semanticweb.owlapi.model.OWLOntologyCreationException
+                    | org.semanticweb.owlapi.model.OWLOntologyStorageException error) {
+                throw new IllegalStateException(
+                    "could not serialize the active ontology for rustdl prove: "
+                        + error.getMessage(), error);
+            } finally {
+                if (ofn != null) {
+                    try {
+                        Files.deleteIfExists(ofn);
+                    } catch (IOException ignored) {
+                        // Temporary-file cleanup must not mask the proof result.
+                    }
+                }
+            }
+        }
+
+        @Override
+        public Collection<? extends Inference<? extends OWLAxiom>> getInferences(Object conclusion) {
+            return proof.getInferences(conclusion);
+        }
+
+        @Override
+        public void addListener(ChangeListener listener) {
+            // Recompute-on-demand (see class javadoc): this snapshot never mutates after
+            // construction, so there is nothing to notify a listener about later. A later
+            // ontology edit is picked up by a FRESH getProof() call, not by this instance
+            // changing in place.
+        }
+
+        @Override
+        public void removeListener(ChangeListener listener) {
+            // No-op: addListener above never retains one.
+        }
+
+        @Override
+        public void dispose() {
+            // Nothing held beyond the immutable `proof` snapshot.
+        }
+    }
+}

--- a/protege/src/main/resources/META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory
+++ b/protege/src/main/resources/META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory
@@ -1,0 +1,2 @@
+com.github.maastrichtu_ids.rustdl.protege.RustdlExplanationGeneratorFactory
+com.github.maastrichtu_ids.rustdl.protege.RustdlLaconicExplanationGeneratorFactory

--- a/protege/src/main/resources/plugin.xml
+++ b/protege/src/main/resources/plugin.xml
@@ -9,4 +9,14 @@
       <name value="rustdl ${project.version}"/>
       <class value="com.github.maastrichtu_ids.rustdl.protege.RustdlReasonerInfo"/>
    </extension>
+
+   <!-- Exposes rustdl's step-level EL proof trees (`rustdl prove --json`) in Protégé's proof
+        view, via the liveontologies proof-explanation plugin's own extension point. Requires
+        that companion plugin to be installed; this bundle itself builds and resolves without it
+        (see protege/pom.xml's Import-Package resolution:=optional entries). -->
+   <extension id="rustdl.proofs"
+              point="org.liveontologies.protege.explanation.proof.service">
+      <name value="rustdl ${project.version}"/>
+      <class value="com.github.maastrichtu_ids.rustdl.protege.RustdlProofService"/>
+   </extension>
 </plugin>

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/PluginRegistrationTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/PluginRegistrationTest.java
@@ -1,8 +1,13 @@
 package com.github.maastrichtu_ids.rustdl.protege;
 
 import org.junit.Test;
+import org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory;
+
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Scanner;
+import java.util.ServiceLoader;
 import static org.junit.Assert.*;
 
 public class PluginRegistrationTest {
@@ -20,5 +25,29 @@ public class PluginRegistrationTest {
                 xml.contains("${project.version}"));
             assertTrue(xml.contains("<class value=\"com.github.maastrichtu_ids.rustdl.protege.RustdlReasonerInfo\""));
         }
+    }
+
+    @Test public void servicesFileListsBothExplanationFactories() throws Exception {
+        String resource = "/META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory";
+        try (InputStream in = getClass().getResourceAsStream(resource)) {
+            assertNotNull(resource + " must be on the classpath", in);
+            String contents = new Scanner(in, "UTF-8").useDelimiter("\\A").next();
+            assertTrue(contents.contains(
+                "com.github.maastrichtu_ids.rustdl.protege.RustdlExplanationGeneratorFactory"));
+            assertTrue(contents.contains(
+                "com.github.maastrichtu_ids.rustdl.protege.RustdlLaconicExplanationGeneratorFactory"));
+        }
+    }
+
+    @Test public void serviceLoaderDiscoversBothExplanationFactories() {
+        List<String> names = new ArrayList<>();
+        for (ExplanationGeneratorFactory<?> factory
+                : ServiceLoader.load(ExplanationGeneratorFactory.class, getClass().getClassLoader())) {
+            names.add(factory.getClass().getName());
+        }
+        assertTrue("ServiceLoader must discover RustdlExplanationGeneratorFactory: " + names,
+            names.contains("com.github.maastrichtu_ids.rustdl.protege.RustdlExplanationGeneratorFactory"));
+        assertTrue("ServiceLoader must discover RustdlLaconicExplanationGeneratorFactory: " + names,
+            names.contains("com.github.maastrichtu_ids.rustdl.protege.RustdlLaconicExplanationGeneratorFactory"));
     }
 }

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/PluginRegistrationTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/PluginRegistrationTest.java
@@ -27,6 +27,25 @@ public class PluginRegistrationTest {
         }
     }
 
+    /**
+     * Fold-in M4.1 (Task 4 review): catches a proof-service registration regression at
+     * {@code mvn test} speed rather than only at the antrun {@code verify}-phase
+     * {@code resourcecontains} check (protege/pom.xml's {@code verify-bundle-contents}
+     * execution), which only runs on a full {@code mvn verify}.
+     */
+    @Test public void pluginXmlRegistersRustdlProofService() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/plugin.xml")) {
+            assertNotNull("plugin.xml must be on the classpath", in);
+            String xml = new Scanner(in, "UTF-8").useDelimiter("\\A").next();
+            assertTrue("plugin.xml must register the proof-service extension point",
+                xml.contains("org.liveontologies.protege.explanation.proof.service"));
+            assertTrue(
+                "plugin.xml must wire that extension point to RustdlProofService",
+                xml.contains(
+                    "<class value=\"com.github.maastrichtu_ids.rustdl.protege.RustdlProofService\""));
+        }
+    }
+
     @Test public void servicesFileListsBothExplanationFactories() throws Exception {
         String resource = "/META-INF/services/org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory";
         try (InputStream in = getClass().getResourceAsStream(resource)) {

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorTest.java
@@ -1,0 +1,224 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.junit.Test;
+import org.semanticweb.owl.explanation.api.Explanation;
+import org.semanticweb.owl.explanation.api.NullExplanationProgressMonitor;
+import org.semanticweb.owl.explanation.api.UnsupportedEntailmentException;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDataProperty;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Covers the entailment→{@code justify} query-argument mapping ({@link
+ * RustdlExplanationGenerator#queryArguments}, including the unsupported-entailment surface) and
+ * the CANNED-report materialization pipeline ({@link RustdlExplanationGenerator#materialize}),
+ * exercised entirely through the test seam — no rustdl subprocess is spawned.
+ */
+public class RustdlExplanationGeneratorTest {
+    private final OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+    private final OWLDataFactory df = m.getOWLDataFactory();
+
+    private OWLClass cls(String local) { return df.getOWLClass(IRI.create("http://ex/#" + local)); }
+    private OWLNamedIndividual ind(String local) { return df.getOWLNamedIndividual(IRI.create("http://ex/#" + local)); }
+    private OWLObjectProperty objProp(String local) { return df.getOWLObjectProperty(IRI.create("http://ex/#" + local)); }
+
+    // --- queryArguments mapping -------------------------------------------------------------
+
+    @Test public void subClassOfMapsToSubclassQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLSubClassOfAxiom(cls("A"), cls("B")));
+        assertEquals(Arrays.asList("subclass", "http://ex/#A", "http://ex/#B"), q);
+    }
+
+    @Test public void subClassOfNothingMapsToUnsatQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLSubClassOfAxiom(cls("A"), df.getOWLNothing()));
+        assertEquals(Arrays.asList("unsat", "http://ex/#A"), q);
+    }
+
+    @Test public void thingSubClassOfNothingMapsToInconsistentQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLSubClassOfAxiom(df.getOWLThing(), df.getOWLNothing()));
+        assertEquals(Arrays.asList("inconsistent"), q);
+    }
+
+    @Test public void equivalentClassesMapsToEquivalentQuerySortedByIri() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLEquivalentClassesAxiom(cls("Z"), cls("A")));
+        assertEquals(Arrays.asList("equivalent", "http://ex/#A", "http://ex/#Z"), q);
+    }
+
+    @Test public void disjointClassesMapsToDisjointQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLDisjointClassesAxiom(cls("A"), cls("B")));
+        assertEquals(Arrays.asList("disjoint", "http://ex/#A", "http://ex/#B"), q);
+    }
+
+    @Test public void classAssertionMapsToInstanceQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLClassAssertionAxiom(cls("A"), ind("i")));
+        assertEquals(Arrays.asList("instance", "http://ex/#i", "http://ex/#A"), q);
+    }
+
+    @Test public void objectPropertyAssertionMapsToPropertyQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLObjectPropertyAssertionAxiom(objProp("p"), ind("i"), ind("j")));
+        assertEquals(Arrays.asList("property", "http://ex/#i", "http://ex/#p", "http://ex/#j"), q);
+    }
+
+    @Test public void subObjectPropertyOfMapsToSubpropertyQuery() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLSubObjectPropertyOfAxiom(objProp("p"), objProp("q")));
+        assertEquals(Arrays.asList("subproperty", "http://ex/#p", "http://ex/#q"), q);
+    }
+
+    @Test public void sameIndividualMapsToSameQuerySortedByIri() {
+        List<String> q = RustdlExplanationGenerator.queryArguments(
+            df.getOWLSameIndividualAxiom(ind("j"), ind("i")));
+        assertEquals(Arrays.asList("same", "http://ex/#i", "http://ex/#j"), q);
+    }
+
+    @Test public void supportsEntailmentAgreesWithQueryArguments() {
+        assertTrue(RustdlExplanationGenerator.supportsEntailment(
+            df.getOWLSubClassOfAxiom(cls("A"), cls("B"))));
+        assertFalse(RustdlExplanationGenerator.supportsEntailment(
+            df.getOWLDeclarationAxiom(cls("A"))));
+    }
+
+    @Test(expected = UnsupportedEntailmentException.class)
+    public void anonymousSubClassIsUnsupported() {
+        RustdlExplanationGenerator.queryArguments(
+            df.getOWLSubClassOfAxiom(df.getOWLObjectIntersectionOf(cls("A"), cls("B")), cls("C")));
+    }
+
+    @Test(expected = UnsupportedEntailmentException.class)
+    public void equivalentClassesWithThreeOperandsIsUnsupported() {
+        RustdlExplanationGenerator.queryArguments(
+            df.getOWLEquivalentClassesAxiom(cls("A"), cls("B"), cls("C")));
+    }
+
+    @Test(expected = UnsupportedEntailmentException.class)
+    public void dataPropertyAssertionIsUnsupported() {
+        OWLDataProperty dp = df.getOWLDataProperty(IRI.create("http://ex/#dp"));
+        RustdlExplanationGenerator.queryArguments(
+            df.getOWLDataPropertyAssertionAxiom(dp, ind("i"), df.getOWLLiteral("v")));
+    }
+
+    @Test(expected = UnsupportedEntailmentException.class)
+    public void declarationAxiomIsUnsupported() {
+        RustdlExplanationGenerator.queryArguments(df.getOWLDeclarationAxiom(cls("A")));
+    }
+
+    // --- materialize (canned report, no subprocess) -----------------------------------------
+
+    private RustdlExplanationGenerator generator(OWLOntology ontology) {
+        return new RustdlExplanationGenerator(
+            ontology, new NullExplanationProgressMonitor<OWLAxiom>(),
+            new RustdlExplainConfiguration(600L, 8), false);
+    }
+
+    private RustdlJson.JustificationJson justification(String ofn) {
+        RustdlJson.JustificationJson j = new RustdlJson.JustificationJson();
+        j.ofn = ofn;
+        return j;
+    }
+
+    @Test public void materializeReturnsVerifiedExplanationDroppingFabrication() throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto1/"));
+        OWLSubClassOfAxiom ab = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(cls("B"), cls("C"));
+        m.addAxiom(o, ab);
+        m.addAxiom(o, bc);
+
+        // The canned justify report: genuine A⊑B, B⊑C PLUS a fabricated X⊑Y not in the source.
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = false;
+        report.justifications = Arrays.asList(justification(
+            "Prefix(:=<http://ex/#>)\nOntology(\n"
+                + "  SubClassOf(:A :B)\n  SubClassOf(:B :C)\n  SubClassOf(:X :Y)\n)\n"));
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        Set<Explanation<OWLAxiom>> explanations = generator(o).materialize(entailment, report);
+
+        assertEquals(1, explanations.size());
+        Explanation<OWLAxiom> explanation = explanations.iterator().next();
+        assertEquals(entailment, explanation.getEntailment());
+        assertEquals(2, explanation.getAxioms().size());
+        assertTrue(explanation.getAxioms().contains(ab));
+        assertTrue(explanation.getAxioms().contains(bc));
+    }
+
+    @Test public void materializeReturnsEmptySetForNotEntailed() throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto2/"));
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "not-entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = false;
+        report.justifications = java.util.Collections.emptyList();
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        Set<Explanation<OWLAxiom>> explanations = generator(o).materialize(entailment, report);
+        assertTrue(explanations.isEmpty());
+    }
+
+    @Test public void materializeSupportsMultipleJustifications() throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto3/"));
+        OWLSubClassOfAxiom ab = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(cls("B"), cls("C"));
+        OWLSubClassOfAxiom ad = df.getOWLSubClassOfAxiom(cls("A"), cls("D"));
+        OWLSubClassOfAxiom dc = df.getOWLSubClassOfAxiom(cls("D"), cls("C"));
+        m.addAxiom(o, ab);
+        m.addAxiom(o, bc);
+        m.addAxiom(o, ad);
+        m.addAxiom(o, dc);
+
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = false;
+        report.justifications = Arrays.asList(
+            justification("Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n  SubClassOf(:B :C)\n)\n"),
+            justification("Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :D)\n  SubClassOf(:D :C)\n)\n"));
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        Set<Explanation<OWLAxiom>> explanations = generator(o).materialize(entailment, report);
+        assertEquals(2, explanations.size());
+    }
+
+    @Test public void getExplanationsWithZeroLimitStillValidatesEntailmentSurface() throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto4/"));
+        try {
+            generator(o).getExplanations(df.getOWLDeclarationAxiom(cls("A")), 5);
+            fail("expected UnsupportedEntailmentException");
+        } catch (UnsupportedEntailmentException expected) {
+            // correct: an unsupported query must fail even before touching the limit.
+        }
+        assertTrue(generator(o).getExplanations(
+            df.getOWLSubClassOfAxiom(cls("A"), cls("B")), 0).isEmpty());
+    }
+}

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorTest.java
@@ -140,7 +140,7 @@ public class RustdlExplanationGeneratorTest {
         return j;
     }
 
-    @Test public void materializeReturnsVerifiedExplanationDroppingFabrication() throws Exception {
+    @Test public void materializeRejectsWholeJustificationContainingFabricatedAxiom() throws Exception {
         OWLOntology o = m.createOntology(IRI.create("http://ex/onto1/"));
         OWLSubClassOfAxiom ab = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
         OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(cls("B"), cls("C"));
@@ -159,6 +159,34 @@ public class RustdlExplanationGeneratorTest {
                 + "  SubClassOf(:A :B)\n  SubClassOf(:B :C)\n  SubClassOf(:X :Y)\n)\n"));
 
         OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        // A justification containing even one non-source axiom must be REJECTED WHOLE -- no
+        // Explanation is produced from it at all (never a silently-thinned genuine subset,
+        // which could be genuine-but-insufficient to actually entail the target).
+        try {
+            generator(o).materialize(entailment, report);
+            fail("expected ExplanationException rejecting the fabricated justification");
+        } catch (org.semanticweb.owl.explanation.api.ExplanationException expected) {
+            // correct: whole-justification reject, mirroring km's actual behavior.
+        }
+    }
+
+    @Test public void materializeReturnsExplanationForFullyGenuineJustification() throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto1b/"));
+        OWLSubClassOfAxiom ab = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(cls("B"), cls("C"));
+        m.addAxiom(o, ab);
+        m.addAxiom(o, bc);
+
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = false;
+        report.justifications = Arrays.asList(justification(
+            "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n  SubClassOf(:B :C)\n)\n"));
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
         Set<Explanation<OWLAxiom>> explanations = generator(o).materialize(entailment, report);
 
         assertEquals(1, explanations.size());
@@ -167,6 +195,36 @@ public class RustdlExplanationGeneratorTest {
         assertEquals(2, explanation.getAxioms().size());
         assertTrue(explanation.getAxioms().contains(ab));
         assertTrue(explanation.getAxioms().contains(bc));
+    }
+
+    @Test public void materializeAbortsWholeBatchWhenOneOfSeveralJustificationsIsFabricated()
+            throws Exception {
+        // Mirrors km's actual choice: materialize() doesn't catch the fail-hard check per
+        // justification, so ANY offending justification aborts the ENTIRE call -- including
+        // other, fully-genuine justifications in the same report/batch.
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto1c/"));
+        OWLSubClassOfAxiom ab = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(cls("B"), cls("C"));
+        m.addAxiom(o, ab);
+        m.addAxiom(o, bc);
+
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = false;
+        report.justifications = Arrays.asList(
+            justification("Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n  SubClassOf(:B :C)\n)\n"),
+            justification("Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:X :Y)\n)\n"));
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        try {
+            generator(o).materialize(entailment, report);
+            fail("expected ExplanationException aborting the whole batch");
+        } catch (org.semanticweb.owl.explanation.api.ExplanationException expected) {
+            // correct.
+        }
     }
 
     @Test public void materializeReturnsEmptySetForNotEntailed() throws Exception {

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlExplanationGeneratorTest.java
@@ -134,6 +134,12 @@ public class RustdlExplanationGeneratorTest {
             new RustdlExplainConfiguration(600L, 8), false);
     }
 
+    private RustdlExplanationGenerator laconicGenerator(OWLOntology ontology) {
+        return new RustdlExplanationGenerator(
+            ontology, new NullExplanationProgressMonitor<OWLAxiom>(),
+            new RustdlExplainConfiguration(600L, 8), true);
+    }
+
     private RustdlJson.JustificationJson justification(String ofn) {
         RustdlJson.JustificationJson j = new RustdlJson.JustificationJson();
         j.ofn = ofn;
@@ -266,6 +272,80 @@ public class RustdlExplanationGeneratorTest {
         OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("C"));
         Set<Explanation<OWLAxiom>> explanations = generator(o).materialize(entailment, report);
         assertEquals(2, explanations.size());
+    }
+
+    // --- Critical regression: laconic must bypass the literal source-membership guard ---------
+
+    /**
+     * Regression test for the Critical bug: a laconic justification is a WEAKENED FRAGMENT of a
+     * source axiom, genuinely absent (as such) from the source ontology by design -- source has
+     * {@code SubClassOf(:A, ObjectIntersectionOf(:B,:C))}, the laconic-weakened justification for
+     * {@code SubClassOf(:A,:B)} is just {@code SubClassOf(:A,:B)} itself, which the source never
+     * literally contains. Before the fix, {@code materialize} unconditionally ran the literal
+     * {@code verifiedAgainst} guard even on the laconic path, so this canned report threw
+     * {@code ExplanationException} ("possible fabrication") instead of returning an Explanation.
+     * After the fix, the laconic generator must return a non-empty Explanation containing exactly
+     * the weakened fragment, without throwing.
+     */
+    @Test public void laconicMaterializeAcceptsGenuinelyWeakenedAxiomNotLiterallyInSource()
+            throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto5/"));
+        OWLSubClassOfAxiom sourceAxiom = df.getOWLSubClassOfAxiom(
+            cls("A"), df.getOWLObjectIntersectionOf(cls("B"), cls("C")));
+        m.addAxiom(o, sourceAxiom);
+
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = true;
+        // The weakened fragment SubClassOf(:A :B) is NOT literally in the source ontology (the
+        // source only has SubClassOf(:A, ObjectIntersectionOf(:B :C))) -- entailed by it, not
+        // equal to it.
+        report.justifications = Arrays.asList(justification(
+            "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n)\n"));
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        Set<Explanation<OWLAxiom>> explanations = laconicGenerator(o).materialize(entailment, report);
+
+        assertEquals(1, explanations.size());
+        Explanation<OWLAxiom> explanation = explanations.iterator().next();
+        assertEquals(entailment, explanation.getEntailment());
+        assertEquals(1, explanation.getAxioms().size());
+        assertTrue(explanation.getAxioms().contains(
+            df.getOWLSubClassOfAxiom(cls("A"), cls("B"))));
+    }
+
+    /**
+     * The non-laconic (minimal) generator must keep rejecting the SAME weakened-fragment
+     * justification whole -- literal source-membership verification is the correct anti-
+     * fabrication defense for minimal justifications and must stay fail-hard even though the
+     * laconic generator now accepts an analogous fragment.
+     */
+    @Test public void nonLaconicMaterializeStillRejectsAxiomAbsentFromSource() throws Exception {
+        OWLOntology o = m.createOntology(IRI.create("http://ex/onto6/"));
+        OWLSubClassOfAxiom sourceAxiom = df.getOWLSubClassOfAxiom(
+            cls("A"), df.getOWLObjectIntersectionOf(cls("B"), cls("C")));
+        m.addAxiom(o, sourceAxiom);
+
+        RustdlJson.JustifyJson report = new RustdlJson.JustifyJson();
+        report.schema_version = 1;
+        report.status = "entailed";
+        report.enumeration_complete = true;
+        report.minimal = true;
+        report.laconic = false;
+        report.justifications = Arrays.asList(justification(
+            "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n)\n"));
+
+        OWLAxiom entailment = df.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        try {
+            generator(o).materialize(entailment, report);
+            fail("expected ExplanationException: SubClassOf(:A :B) is not literally a source "
+                + "axiom, and the non-laconic path must keep the fail-hard literal guard");
+        } catch (org.semanticweb.owl.explanation.api.ExplanationException expected) {
+            // correct.
+        }
     }
 
     @Test public void getExplanationsWithZeroLimitStillValidatesEntailmentSurface() throws Exception {

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfnTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfnTest.java
@@ -1,6 +1,7 @@
 package com.github.maastrichtu_ids.rustdl.protege;
 
 import org.junit.Test;
+import org.semanticweb.owl.explanation.api.ExplanationException;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
@@ -13,15 +14,15 @@ import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * {@link RustdlOfn} round-trips the self-contained OFN ontology DOCUMENT rustdl emits per
  * justification (Prefix(...)/Ontology(...) — see the real fixture captured in
- * {@code src/test/resources/json/justify.json}), and enforces the anti-fabrication guard: an
- * axiom absent from the source ontology's imports closure must never survive into a displayed
- * {@code Explanation}.
+ * {@code src/test/resources/json/justify.json}), and enforces the FAIL-HARD anti-fabrication
+ * guard: an axiom absent from the source ontology's imports closure must reject the WHOLE
+ * justification (never survive, partially or otherwise, into a displayed {@code Explanation}).
  */
 public class RustdlOfnTest {
 
@@ -54,7 +55,7 @@ public class RustdlOfnTest {
     }
 
     @Test
-    public void verifiedAgainstDropsFabricatedAxiom() throws Exception {
+    public void verifiedAgainstRejectsWholeJustificationOnFabricatedAxiom() throws Exception {
         OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
         OWLDataFactory df = manager.getOWLDataFactory();
         OWLClass a = df.getOWLClass(IRI.create("http://ex/#A"));
@@ -72,10 +73,17 @@ public class RustdlOfnTest {
         parsed.add(genuine);
         parsed.add(fabricated);
 
-        Set<OWLAxiom> verified = RustdlOfn.verifiedAgainst(parsed, source);
-        assertEquals(1, verified.size());
-        assertTrue(verified.contains(genuine));
-        assertFalse(verified.contains(fabricated));
+        // A single fabricated/non-source axiom must reject the ENTIRE justification -- not
+        // silently surface the genuine subset, which could be genuine-but-insufficient to
+        // actually entail the target (a misleading "Explanation").
+        try {
+            RustdlOfn.verifiedAgainst(parsed, source);
+            fail("expected ExplanationException rejecting the whole justification");
+        } catch (ExplanationException expected) {
+            assertTrue("exception should identify the offending axiom: " + expected.getMessage(),
+                expected.getMessage().contains(fabricated.toString())
+                    || expected.getMessage().contains("http://ex/#X"));
+        }
     }
 
     @Test

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfnTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfnTest.java
@@ -1,0 +1,102 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.junit.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link RustdlOfn} round-trips the self-contained OFN ontology DOCUMENT rustdl emits per
+ * justification (Prefix(...)/Ontology(...) — see the real fixture captured in
+ * {@code src/test/resources/json/justify.json}), and enforces the anti-fabrication guard: an
+ * axiom absent from the source ontology's imports closure must never survive into a displayed
+ * {@code Explanation}.
+ */
+public class RustdlOfnTest {
+
+    @Test
+    public void parsesRealJustificationDocument() {
+        String ofn = "Prefix(:=<http://ex/#>)\n"
+            + "Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n"
+            + "Ontology(\n"
+            + "  SubClassOf(:A :B)\n"
+            + "  SubClassOf(:B :C)\n"
+            + ")\n";
+        Set<OWLAxiom> axioms = RustdlOfn.parse(ofn);
+        assertEquals(2, axioms.size());
+        OWLDataFactory df = OWLManager.getOWLDataFactory();
+        OWLClass a = df.getOWLClass(IRI.create("http://ex/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex/#B"));
+        OWLClass c = df.getOWLClass(IRI.create("http://ex/#C"));
+        assertTrue(axioms.contains(df.getOWLSubClassOfAxiom(a, b)));
+        assertTrue(axioms.contains(df.getOWLSubClassOfAxiom(b, c)));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectsUnparseableDocument() {
+        RustdlOfn.parse("not an ofn document at all {{{");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsEmptyDocument() {
+        RustdlOfn.parse("");
+    }
+
+    @Test
+    public void verifiedAgainstDropsFabricatedAxiom() throws Exception {
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+        OWLDataFactory df = manager.getOWLDataFactory();
+        OWLClass a = df.getOWLClass(IRI.create("http://ex/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex/#B"));
+        OWLClass x = df.getOWLClass(IRI.create("http://ex/#X"));
+        OWLClass y = df.getOWLClass(IRI.create("http://ex/#Y"));
+        OWLSubClassOfAxiom genuine = df.getOWLSubClassOfAxiom(a, b);
+        OWLSubClassOfAxiom fabricated = df.getOWLSubClassOfAxiom(x, y);
+
+        OWLOntology source = manager.createOntology(IRI.create("http://ex/"));
+        manager.addAxiom(source, genuine);
+        // NOTE: `fabricated` is deliberately never added to `source`.
+
+        Set<OWLAxiom> parsed = new java.util.LinkedHashSet<>();
+        parsed.add(genuine);
+        parsed.add(fabricated);
+
+        Set<OWLAxiom> verified = RustdlOfn.verifiedAgainst(parsed, source);
+        assertEquals(1, verified.size());
+        assertTrue(verified.contains(genuine));
+        assertFalse(verified.contains(fabricated));
+    }
+
+    @Test
+    public void verifiedAgainstKeepsEveryGenuineAxiom() throws Exception {
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+        OWLDataFactory df = manager.getOWLDataFactory();
+        OWLClass a = df.getOWLClass(IRI.create("http://ex/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex/#B"));
+        OWLClass c = df.getOWLClass(IRI.create("http://ex/#C"));
+        OWLSubClassOfAxiom ab = df.getOWLSubClassOfAxiom(a, b);
+        OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(b, c);
+
+        OWLOntology source = manager.createOntology(IRI.create("http://ex/"));
+        manager.addAxiom(source, ab);
+        manager.addAxiom(source, bc);
+
+        Set<OWLAxiom> parsed = new java.util.LinkedHashSet<>();
+        parsed.add(ab);
+        parsed.add(bc);
+
+        Set<OWLAxiom> verified = RustdlOfn.verifiedAgainst(parsed, source);
+        assertEquals(2, verified.size());
+    }
+}

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfnTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfnTest.java
@@ -87,6 +87,40 @@ public class RustdlOfnTest {
     }
 
     @Test
+    public void singleLogicalAxiomExtractsTheOneLogicalAxiom() {
+        String ofn = "Prefix(:=<http://ex/#>)\n"
+            + "Ontology(\n"
+            + "  Declaration(Class(:A))\n"
+            + "  Declaration(Class(:B))\n"
+            + "  SubClassOf(:A :B)\n"
+            + ")\n";
+        OWLAxiom axiom = RustdlOfn.singleLogicalAxiom(ofn);
+        OWLDataFactory df = OWLManager.getOWLDataFactory();
+        OWLClass a = df.getOWLClass(IRI.create("http://ex/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex/#B"));
+        assertEquals(df.getOWLSubClassOfAxiom(a, b), axiom);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void singleLogicalAxiomRejectsZeroLogicalAxioms() {
+        String ofn = "Prefix(:=<http://ex/#>)\n"
+            + "Ontology(\n"
+            + "  Declaration(Class(:A))\n"
+            + ")\n";
+        RustdlOfn.singleLogicalAxiom(ofn);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void singleLogicalAxiomRejectsMoreThanOneLogicalAxiom() {
+        String ofn = "Prefix(:=<http://ex/#>)\n"
+            + "Ontology(\n"
+            + "  SubClassOf(:A :B)\n"
+            + "  SubClassOf(:B :C)\n"
+            + ")\n";
+        RustdlOfn.singleLogicalAxiom(ofn);
+    }
+
+    @Test
     public void verifiedAgainstKeepsEveryGenuineAxiom() throws Exception {
         OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
         OWLDataFactory df = manager.getOWLDataFactory();

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
@@ -157,6 +157,60 @@ public class RustdlProcessTest {
     }
 
     @Test
+    public void pollingRunCommandAbortsPromptlyWhenCancelled() throws Exception {
+        assumeFalse(isWindows());
+        long start = System.currentTimeMillis();
+        java.util.concurrent.atomic.AtomicInteger polls = new java.util.concurrent.atomic.AtomicInteger();
+        try {
+            // A predicate that reports cancelled on its very first poll: the polling loop ticks
+            // every ~100ms, so this must destroy the still-sleeping process and abort in well
+            // under the (deliberately generous, real-timeout-would-mask-the-bug) 30s command
+            // timeout and the 30s sleep itself.
+            RustdlProcess.runCommand(
+                Arrays.asList("sh", "-c", "sleep 30"), "test", 30,
+                () -> polls.incrementAndGet() >= 1);
+            fail("expected CancelledException when the predicate reports cancelled");
+        } catch (RustdlProcess.CancelledException e) {
+            assertTrue("message should mention cancellation: " + e.getMessage(),
+                e.getMessage().contains("cancelled"));
+        }
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue("expected cancellation to fire within ~100ms polling granularity, took "
+                + elapsed + "ms",
+            elapsed < 5_000);
+        assertTrue("expected the predicate to actually be polled", polls.get() >= 1);
+    }
+
+    @Test
+    public void pollingRunCommandBehavesLikeNonPollingVariantWhenNeverCancelled() throws Exception {
+        // The plain 3-arg runCommand delegates to the polling 4-arg variant with `() -> false`;
+        // confirm that delegation preserves identical success-path behavior for the reasoner
+        // path's existing callers (no cancellation predicate involved at all).
+        String out = RustdlProcess.runCommand(
+            Arrays.asList("sh", "-c", "printf DONE"), "test", 5, () -> false);
+        assertEquals("DONE", out);
+    }
+
+    @Test
+    public void pollingRunCommandStillTimesOutWhenNeverCancelled() throws Exception {
+        assumeFalse(isWindows());
+        long start = System.currentTimeMillis();
+        try {
+            RustdlProcess.runCommand(
+                Arrays.asList("sh", "-c", "sleep 30"), "test", 1, () -> false);
+            fail("expected plain (non-Cancelled) IOException for a timed-out process");
+        } catch (RustdlProcess.CancelledException e) {
+            fail("timeout must not be reported as CancelledException: " + e.getMessage());
+        } catch (IOException e) {
+            assertTrue("message should mention timeout: " + e.getMessage(),
+                e.getMessage().contains("timed out"));
+        }
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue("expected the timeout to fire well under 30s, took " + elapsed + "ms",
+            elapsed < 10_000);
+    }
+
+    @Test
     public void noDeadlockOnLargeStderr() throws Exception {
         assumeFalse(isWindows());
         String out = RustdlProcess.runCommand(

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
@@ -87,6 +87,55 @@ public class RustdlProcessTest {
         RustdlProcess.parseDisjoint("{\"schema_version\":2}");
     }
 
+    @Test public void parsesJustify() throws Exception {
+        RustdlJson.JustifyJson j = RustdlProcess.parseJustify(fixture("justify.json"));
+        assertEquals(1, j.schema_version);
+        assertEquals("entailed", j.status);
+        assertTrue(j.enumeration_complete);
+        assertTrue(j.minimal);
+        assertFalse(j.laconic);
+        assertEquals(1, j.justifications.size());
+        assertTrue(j.justifications.get(0).ofn.contains("SubClassOf(:A :B)"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectsWrongSchemaVersionJustify() {
+        RustdlProcess.parseJustify("{\"schema_version\":2}");
+    }
+
+    @Test
+    public void justifyCommandShapeNonLaconic() throws Exception {
+        String prev = System.getProperty("rustdl.bin");
+        Path fakeBin = Paths.get(getClass().getResource("/json/classify.json").toURI());
+        System.setProperty("rustdl.bin", fakeBin.toString());
+        try {
+            java.util.List<String> cmd = RustdlProcess.buildJustifyCommand(
+                Paths.get("ont.ofn"), false, 8,
+                Arrays.asList("subclass", "http://ex/#A", "http://ex/#C"));
+            assertEquals(Arrays.asList(
+                fakeBin.toString(), "justify", "--all", "--json", "--max", "8",
+                "ont.ofn", "subclass", "http://ex/#A", "http://ex/#C"), cmd);
+        } finally {
+            if (prev == null) System.clearProperty("rustdl.bin"); else System.setProperty("rustdl.bin", prev);
+        }
+    }
+
+    @Test
+    public void justifyCommandShapeLaconicIncludesFlag() throws Exception {
+        String prev = System.getProperty("rustdl.bin");
+        Path fakeBin = Paths.get(getClass().getResource("/json/classify.json").toURI());
+        System.setProperty("rustdl.bin", fakeBin.toString());
+        try {
+            java.util.List<String> cmd = RustdlProcess.buildJustifyCommand(
+                Paths.get("ont.ofn"), true, 3, Arrays.asList("inconsistent"));
+            assertEquals(Arrays.asList(
+                fakeBin.toString(), "justify", "--all", "--json", "--laconic", "--max", "3",
+                "ont.ofn", "inconsistent"), cmd);
+        } finally {
+            if (prev == null) System.clearProperty("rustdl.bin"); else System.setProperty("rustdl.bin", prev);
+        }
+    }
+
     private static boolean isWindows() {
         return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
     }

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
@@ -103,6 +103,53 @@ public class RustdlProcessTest {
         RustdlProcess.parseJustify("{\"schema_version\":2}");
     }
 
+    @Test public void parsesProveWithStepProof() throws Exception {
+        RustdlJson.ProveJson p = RustdlProcess.parseProve(fixture("prove.json"));
+        assertEquals(1, p.schema_version);
+        assertTrue(p.entailed);
+        assertTrue(p.has_proof);
+        assertNull(p.justification_fallback);
+        assertNotNull(p.proof);
+        assertEquals("SubsumerTransitivity(fwd)", p.proof.rule);
+        assertTrue(p.proof.conclusion.contains("SubClassOf(:A :C)"));
+        assertTrue(p.proof.axioms.isEmpty());
+        assertEquals(2, p.proof.premises.size());
+        assertEquals("ToldSubsumer", p.proof.premises.get(0).rule);
+        assertTrue(p.proof.premises.get(0).conclusion.contains("SubClassOf(:A :B)"));
+        assertEquals(1, p.proof.premises.get(0).axioms.size());
+        assertTrue(p.proof.premises.get(1).conclusion.contains("SubClassOf(:B :C)"));
+    }
+
+    @Test public void parsesProveFallback() throws Exception {
+        RustdlJson.ProveJson p = RustdlProcess.parseProve(fixture("prove_fallback.json"));
+        assertTrue(p.entailed);
+        assertFalse(p.has_proof);
+        assertNull(p.proof);
+        assertTrue(p.justification_fallback.contains("SubClassOf(:X :Y)"));
+        assertTrue(p.justification_fallback.contains("SubClassOf(:Y :Z)"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectsWrongSchemaVersionProve() {
+        RustdlProcess.parseProve("{\"schema_version\":2}");
+    }
+
+    @Test
+    public void proveCommandShape() throws Exception {
+        String prev = System.getProperty("rustdl.bin");
+        Path fakeBin = Paths.get(getClass().getResource("/json/classify.json").toURI());
+        System.setProperty("rustdl.bin", fakeBin.toString());
+        try {
+            java.util.List<String> cmd = RustdlProcess.buildProveCommand(
+                Paths.get("ont.ofn"), "http://ex/#A", "http://ex/#C");
+            assertEquals(Arrays.asList(
+                fakeBin.toString(), "prove", "--json", "ont.ofn",
+                "http://ex/#A", "http://ex/#C"), cmd);
+        } finally {
+            if (prev == null) System.clearProperty("rustdl.bin"); else System.setProperty("rustdl.bin", prev);
+        }
+    }
+
     @Test
     public void justifyCommandShapeNonLaconic() throws Exception {
         String prev = System.getProperty("rustdl.bin");

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProcessTest.java
@@ -143,7 +143,7 @@ public class RustdlProcessTest {
             java.util.List<String> cmd = RustdlProcess.buildProveCommand(
                 Paths.get("ont.ofn"), "http://ex/#A", "http://ex/#C");
             assertEquals(Arrays.asList(
-                fakeBin.toString(), "prove", "--json", "ont.ofn",
+                fakeBin.toString(), "prove", "--json", "--", "ont.ofn",
                 "http://ex/#A", "http://ex/#C"), cmd);
         } finally {
             if (prev == null) System.clearProperty("rustdl.bin"); else System.setProperty("rustdl.bin", prev);
@@ -160,7 +160,7 @@ public class RustdlProcessTest {
                 Paths.get("ont.ofn"), false, 8,
                 Arrays.asList("subclass", "http://ex/#A", "http://ex/#C"));
             assertEquals(Arrays.asList(
-                fakeBin.toString(), "justify", "--all", "--json", "--max", "8",
+                fakeBin.toString(), "justify", "--all", "--json", "--max", "8", "--",
                 "ont.ofn", "subclass", "http://ex/#A", "http://ex/#C"), cmd);
         } finally {
             if (prev == null) System.clearProperty("rustdl.bin"); else System.setProperty("rustdl.bin", prev);
@@ -176,7 +176,7 @@ public class RustdlProcessTest {
             java.util.List<String> cmd = RustdlProcess.buildJustifyCommand(
                 Paths.get("ont.ofn"), true, 3, Arrays.asList("inconsistent"));
             assertEquals(Arrays.asList(
-                fakeBin.toString(), "justify", "--all", "--json", "--laconic", "--max", "3",
+                fakeBin.toString(), "justify", "--all", "--json", "--laconic", "--max", "3", "--",
                 "ont.ofn", "inconsistent"), cmd);
         } finally {
             if (prev == null) System.clearProperty("rustdl.bin"); else System.setProperty("rustdl.bin", prev);

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofTest.java
@@ -1,0 +1,123 @@
+package com.github.maastrichtu_ids.rustdl.protege;
+
+import org.junit.Test;
+import org.liveontologies.puli.Inference;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link RustdlProof} converts a canned {@code prove --json} result (the fixtures under
+ * {@code src/test/resources/json}) into a puli {@link org.liveontologies.puli.Proof} whose
+ * {@code getInferences(conclusion)} answers not just the root but every nested premise too.
+ */
+public class RustdlProofTest {
+
+    private static final OWLDataFactory DF = OWLManager.getOWLDataFactory();
+
+    private static OWLClass cls(String localName) {
+        return DF.getOWLClass(IRI.create("http://ex/#" + localName));
+    }
+
+    private String fixture(String name) throws Exception {
+        return new String(Files.readAllBytes(
+            Paths.get(getClass().getResource("/json/" + name).toURI())));
+    }
+
+    @Test
+    public void stepProofRootInferenceHasCorrectRuleAndPremises() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+
+        Collection<? extends Inference<OWLAxiom>> rootInferences = proof.getInferences(goal);
+        assertEquals(1, rootInferences.size());
+        Inference<OWLAxiom> root = rootInferences.iterator().next();
+        assertEquals("SubsumerTransitivity(fwd)", root.getName());
+        assertEquals(goal, root.getConclusion());
+
+        // The root's own JSON node cited no axioms (a pure transitivity step), so its premises
+        // are exactly the two child nodes' conclusions.
+        OWLSubClassOfAxiom ab = DF.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        OWLSubClassOfAxiom bc = DF.getOWLSubClassOfAxiom(cls("B"), cls("C"));
+        assertEquals(2, root.getPremises().size());
+        assertTrue(root.getPremises().contains(ab));
+        assertTrue(root.getPremises().contains(bc));
+    }
+
+    @Test
+    public void nestedPremiseInferenceIsReachableAndCitesItsAxiom() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+
+        OWLSubClassOfAxiom ab = DF.getOWLSubClassOfAxiom(cls("A"), cls("B"));
+        Collection<? extends Inference<OWLAxiom>> abInferences = proof.getInferences(ab);
+        // ab is BOTH the "ToldSubsumer" step's conclusion AND that same step's own cited axiom
+        // (a leaf node with no child premises, only a directly-cited axiom identical to what it
+        // proves) -- both got produce()d keyed by the same (structurally-equal) axiom, so both
+        // inferences are reachable from one getInferences(ab) call.
+        assertEquals(2, abInferences.size());
+
+        Inference<OWLAxiom> toldSubsumer = null;
+        Inference<OWLAxiom> asserted = null;
+        for (Inference<OWLAxiom> inference : abInferences) {
+            if ("ToldSubsumer".equals(inference.getName())) {
+                toldSubsumer = inference;
+            } else if ("asserted".equals(inference.getName())) {
+                asserted = inference;
+            }
+        }
+        assertTrue("expected a ToldSubsumer inference for ab", toldSubsumer != null);
+        assertTrue("expected an 'asserted' leaf inference for the cited axiom", asserted != null);
+
+        assertEquals(ab, toldSubsumer.getConclusion());
+        // The ToldSubsumer step cited its own axiom (SubClassOf(:A :B)) as its one premise.
+        assertEquals(1, toldSubsumer.getPremises().size());
+        assertEquals(ab, toldSubsumer.getPremises().get(0));
+
+        assertEquals(ab, asserted.getConclusion());
+        assertTrue(asserted.getPremises().isEmpty());
+    }
+
+    @Test
+    public void fallbackBuildsSyntheticJustificationInference() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove_fallback.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("Sub"), cls("Sup"));
+
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+
+        Collection<? extends Inference<OWLAxiom>> inferences = proof.getInferences(goal);
+        assertEquals(1, inferences.size());
+        Inference<OWLAxiom> inference = inferences.iterator().next();
+        assertEquals("justification", inference.getName());
+        assertEquals(goal, inference.getConclusion());
+
+        OWLSubClassOfAxiom xy = DF.getOWLSubClassOfAxiom(cls("X"), cls("Y"));
+        OWLSubClassOfAxiom yz = DF.getOWLSubClassOfAxiom(cls("Y"), cls("Z"));
+        assertEquals(2, inference.getPremises().size());
+        assertTrue(inference.getPremises().contains(xy));
+        assertTrue(inference.getPremises().contains(yz));
+    }
+
+    @Test
+    public void unreachableConclusionHasNoInferences() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+
+        OWLSubClassOfAxiom unrelated = DF.getOWLSubClassOfAxiom(cls("Unrelated1"), cls("Unrelated2"));
+        assertTrue(proof.getInferences(unrelated).isEmpty());
+    }
+}

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlSmokeIT.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlSmokeIT.java
@@ -190,6 +190,110 @@ public class RustdlSmokeIT {
     }
 
     /**
+     * Regression guard for the Critical bug fixed alongside this test: a laconic justification is
+     * a WEAKENED FRAGMENT of a source axiom, genuinely absent (as such, verbatim) from the source
+     * ontology by design -- {@code materialize} must NOT run the literal source-membership guard
+     * ({@link RustdlOfn#verifiedAgainst}) on the laconic path.
+     *
+     * <p>Ontology: {@code SubClassOf(:A, ObjectIntersectionOf(:B,:C))} only. Querying
+     * {@code justify --laconic subclass A B} against a REAL rustdl binary weakens the sole source
+     * axiom's RHS conjunction down to {@code SubClassOf(:A,:B)} -- entailed by the source axiom,
+     * but not literally equal to (or contained in) it. Before the fix, this genuinely-weakened
+     * case aborted the whole request via {@code ExplanationException} ("possible fabrication"),
+     * breaking laconic explanations in exactly the case they exist for. After the fix, the laconic
+     * generator must return a non-empty {@code Explanation} containing the weakened fragment.</p>
+     */
+    @Test public void laconicExplanationAcceptsGenuinelyWeakenedAxiomWithRealBinary() throws Exception {
+        assumeTrue("no rustdl binary available",
+            RustdlBinary.configuredOverride() != null
+            || RustdlBinary.class.getResource("/native") != null);
+        OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+        OWLDataFactory df = m.getOWLDataFactory();
+        OWLOntology o = m.createOntology(IRI.create("http://ex7/"));
+
+        OWLClass a = df.getOWLClass(IRI.create("http://ex7/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex7/#B"));
+        OWLClass c = df.getOWLClass(IRI.create("http://ex7/#C"));
+        // The ONLY source axiom: A subclass-of (B and C). Entails A subclass-of B, but that
+        // entailment is nowhere LITERALLY present as its own axiom in the source.
+        m.addAxiom(o, df.getOWLSubClassOfAxiom(a, df.getOWLObjectIntersectionOf(b, c)));
+
+        OWLSubClassOfAxiom entailment = df.getOWLSubClassOfAxiom(a, b);
+        ExplanationGenerator<OWLAxiom> laconicGenerator =
+            new RustdlLaconicExplanationGeneratorFactory().createExplanationGenerator(o);
+
+        Set<Explanation<OWLAxiom>> explanations = laconicGenerator.getExplanations(entailment);
+        assertFalse(
+            "real rustdl binary's laconic weakening must produce a genuine, non-empty "
+                + "Explanation instead of the fabrication guard aborting the whole request",
+            explanations.isEmpty());
+        boolean containsWeakenedFragment = explanations.stream()
+            .anyMatch(exp -> exp.getAxioms().contains(entailment));
+        assertTrue(
+            "expected at least one explanation to contain the weakened fragment SubClassOf(A,B)",
+            containsWeakenedFragment);
+    }
+
+    /**
+     * Minor hardening #4: round-trips a NON-TRIVIAL axiom shape (here, {@code
+     * ObjectSomeValuesFrom}) through the full in-memory-OWLAPI -> OFN -> {@code rustdl justify
+     * --json} -> OFN-parse -> {@code containsAxiom} path (the non-laconic/minimal
+     * anti-fabrication guard, {@link RustdlOfn#verifiedAgainst}), asserting the genuine axioms are
+     * NOT dropped. Guards against a future OFN writer/parser normalization mismatch silently
+     * rejecting genuine explanations for anything beyond bare named-class SubClassOf axioms.
+     *
+     * <p>Ontology: {@code A ⊑ ∃hasParent.B}, {@code B ⊑ C}, {@code ∃hasParent.C ⊑ D}, entailing
+     * {@code A ⊑ D} (via {@code B ⊑ C} monotonicity through the existential). The minimal
+     * justification for this entailment is exactly those three axioms, each involving
+     * {@code ObjectSomeValuesFrom} -- confirmed against the real binary before finalizing this
+     * test.</p>
+     */
+    @Test public void justifyRoundTripsNonTrivialExistentialAxiomWithRealBinary() throws Exception {
+        assumeTrue("no rustdl binary available",
+            RustdlBinary.configuredOverride() != null
+            || RustdlBinary.class.getResource("/native") != null);
+        OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+        OWLDataFactory df = m.getOWLDataFactory();
+        OWLOntology o = m.createOntology(IRI.create("http://ex8/"));
+
+        OWLClass a = df.getOWLClass(IRI.create("http://ex8/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex8/#B"));
+        OWLClass c = df.getOWLClass(IRI.create("http://ex8/#C"));
+        OWLClass d = df.getOWLClass(IRI.create("http://ex8/#D"));
+        OWLObjectProperty hasParent = df.getOWLObjectProperty(IRI.create("http://ex8/#hasParent"));
+
+        OWLSubClassOfAxiom aExistsB = df.getOWLSubClassOfAxiom(
+            a, df.getOWLObjectSomeValuesFrom(hasParent, b));
+        OWLSubClassOfAxiom bc = df.getOWLSubClassOfAxiom(b, c);
+        OWLSubClassOfAxiom existsCD = df.getOWLSubClassOfAxiom(
+            df.getOWLObjectSomeValuesFrom(hasParent, c), d);
+        m.addAxiom(o, aExistsB);
+        m.addAxiom(o, bc);
+        m.addAxiom(o, existsCD);
+
+        OWLSubClassOfAxiom entailment = df.getOWLSubClassOfAxiom(a, d);
+        ExplanationGenerator<OWLAxiom> generator =
+            new RustdlExplanationGeneratorFactory().createExplanationGenerator(o);
+        Set<Explanation<OWLAxiom>> explanations = generator.getExplanations(entailment);
+
+        assertFalse("real rustdl binary must return at least one justification for A subclass-of D",
+            explanations.isEmpty());
+        Explanation<OWLAxiom> explanation = explanations.iterator().next();
+        assertTrue(
+            "genuine ObjectSomeValuesFrom-bearing axiom A subclass-of ExistsHasParent.B must "
+                + "round-trip through OFN-write/rustdl-justify/OFN-parse and NOT be dropped by "
+                + "the literal-membership anti-fabrication guard",
+            explanation.getAxioms().contains(aExistsB));
+        assertTrue(
+            "genuine axiom B subclass-of C must round-trip and NOT be dropped",
+            explanation.getAxioms().contains(bc));
+        assertTrue(
+            "genuine ObjectSomeValuesFrom-bearing axiom ExistsHasParent.C subclass-of D must "
+                + "round-trip and NOT be dropped",
+            explanation.getAxioms().contains(existsCD));
+    }
+
+    /**
      * End-to-end proof-tree smoke against a REAL rustdl binary (Task 5, Step 1): the same tiny EL
      * ontology as above, this time queried via {@code rustdl prove --json} directly through
      * {@link RustdlProcess#prove} and converted with {@link RustdlProof#fromProveJson}.

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlSmokeIT.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlSmokeIT.java
@@ -1,11 +1,20 @@
 package com.github.maastrichtu_ids.rustdl.protege;
 
 import org.junit.Test;
+import org.liveontologies.puli.Inference;
+import org.semanticweb.owl.explanation.api.Explanation;
+import org.semanticweb.owl.explanation.api.ExplanationGenerator;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.reasoner.*;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Set;
 
 public class RustdlSmokeIT {
     @Test public void classifiesTinyOntologyWithRealBinary() throws Exception {
@@ -127,6 +136,113 @@ public class RustdlSmokeIT {
             fail("expected InconsistentOntologyException");
         } catch (org.semanticweb.owlapi.reasoner.InconsistentOntologyException expected) {
             // correct contract behaviour
+        }
+    }
+
+    /**
+     * End-to-end justification/laconic-justification smoke against a REAL rustdl binary (Task 5,
+     * Step 1): a tiny EL ontology ({@code A ⊑ B ⊑ C}, entailing {@code A ⊑ C}) is handed to
+     * {@link RustdlExplanationGeneratorFactory#createExplanationGenerator(OWLOntology)}, which
+     * spawns {@code rustdl justify --json} as a subprocess and parses its output. Asserts a
+     * non-empty {@code Set<Explanation<OWLAxiom>>} from both the non-laconic and laconic
+     * factories, and — the anti-fabrication guarantee holding end-to-end through the real
+     * binary, not just against canned JSON — that every axiom in every returned explanation is a
+     * genuine source axiom of the ontology (mirrors the fail-hard check in
+     * {@link RustdlOfn#verifiedAgainst}, exercised here via the real subprocess rather than a
+     * test seam).
+     */
+    @Test public void justifiesEntailmentWithRealBinaryAgainstSourceAxioms() throws Exception {
+        assumeTrue("no rustdl binary available",
+            RustdlBinary.configuredOverride() != null
+            || RustdlBinary.class.getResource("/native") != null);
+        OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+        OWLDataFactory df = m.getOWLDataFactory();
+        OWLOntology o = m.createOntology(IRI.create("http://ex4/"));
+
+        OWLClass a = df.getOWLClass(IRI.create("http://ex4/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex4/#B"));
+        OWLClass c = df.getOWLClass(IRI.create("http://ex4/#C"));
+        m.addAxiom(o, df.getOWLSubClassOfAxiom(a, b));
+        m.addAxiom(o, df.getOWLSubClassOfAxiom(b, c));
+
+        OWLSubClassOfAxiom entailment = df.getOWLSubClassOfAxiom(a, c);
+        Set<OWLAxiom> sourceAxioms = o.getAxioms(Imports.INCLUDED);
+
+        ExplanationGenerator<OWLAxiom> generator =
+            new RustdlExplanationGeneratorFactory().createExplanationGenerator(o);
+        Set<Explanation<OWLAxiom>> explanations = generator.getExplanations(entailment);
+        assertFalse("real rustdl binary must return at least one justification",
+            explanations.isEmpty());
+        for (Explanation<OWLAxiom> explanation : explanations) {
+            for (OWLAxiom axiom : explanation.getAxioms()) {
+                assertTrue(
+                    "explanation axiom must be a genuine source axiom of the ontology "
+                        + "(anti-fabrication): " + axiom,
+                    sourceAxioms.contains(axiom));
+            }
+        }
+
+        ExplanationGenerator<OWLAxiom> laconicGenerator =
+            new RustdlLaconicExplanationGeneratorFactory().createExplanationGenerator(o);
+        Set<Explanation<OWLAxiom>> laconicExplanations = laconicGenerator.getExplanations(entailment);
+        assertFalse("real rustdl binary must return at least one laconic justification",
+            laconicExplanations.isEmpty());
+    }
+
+    /**
+     * End-to-end proof-tree smoke against a REAL rustdl binary (Task 5, Step 1): the same tiny EL
+     * ontology as above, this time queried via {@code rustdl prove --json} directly through
+     * {@link RustdlProcess#prove} and converted with {@link RustdlProof#fromProveJson}.
+     *
+     * <p><b>Why not {@code RustdlProofService.getProof}:</b> {@code RustdlProofService} extends
+     * the liveontologies {@code ProofService} base class, whose {@code getEditorKit()} requires a
+     * full {@code org.protege.editor.owl.OWLEditorKit} — wired up only inside a running Protégé
+     * workbench ({@code ProofService.setup(OWLEditorKit, ...)}) — which cannot be constructed in
+     * a headless JUnit/Failsafe process. {@link RustdlProcess#prove} and {@link RustdlProof} are
+     * exactly the two pieces {@code RustdlProofService}'s {@code RecomputingProof.compute} calls
+     * internally (see its source), so invoking them directly here still exercises the real binary
+     * end-to-end through the proof path — the only piece skipped is the Protégé editor-kit
+     * plumbing around it, which has no reasoning logic of its own.</p>
+     */
+    @Test public void provesEntailmentWithRealBinaryProducingNonTrivialProof() throws Exception {
+        assumeTrue("no rustdl binary available",
+            RustdlBinary.configuredOverride() != null
+            || RustdlBinary.class.getResource("/native") != null);
+        OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+        OWLDataFactory df = m.getOWLDataFactory();
+        OWLOntology o = m.createOntology(IRI.create("http://ex5/"));
+
+        OWLClass a = df.getOWLClass(IRI.create("http://ex5/#A"));
+        OWLClass b = df.getOWLClass(IRI.create("http://ex5/#B"));
+        OWLClass c = df.getOWLClass(IRI.create("http://ex5/#C"));
+        m.addAxiom(o, df.getOWLSubClassOfAxiom(a, b));
+        m.addAxiom(o, df.getOWLSubClassOfAxiom(b, c));
+
+        Path ofn = Files.createTempFile("rustdl-smoke-prove-", ".ofn");
+        try {
+            FlattenedOntology.writeOfn(o, ofn);
+            RustdlJson.ProveJson json = RustdlProcess.prove(
+                ofn, "http://ex5/#A", "http://ex5/#C", 60L);
+            assertTrue("real rustdl binary must report the SubClassOf(A,C) entailment",
+                json.entailed);
+            assertTrue(
+                "real rustdl binary must return a step-level proof for this EL entailment "
+                    + "(not just the justification fallback)",
+                json.has_proof);
+
+            OWLSubClassOfAxiom goal = df.getOWLSubClassOfAxiom(a, c);
+            RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+
+            Collection<? extends Inference<OWLAxiom>> rootInferences = proof.getInferences(goal);
+            assertFalse("proof must contain an inference for the root goal conclusion",
+                rootInferences.isEmpty());
+            Inference<OWLAxiom> root = rootInferences.iterator().next();
+            assertEquals(goal, root.getConclusion());
+            assertFalse(
+                "root inference must be non-trivial (at least one premise, not a bare fact)",
+                root.getPremises().isEmpty());
+        } finally {
+            Files.deleteIfExists(ofn);
         }
     }
 }

--- a/protege/src/test/resources/json/justify.json
+++ b/protege/src/test/resources/json/justify.json
@@ -1,0 +1,4 @@
+{ "schema_version": 1, "status": "entailed", "enumeration_complete": true, "minimal": true, "laconic": false,
+  "justifications": [
+    { "ofn": "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n  SubClassOf(:B :C)\n)\n" }
+  ] }

--- a/protege/src/test/resources/json/prove.json
+++ b/protege/src/test/resources/json/prove.json
@@ -1,0 +1,22 @@
+{ "schema_version": 1, "entailed": true, "has_proof": true,
+  "proof": {
+    "conclusion": "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :C)\n)\n",
+    "rule": "SubsumerTransitivity(fwd)",
+    "axioms": [],
+    "premises": [
+      {
+        "conclusion": "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n)\n",
+        "rule": "ToldSubsumer",
+        "axioms": ["Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:A :B)\n)\n"],
+        "premises": []
+      },
+      {
+        "conclusion": "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:B :C)\n)\n",
+        "rule": "ToldSubsumer",
+        "axioms": ["Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:B :C)\n)\n"],
+        "premises": []
+      }
+    ]
+  },
+  "justification_fallback": null
+}

--- a/protege/src/test/resources/json/prove_fallback.json
+++ b/protege/src/test/resources/json/prove_fallback.json
@@ -1,0 +1,4 @@
+{ "schema_version": 1, "entailed": true, "has_proof": false,
+  "proof": null,
+  "justification_fallback": "Prefix(:=<http://ex/#>)\nOntology(\n  SubClassOf(:X :Y)\n  SubClassOf(:Y :Z)\n)\n"
+}


### PR DESCRIPTION
## Explanation surface: justifications, laconic, and proof trees in Protégé

Exposes rustdl's explanation capabilities in Protégé, bridged through two new CLI `--json` modes.

### CLI (Rust)
- **`rustdl justify --json`** — minimal/laconic justifications as JSON. Each justification is a self-contained OWL Functional Syntax ontology document (`ofn`), plus honesty flags: `status`, `minimal` (true only when every justification is `minimal_guaranteed`), `laconic`, and `enumeration_complete` (exact via a `max+1` probe).
- **`rustdl prove --json`** — step-level EL proof trees (recursive `{conclusion, rule, axioms[], premises[]}`), or a `justification_fallback` outside the EL fragment. `DerivedFact`/`AxiomRef` render faithfully to OFN; the synthetic-def fallback fails loudly rather than emitting a placeholder.
- Schemas documented in `docs/json-schema.md`.

### Protégé plugin (Java / OSGi)
- **Justifications + laconic** via the OWL Explanation API — two factories (`rustdl`, `rustdl (laconic)`) surfaced in the "?" dialog. Mirrors the km plugin; owlexplanation 2.0.1 + telemetry 2.0.0 embedded.
- **Anti-fabrication**: minimal justifications are fail-hard verified against the source ontology (any non-source axiom rejects the whole justification). Laconic fragments — entailed-by-source weakenings, not source axioms — correctly bypass the literal-membership guard and rely on rustdl's sound-by-construction weakening.
- **Proof trees** via the liveontologies `ProofService` extension point. Mirrors ELK; puli / owlapi-proof / protege-proof-explanation / protege-proof-justification are optional OSGi imports (NOT embedded) — the proof view requires Protégé's proof-explanation plugin installed; justifications work without it.

### Testing
- Rust golden tests for both `--json` modes (incl. a Tseitin-conjunction proof node and SROIQ fallback).
- Java unit tests (entailment→query mapping, OFN round-trip + `.contains()` guard, canned-JSON generator/proof construction) + a **real-binary smoke IT** exercising justify, laconic (with genuine weakening), and the proof path end-to-end.
- Hardening: `--` end-of-options separator before positional IRI args; non-trivial-axiom round-trip coverage.

Ships as one patch release once merged. Built on `RUSTUP_TOOLCHAIN=stable`; plugin on JDK 17 / OWLAPI 4.5.29 / Protégé 5.6.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
