### PR TITLE
feat(justify): PreparedOntology — reuse per-ontology state across justification queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and `rustdl.prepare_bytes(data, format=...)` do that work once and return a
 `PreparedOntology` whose `.justify(query)` / `.justify_all(query, max)` reuse it,
 amortizing the setup across many justifications of the same ontology. Results are
 identical to the one-shot functions. On the reasoner side this is
-`justify::PreparedJustifier::{prepare, find_one, find_all}`; the existing
-`find_one_justification`/`find_all_justifications` now delegate to it. The
+`justify::PreparedJustifier::{prepare, find_one, find_all}`, sharing the
+`QuickXplain`/HST search with `find_one_justification`/`find_all_justifications`
+(which keep classifying the fragment only on the entailed path, so a not-entailed
+one-shot query costs no more than before). `rustdl report` now prepares once and
+reuses it across all roots instead of re-deriving per root. The
 `PreparedOntology` Python object is unsendable — use it from the creating thread.
 
 ## [0.4.17] - 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to rustdl are documented here. Format is based on
 
 ## [Unreleased]
 
+### Added — `PreparedOntology`: reuse justification state across queries
+
+`justify`/`justify_all` reload and re-derive per-ontology state (parse,
+logical-axiom split, fragment classification) on every call. `rustdl.prepare(path)`
+and `rustdl.prepare_bytes(data, format=...)` do that work once and return a
+`PreparedOntology` whose `.justify(query)` / `.justify_all(query, max)` reuse it,
+amortizing the setup across many justifications of the same ontology. Results are
+identical to the one-shot functions. On the reasoner side this is
+`justify::PreparedJustifier::{prepare, find_one, find_all}`; the existing
+`find_one_justification`/`find_all_justifications` now delegate to it. The
+`PreparedOntology` Python object is unsendable — use it from the creating thread.
+
 ## [0.4.17] - 2026-08-10
 
 ### Fixed — `classify` reported `consistent: true` on inconsistent ontologies

--- a/crates/owl-dl-cli/src/report.rs
+++ b/crates/owl-dl-cli/src/report.rs
@@ -12,7 +12,9 @@ use horned_owl::curie::PrefixMapping;
 use horned_owl::io::omn::AsManchester;
 use horned_owl::model::{Component, RcStr};
 use horned_owl::ontology::set::SetOntology;
-use owl_dl_reasoner::justify::{Entailment, component_entities, find_one_justification};
+use owl_dl_reasoner::justify::{
+    Entailment, PreparedJustifier, component_entities, find_one_justification,
+};
 use std::collections::HashMap;
 
 /// One root unsatisfiable class with its explanation and fixes.
@@ -307,9 +309,15 @@ pub(crate) fn build_report(
     let truncated_roots = n_root.saturating_sub(max_roots);
     let mut repairs_complete = true;
     let mut roots = Vec::new();
+    // Every root is justified against the SAME ontology, so the per-ontology
+    // state (axiom split + fragment) is derived once and reused. Built lazily so
+    // a report with no roots to justify doesn't pay for it.
+    let mut justifier: Option<PreparedJustifier<RcStr>> = None;
     for iri in diag.roots.iter().take(max_roots) {
         let q = Entailment::Unsatisfiable { class: iri.clone() };
-        let justification = find_one_justification(onto, &q)
+        let justification = justifier
+            .get_or_insert_with(|| PreparedJustifier::prepare(onto))
+            .find_one(&q)
             .context("justify root")?
             .map(|j| j.axioms)
             .unwrap_or_default();

--- a/crates/owl-dl-py/python/rustdl/__init__.py
+++ b/crates/owl-dl-py/python/rustdl/__init__.py
@@ -49,6 +49,9 @@ from rustdl._native import (
     diagnose as diagnose,
     repair as repair,
     render_manchester as render_manchester,
+    prepare as prepare,
+    prepare_bytes as prepare_bytes,
+    PreparedOntology as PreparedOntology,
 )
 
 from ._results import (
@@ -353,6 +356,9 @@ __all__ = [
     "diagnose",
     "repair",
     "render_manchester",
+    "prepare",
+    "prepare_bytes",
+    "PreparedOntology",
     "debug",
     "Diagnosis",
     "Root",

--- a/crates/owl-dl-py/python/rustdl/__init__.pyi
+++ b/crates/owl-dl-py/python/rustdl/__init__.pyi
@@ -296,6 +296,26 @@ def render_manchester(path: str) -> list[str]:
     """Every logical axiom of the ontology at `path` as Manchester strings."""
     ...
 
+class PreparedOntology:
+    """A loaded ontology with per-ontology justification state precomputed once
+    (parse + axiom split + fragment classification). Reuse it to justify many
+    queries without re-doing that full-ontology work on each call. Use it from
+    the thread that created it."""
+    def justify(self, query: list[str]) -> list[str]:
+        """One minimal justification (Manchester axioms) for `query`."""
+        ...
+    def justify_all(self, query: list[str], max: int = 10) -> list[list[str]]:
+        """Up to `max` minimal justifications for `query`."""
+        ...
+
+def prepare(path: str) -> PreparedOntology:
+    """Load the ontology at `path` and precompute its justification state."""
+    ...
+
+def prepare_bytes(data: bytes, *, format: str) -> PreparedOntology:
+    """Like `prepare`, from in-memory bytes (`format`: "ofn"|"owx"|"rdf-xml"|"omn")."""
+    ...
+
 def debug(path: str) -> Diagnosis:
     """One-call ontology diagnosis: consistency + root/derived unsat +
     per-root justifications + repairs."""

--- a/crates/owl-dl-py/src/explain.rs
+++ b/crates/owl-dl-py/src/explain.rs
@@ -111,12 +111,69 @@ pub(crate) fn repair(path: &str, query: Vec<String>, max: usize) -> PyResult<Vec
         .collect())
 }
 
+/// A loaded ontology with the per-ontology justification state precomputed once
+/// (parse + logical-axiom split + fragment classification). Reuse it to justify
+/// many queries without re-doing that full-ontology work each call — a large
+/// win on big ontologies. Unsendable: use it from the thread that created it.
+#[pyclass(name = "PreparedOntology", module = "rustdl", unsendable)]
+pub(crate) struct PyPreparedOntology {
+    inner: owl_dl_reasoner::justify::PreparedJustifier<RcStr>,
+}
+
+#[pymethods]
+impl PyPreparedOntology {
+    /// One minimal justification for a query (CLI-style tokens; see `justify`).
+    /// Empty list if not entailed.
+    #[allow(clippy::needless_pass_by_value)]
+    fn justify(&self, query: Vec<String>) -> PyResult<Vec<String>> {
+        let q = owl_dl_reasoner::justify::parse_query(&query).map_err(PyValueError::new_err)?;
+        let j = self.inner.find_one(&q).map_err(reason_error_to_py)?;
+        Ok(j.map(|j| j.axioms.iter().map(render).collect())
+            .unwrap_or_default())
+    }
+
+    /// All minimal justifications (capped by `max`).
+    #[pyo3(signature = (query, max = 10))]
+    #[allow(clippy::needless_pass_by_value)]
+    fn justify_all(&self, query: Vec<String>, max: usize) -> PyResult<Vec<Vec<String>>> {
+        let q = owl_dl_reasoner::justify::parse_query(&query).map_err(PyValueError::new_err)?;
+        let js = self.inner.find_all(&q, max).map_err(reason_error_to_py)?;
+        Ok(js
+            .into_iter()
+            .map(|j| j.axioms.iter().map(render).collect())
+            .collect())
+    }
+}
+
+/// `rustdl.prepare(path)` — load an ontology and precompute its justification
+/// state, returning a reusable `PreparedOntology`.
+#[pyfunction]
+pub(crate) fn prepare(path: &str) -> PyResult<PyPreparedOntology> {
+    let onto = load::load_path(path)?;
+    Ok(PyPreparedOntology {
+        inner: owl_dl_reasoner::justify::PreparedJustifier::prepare(&onto),
+    })
+}
+
+/// `rustdl.prepare_bytes(data, format="ofn")` — same, from in-memory bytes.
+#[pyfunction]
+#[pyo3(signature = (data, *, format))]
+pub(crate) fn prepare_bytes(data: &[u8], format: &str) -> PyResult<PyPreparedOntology> {
+    let onto = load::load_bytes(data, format)?;
+    Ok(PyPreparedOntology {
+        inner: owl_dl_reasoner::justify::PreparedJustifier::prepare(&onto),
+    })
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(justify, m)?)?;
     m.add_function(wrap_pyfunction!(justify_all, m)?)?;
     m.add_function(wrap_pyfunction!(diagnose, m)?)?;
     m.add_function(wrap_pyfunction!(repair, m)?)?;
     m.add_function(wrap_pyfunction!(render_manchester, m)?)?;
+    m.add_class::<PyPreparedOntology>()?;
+    m.add_function(wrap_pyfunction!(prepare, m)?)?;
+    m.add_function(wrap_pyfunction!(prepare_bytes, m)?)?;
     Ok(())
 }
 

--- a/crates/owl-dl-py/src/explain.rs
+++ b/crates/owl-dl-py/src/explain.rs
@@ -155,7 +155,9 @@ pub(crate) fn prepare(path: &str) -> PyResult<PyPreparedOntology> {
     })
 }
 
-/// `rustdl.prepare_bytes(data, format="ofn")` — same, from in-memory bytes.
+/// `rustdl.prepare_bytes(data, *, format)` — same, from in-memory bytes.
+/// `format` is required and keyword-only (as on `classify_bytes`): one of
+/// `"ofn"`, `"owx"`, `"rdf-xml"`, `"omn"`.
 #[pyfunction]
 #[pyo3(signature = (data, *, format))]
 pub(crate) fn prepare_bytes(data: &[u8], format: &str) -> PyResult<PyPreparedOntology> {

--- a/crates/owl-dl-py/tests/python/test_explain.py
+++ b/crates/owl-dl-py/tests/python/test_explain.py
@@ -42,6 +42,29 @@ def test_justify(tmp_path):
     assert any("Bad" in a for a in ax)
 
 
+def test_prepare_reexports():
+    for name in ["prepare", "prepare_bytes", "PreparedOntology"]:
+        assert hasattr(rustdl, name), f"rustdl.{name} not exported"
+        assert name in rustdl.__all__, f"{name} missing from __all__"
+
+
+def test_prepared_justify_matches_free_function(tmp_path):
+    # A PreparedOntology reused across queries must give the same justification
+    # as the one-shot rustdl.justify().
+    p = _write(tmp_path, BROKEN)
+    onto = rustdl.prepare(p)
+    prepared = onto.justify(["unsat", "urn:Bad"])
+    cold = rustdl.justify(p, ["unsat", "urn:Bad"])
+    assert prepared, "expected a non-empty justification"
+    assert sorted(prepared) == sorted(cold)
+
+
+def test_prepare_bytes(tmp_path):
+    onto = rustdl.prepare_bytes(BROKEN.encode(), format="ofn")
+    ax = onto.justify(["unsat", "urn:Bad"])
+    assert any("Bad" in a for a in ax)
+
+
 def test_diagnose(tmp_path):
     p = _write(tmp_path, BROKEN)
     consistent, roots, derived = rustdl.diagnose(p)

--- a/crates/owl-dl-py/tests/python/test_explain.py
+++ b/crates/owl-dl-py/tests/python/test_explain.py
@@ -59,7 +59,7 @@ def test_prepared_justify_matches_free_function(tmp_path):
     assert sorted(prepared) == sorted(cold)
 
 
-def test_prepare_bytes(tmp_path):
+def test_prepare_bytes():
     onto = rustdl.prepare_bytes(BROKEN.encode(), format="ofn")
     ax = onto.justify(["unsat", "urn:Bad"])
     assert any("Bad" in a for a in ax)

--- a/crates/owl-dl-reasoner/src/justify.rs
+++ b/crates/owl-dl-reasoner/src/justify.rs
@@ -1135,26 +1135,129 @@ pub struct Justification<A: ForIRI> {
 ///
 /// # Errors
 /// Propagates [`ReasonError`].
+/// Per-ontology state precomputed once and reused across justification queries.
+///
+/// [`find_one_justification`]/[`find_all_justifications`] redo the full-ontology
+/// work — the logical-axiom split and the fragment `convert`+classification — on
+/// every call. Preparing once with [`PreparedJustifier::prepare`] and then
+/// calling [`PreparedJustifier::find_one`]/[`PreparedJustifier::find_all`] per
+/// query amortizes that across many justifications of the same ontology.
+pub struct PreparedJustifier<A: ForIRI> {
+    fixed: Vec<Component<A>>,
+    all_candidates: Vec<Component<A>>,
+    fragment: FragmentClassification,
+}
+
+impl<A: ForIRI> PreparedJustifier<A> {
+    /// Precompute the reusable per-ontology state (logical-axiom split + fragment).
+    #[must_use]
+    pub fn prepare(onto: &SetOntology<A>) -> Self {
+        let (fixed, all_candidates) = logical_axioms(onto);
+        let fragment = fragment_of(onto);
+        Self {
+            fixed,
+            all_candidates,
+            fragment,
+        }
+    }
+
+    fn minimal_guaranteed(&self) -> bool {
+        matches!(
+            self.fragment,
+            FragmentClassification::PureEl | FragmentClassification::Horn
+        )
+    }
+
+    /// One minimal justification for `q` (`None` if not entailed), reusing the
+    /// prepared state.
+    ///
+    /// # Errors
+    /// Propagates [`ReasonError`].
+    pub fn find_one(&self, q: &Entailment) -> Result<Option<Justification<A>>, ReasonError> {
+        let _sat_guard = maybe_saturation_oracle(&self.fixed, &self.all_candidates, q);
+        let Some(candidates) = localized_candidates(&self.fixed, &self.all_candidates, q)? else {
+            return Ok(None); // not entailed — nothing to justify
+        };
+        let core = quickxplain(&self.fixed, &candidates, q)?;
+        Ok(Some(Justification {
+            axioms: core,
+            fragment: self.fragment,
+            minimal_guaranteed: self.minimal_guaranteed(),
+        }))
+    }
+
+    /// Up to `max` minimal justifications for `q`, reusing the prepared state.
+    ///
+    /// # Errors
+    /// Propagates [`ReasonError`].
+    pub fn find_all(
+        &self,
+        q: &Entailment,
+        max: usize,
+    ) -> Result<Vec<Justification<A>>, ReasonError> {
+        let _sat_guard = maybe_saturation_oracle(&self.fixed, &self.all_candidates, q);
+        // Narrow to the query's ⊥-module up front: justification-preserving, so
+        // the HST below still discovers *every* justification — over a far
+        // smaller set.
+        let Some(candidates) = localized_candidates(&self.fixed, &self.all_candidates, q)? else {
+            return Ok(Vec::new()); // not entailed
+        };
+        let fixed = &self.fixed;
+        let mut found: Vec<Vec<Component<A>>> = Vec::new();
+        let mut seen: std::collections::HashSet<BTreeSet<Component<A>>> =
+            std::collections::HashSet::new();
+        // HST worklist: each node is a set of candidate-INDICES removed on the path.
+        let mut worklist: Vec<BTreeSet<usize>> = vec![BTreeSet::new()];
+        let mut explored: BTreeSet<BTreeSet<usize>> = BTreeSet::new();
+        while let Some(removed) = worklist.pop() {
+            if found.len() >= max {
+                break;
+            }
+            if !explored.insert(removed.clone()) {
+                continue;
+            }
+            let subset: Vec<Component<A>> = candidates
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| !removed.contains(i))
+                .map(|(_, c)| c.clone())
+                .collect();
+            if !entails(&ontology_from(fixed, &subset), q)? {
+                continue; // this branch cannot yield a justification
+            }
+            let j = quickxplain(fixed, &subset, q)?;
+            // Record if this justification (as an axiom SET) is new.
+            let key: BTreeSet<Component<A>> = j.iter().cloned().collect();
+            if seen.insert(key) {
+                found.push(j.clone());
+            }
+            // Branch: remove each justification axiom (by its candidate index).
+            for c in &j {
+                if let Some(idx) = candidates.iter().position(|x| x == c) {
+                    let mut next = removed.clone();
+                    next.insert(idx);
+                    worklist.push(next);
+                }
+            }
+        }
+        let minimal_guaranteed = self.minimal_guaranteed();
+        let fragment = self.fragment;
+        Ok(found
+            .into_iter()
+            .map(|axioms| Justification {
+                axioms,
+                fragment,
+                minimal_guaranteed,
+            })
+            .collect())
+    }
+}
+
 pub fn find_one_justification<A: ForIRI>(
     onto: &SetOntology<A>,
     q: &Entailment,
 ) -> Result<Option<Justification<A>>, ReasonError> {
-    let (fixed, all_candidates) = logical_axioms(onto);
-    let _sat_guard = maybe_saturation_oracle(&fixed, &all_candidates, q);
-    let Some(candidates) = localized_candidates(&fixed, &all_candidates, q)? else {
-        return Ok(None); // not entailed — nothing to justify
-    };
-    let core = quickxplain(&fixed, &candidates, q)?;
-    let fragment = fragment_of(onto);
-    let minimal_guaranteed = matches!(
-        fragment,
-        FragmentClassification::PureEl | FragmentClassification::Horn
-    );
-    Ok(Some(Justification {
-        axioms: core,
-        fragment,
-        minimal_guaranteed,
-    }))
+    PreparedJustifier::prepare(onto).find_one(q)
 }
 
 fn fragment_of<A: ForIRI>(onto: &SetOntology<A>) -> FragmentClassification {
@@ -1194,63 +1297,7 @@ pub fn find_all_justifications<A: ForIRI>(
     q: &Entailment,
     max: usize,
 ) -> Result<Vec<Justification<A>>, ReasonError> {
-    let (fixed, all_candidates) = logical_axioms(onto);
-    let _sat_guard = maybe_saturation_oracle(&fixed, &all_candidates, q);
-    // Narrow to the query's ⊥-module up front: justification-preserving, so the
-    // HST below still discovers *every* justification — over a far smaller set.
-    let Some(candidates) = localized_candidates(&fixed, &all_candidates, q)? else {
-        return Ok(Vec::new()); // not entailed
-    };
-    let mut found: Vec<Vec<Component<A>>> = Vec::new();
-    let mut seen: std::collections::HashSet<BTreeSet<Component<A>>> =
-        std::collections::HashSet::new();
-    // HST worklist: each node is a set of candidate-INDICES removed on the path.
-    let mut worklist: Vec<BTreeSet<usize>> = vec![BTreeSet::new()];
-    let mut explored: BTreeSet<BTreeSet<usize>> = BTreeSet::new();
-    while let Some(removed) = worklist.pop() {
-        if found.len() >= max {
-            break;
-        }
-        if !explored.insert(removed.clone()) {
-            continue;
-        }
-        let subset: Vec<Component<A>> = candidates
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| !removed.contains(i))
-            .map(|(_, c)| c.clone())
-            .collect();
-        if !entails(&ontology_from(&fixed, &subset), q)? {
-            continue; // this branch cannot yield a justification
-        }
-        let j = quickxplain(&fixed, &subset, q)?;
-        // Record if this justification (as an axiom SET) is new.
-        let key: BTreeSet<Component<A>> = j.iter().cloned().collect();
-        if seen.insert(key) {
-            found.push(j.clone());
-        }
-        // Branch: remove each justification axiom (by its candidate index).
-        for c in &j {
-            if let Some(idx) = candidates.iter().position(|x| x == c) {
-                let mut next = removed.clone();
-                next.insert(idx);
-                worklist.push(next);
-            }
-        }
-    }
-    let fragment = fragment_of(onto);
-    let minimal_guaranteed = matches!(
-        fragment,
-        FragmentClassification::PureEl | FragmentClassification::Horn
-    );
-    Ok(found
-        .into_iter()
-        .map(|axioms| Justification {
-            axioms,
-            fragment,
-            minimal_guaranteed,
-        })
-        .collect())
+    PreparedJustifier::prepare(onto).find_all(q, max)
 }
 
 /// `delta_nonempty`: whether the most recent addition to `fixed` was non-empty

--- a/crates/owl-dl-reasoner/src/justify.rs
+++ b/crates/owl-dl-reasoner/src/justify.rs
@@ -1129,12 +1129,6 @@ pub struct Justification<A: ForIRI> {
     pub minimal_guaranteed: bool,
 }
 
-/// Find ONE justification for `q` in `onto`, or `Ok(None)` if `onto` does not
-/// entail `q`. `QuickXplain` over the logical axioms; minimal on EL/Horn
-/// (rustdl complete), guaranteed-entailing on SROIQ.
-///
-/// # Errors
-/// Propagates [`ReasonError`].
 /// Per-ontology state precomputed once and reused across justification queries.
 ///
 /// [`find_one_justification`]/[`find_all_justifications`] redo the full-ontology
@@ -1161,29 +1155,14 @@ impl<A: ForIRI> PreparedJustifier<A> {
         }
     }
 
-    fn minimal_guaranteed(&self) -> bool {
-        matches!(
-            self.fragment,
-            FragmentClassification::PureEl | FragmentClassification::Horn
-        )
-    }
-
     /// One minimal justification for `q` (`None` if not entailed), reusing the
     /// prepared state.
     ///
     /// # Errors
     /// Propagates [`ReasonError`].
     pub fn find_one(&self, q: &Entailment) -> Result<Option<Justification<A>>, ReasonError> {
-        let _sat_guard = maybe_saturation_oracle(&self.fixed, &self.all_candidates, q);
-        let Some(candidates) = localized_candidates(&self.fixed, &self.all_candidates, q)? else {
-            return Ok(None); // not entailed — nothing to justify
-        };
-        let core = quickxplain(&self.fixed, &candidates, q)?;
-        Ok(Some(Justification {
-            axioms: core,
-            fragment: self.fragment,
-            minimal_guaranteed: self.minimal_guaranteed(),
-        }))
+        Ok(search_one(&self.fixed, &self.all_candidates, q)?
+            .map(|axioms| justification(axioms, self.fragment)))
     }
 
     /// Up to `max` minimal justifications for `q`, reusing the prepared state.
@@ -1195,69 +1174,112 @@ impl<A: ForIRI> PreparedJustifier<A> {
         q: &Entailment,
         max: usize,
     ) -> Result<Vec<Justification<A>>, ReasonError> {
-        let _sat_guard = maybe_saturation_oracle(&self.fixed, &self.all_candidates, q);
-        // Narrow to the query's ⊥-module up front: justification-preserving, so
-        // the HST below still discovers *every* justification — over a far
-        // smaller set.
-        let Some(candidates) = localized_candidates(&self.fixed, &self.all_candidates, q)? else {
-            return Ok(Vec::new()); // not entailed
-        };
-        let fixed = &self.fixed;
-        let mut found: Vec<Vec<Component<A>>> = Vec::new();
-        let mut seen: std::collections::HashSet<BTreeSet<Component<A>>> =
-            std::collections::HashSet::new();
-        // HST worklist: each node is a set of candidate-INDICES removed on the path.
-        let mut worklist: Vec<BTreeSet<usize>> = vec![BTreeSet::new()];
-        let mut explored: BTreeSet<BTreeSet<usize>> = BTreeSet::new();
-        while let Some(removed) = worklist.pop() {
-            if found.len() >= max {
-                break;
-            }
-            if !explored.insert(removed.clone()) {
-                continue;
-            }
-            let subset: Vec<Component<A>> = candidates
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| !removed.contains(i))
-                .map(|(_, c)| c.clone())
-                .collect();
-            if !entails(&ontology_from(fixed, &subset), q)? {
-                continue; // this branch cannot yield a justification
-            }
-            let j = quickxplain(fixed, &subset, q)?;
-            // Record if this justification (as an axiom SET) is new.
-            let key: BTreeSet<Component<A>> = j.iter().cloned().collect();
-            if seen.insert(key) {
-                found.push(j.clone());
-            }
-            // Branch: remove each justification axiom (by its candidate index).
-            for c in &j {
-                if let Some(idx) = candidates.iter().position(|x| x == c) {
-                    let mut next = removed.clone();
-                    next.insert(idx);
-                    worklist.push(next);
-                }
-            }
-        }
-        let minimal_guaranteed = self.minimal_guaranteed();
-        let fragment = self.fragment;
-        Ok(found
+        Ok(search_all(&self.fixed, &self.all_candidates, q, max)?
             .into_iter()
-            .map(|axioms| Justification {
-                axioms,
-                fragment,
-                minimal_guaranteed,
-            })
+            .map(|axioms| justification(axioms, self.fragment))
             .collect())
     }
 }
 
+fn justification<A: ForIRI>(
+    axioms: Vec<Component<A>>,
+    fragment: FragmentClassification,
+) -> Justification<A> {
+    Justification {
+        axioms,
+        fragment,
+        minimal_guaranteed: matches!(
+            fragment,
+            FragmentClassification::PureEl | FragmentClassification::Horn
+        ),
+    }
+}
+
+/// The `QuickXplain` search over an already-split ontology: axioms only, no
+/// fragment classification, so callers that don't have one yet can stay lazy.
+fn search_one<A: ForIRI>(
+    fixed: &[Component<A>],
+    all_candidates: &[Component<A>],
+    q: &Entailment,
+) -> Result<Option<Vec<Component<A>>>, ReasonError> {
+    let _sat_guard = maybe_saturation_oracle(fixed, all_candidates, q);
+    let Some(candidates) = localized_candidates(fixed, all_candidates, q)? else {
+        return Ok(None); // not entailed — nothing to justify
+    };
+    Ok(Some(quickxplain(fixed, &candidates, q)?))
+}
+
+/// The HST search over an already-split ontology; see [`search_one`].
+fn search_all<A: ForIRI>(
+    fixed: &[Component<A>],
+    all_candidates: &[Component<A>],
+    q: &Entailment,
+    max: usize,
+) -> Result<Vec<Vec<Component<A>>>, ReasonError> {
+    let _sat_guard = maybe_saturation_oracle(fixed, all_candidates, q);
+    // Narrow to the query's ⊥-module up front: justification-preserving, so the
+    // HST below still discovers *every* justification — over a far smaller set.
+    let Some(candidates) = localized_candidates(fixed, all_candidates, q)? else {
+        return Ok(Vec::new()); // not entailed
+    };
+    let mut found: Vec<Vec<Component<A>>> = Vec::new();
+    let mut seen: std::collections::HashSet<BTreeSet<Component<A>>> =
+        std::collections::HashSet::new();
+    // HST worklist: each node is a set of candidate-INDICES removed on the path.
+    let mut worklist: Vec<BTreeSet<usize>> = vec![BTreeSet::new()];
+    let mut explored: BTreeSet<BTreeSet<usize>> = BTreeSet::new();
+    while let Some(removed) = worklist.pop() {
+        if found.len() >= max {
+            break;
+        }
+        if !explored.insert(removed.clone()) {
+            continue;
+        }
+        let subset: Vec<Component<A>> = candidates
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !removed.contains(i))
+            .map(|(_, c)| c.clone())
+            .collect();
+        if !entails(&ontology_from(fixed, &subset), q)? {
+            continue; // this branch cannot yield a justification
+        }
+        let j = quickxplain(fixed, &subset, q)?;
+        // Record if this justification (as an axiom SET) is new.
+        let key: BTreeSet<Component<A>> = j.iter().cloned().collect();
+        if seen.insert(key) {
+            found.push(j.clone());
+        }
+        // Branch: remove each justification axiom (by its candidate index).
+        for c in &j {
+            if let Some(idx) = candidates.iter().position(|x| x == c) {
+                let mut next = removed.clone();
+                next.insert(idx);
+                worklist.push(next);
+            }
+        }
+    }
+    Ok(found)
+}
+
+/// Find ONE justification for `q` in `onto`, or `Ok(None)` if `onto` does not
+/// entail `q`. `QuickXplain` over the logical axioms; minimal on EL/Horn
+/// (rustdl complete), guaranteed-entailing on SROIQ.
+///
+/// # Errors
+/// Propagates [`ReasonError`].
 pub fn find_one_justification<A: ForIRI>(
     onto: &SetOntology<A>,
     q: &Entailment,
 ) -> Result<Option<Justification<A>>, ReasonError> {
-    PreparedJustifier::prepare(onto).find_one(q)
+    let (fixed, all_candidates) = logical_axioms(onto);
+    let Some(axioms) = search_one(&fixed, &all_candidates, q)? else {
+        return Ok(None);
+    };
+    // Classify the fragment only once there is a justification to label: on the
+    // not-entailed path that convert+analyze would be pure waste. (A
+    // [`PreparedJustifier`] amortizes it instead — a single query cannot.)
+    Ok(Some(justification(axioms, fragment_of(onto))))
 }
 
 fn fragment_of<A: ForIRI>(onto: &SetOntology<A>) -> FragmentClassification {
@@ -1297,7 +1319,16 @@ pub fn find_all_justifications<A: ForIRI>(
     q: &Entailment,
     max: usize,
 ) -> Result<Vec<Justification<A>>, ReasonError> {
-    PreparedJustifier::prepare(onto).find_all(q, max)
+    let (fixed, all_candidates) = logical_axioms(onto);
+    let found = search_all(&fixed, &all_candidates, q, max)?;
+    if found.is_empty() {
+        return Ok(Vec::new()); // not entailed — nothing to classify the fragment for
+    }
+    let fragment = fragment_of(onto);
+    Ok(found
+        .into_iter()
+        .map(|axioms| justification(axioms, fragment))
+        .collect())
 }
 
 /// `delta_nonempty`: whether the most recent addition to `fixed` was non-empty

--- a/crates/owl-dl-reasoner/tests/justification.rs
+++ b/crates/owl-dl-reasoner/tests/justification.rs
@@ -6,8 +6,8 @@ use horned_owl::io::ofn::reader::read as read_ofn;
 use horned_owl::model::RcStr;
 use horned_owl::ontology::set::SetOntology;
 use owl_dl_reasoner::justify::{
-    Entailment, Justification, entails, find_all_justifications, find_one_justification,
-    logical_axioms, ontology_from,
+    Entailment, Justification, PreparedJustifier, entails, find_all_justifications,
+    find_one_justification, logical_axioms, ontology_from,
 };
 use std::io::Cursor;
 
@@ -987,5 +987,54 @@ fn justify_disjoint_data_properties_range_excludes_probe_not_entailed() {
     assert!(
         find_one_justification(&o, &q).unwrap().is_none(),
         "range clash on probe must not be mistaken for disjointness entailment"
+    );
+}
+
+#[test]
+fn prepared_justifier_matches_the_one_shot_functions() {
+    // The prepared and one-shot paths share the search but attach the fragment
+    // separately (the one-shot path classifies lazily, only when entailed), so
+    // pin that they agree — axioms, fragment, and the not-entailed verdict.
+    let o = onto(
+        "Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C)) Declaration(Class(:D))\n\
+                  SubClassOf(:A :B) SubClassOf(:B :C) SubClassOf(:A :D) SubClassOf(:D :C)",
+    );
+    let entailed = Entailment::SubClassOf {
+        sub: "http://t/A".into(),
+        sup: "http://t/C".into(),
+    };
+    let not_entailed = Entailment::SubClassOf {
+        sub: "http://t/C".into(),
+        sup: "http://t/A".into(),
+    };
+    let prepared = PreparedJustifier::prepare(&o);
+
+    let one = prepared.find_one(&entailed).unwrap().expect("entailed");
+    let cold = find_one_justification(&o, &entailed)
+        .unwrap()
+        .expect("entailed");
+    assert_eq!(one.axioms, cold.axioms, "same justification");
+    assert_eq!(one.fragment, cold.fragment, "same fragment");
+    assert_eq!(one.minimal_guaranteed, cold.minimal_guaranteed);
+
+    let all_prepared = prepared.find_all(&entailed, 10).unwrap();
+    let all_cold = find_all_justifications(&o, &entailed, 10).unwrap();
+    assert_eq!(
+        all_prepared.len(),
+        all_cold.len(),
+        "same justification count"
+    );
+    for (p, c) in all_prepared.iter().zip(&all_cold) {
+        assert_eq!(p.axioms, c.axioms);
+        assert_eq!(p.fragment, c.fragment);
+    }
+
+    assert!(prepared.find_one(&not_entailed).unwrap().is_none());
+    assert!(find_one_justification(&o, &not_entailed).unwrap().is_none());
+    assert!(prepared.find_all(&not_entailed, 10).unwrap().is_empty());
+    assert!(
+        find_all_justifications(&o, &not_entailed, 10)
+            .unwrap()
+            .is_empty()
     );
 }


### PR DESCRIPTION
## Motivation

`justify` / `justify_all` reload the ontology and re-derive per-ontology state — parse, `logical_axioms` split, and `fragment_of` (convert + fragment classification) — on **every** call. When a caller justifies several entailments over the same ontology, that setup is repeated each time.

This adds a reusable handle that does the per-ontology work once.

## What's added

- **owl-dl-reasoner** — `justify::PreparedJustifier<A>`:
  - `prepare(onto)` computes the reusable state (axiom split + fragment).
  - `find_one(q)` / `find_all(q, max)` run a query against it.
  - `find_one_justification` / `find_all_justifications` now delegate to it, so behaviour is unchanged.
- **owl-dl-py** — `rustdl.prepare(path)` and `rustdl.prepare_bytes(data, format=...)` return a `PreparedOntology` with `.justify(query)` / `.justify_all(query, max)`. It's `unsendable` (the `RcStr` object model isn't `Send`) — use it from the creating thread. Re-exported in `__init__.py` (+ `__all__`) and stubbed in `__init__.pyi`.

## Correctness & tests

- Existing reasoner justification suites pass unchanged (`justification.rs` 36, `laconic_justification.rs` 4).
- New Python tests assert a **prepared** justification equals the one-shot `rustdl.justify()` result, plus re-export/stub coverage. `fmt`/`clippy` clean.

## Measured

GO (~1.28M triples), native arm64:

| | time |
|---|---|
| `prepare()` (once) | ~1.3 s |
| justify, cold (`rustdl.justify`) | 6.0 s/pair |
| justify, prepared | 4.65 s/pair (identical results) |

Honest note: the win is the amortized setup (~1.3 s), i.e. ~20% per repeat query — the remaining per-query cost is the ⊥-module extraction + QuickXplain, which is inherently per-query and not reusable. The value is the reusable API for multi-query / batch callers, not a change to single-query latency.