### PR TITLE
fix(justify): canonical order for the justification search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ one-shot query costs no more than before). `rustdl report` now prepares once and
 reuses it across all roots instead of re-deriving per root. The
 `PreparedOntology` Python object is unsendable — use it from the creating thread.
 
+### Fixed — justification output was not reproducible run-to-run
+
+`SetOntology` is backed by a `HashSet` whose hasher std seeds per PROCESS, so
+`logical_axioms` yielded the ontology's axioms in a different order on every run.
+`QuickXplain` and the HST follow their input order, so the same query reported the
+same justification's axioms in a different order each run — and where several
+minimal justifications exist it could return a different (equally valid) one, or a
+different subset of them under a `max` cap. `localized_candidates` now returns the
+search input in a canonical, content-derived order, making `justify`,
+`justify --all`, `repair`, `report` and the Python surface byte-reproducible.
+Selection and ordering only — the axiom *sets* are unchanged.
+
 ## [0.4.17] - 2026-08-10
 
 ### Fixed — `classify` reported `consistent: true` on inconsistent ontologies

--- a/crates/owl-dl-reasoner/src/justify.rs
+++ b/crates/owl-dl-reasoner/src/justify.rs
@@ -1100,9 +1100,8 @@ fn localized_candidates<A: ForIRI>(
         query_seed_signature(q)
     }) else {
         // Not localizable (or disabled): decide on the full set.
-        return Ok(
-            entails(&ontology_from(fixed, all_candidates), q)?.then(|| all_candidates.to_vec())
-        );
+        return Ok(entails(&ontology_from(fixed, all_candidates), q)?
+            .then(|| canonical_order(all_candidates.to_vec())));
     };
     let module = extract_bot_module(all_candidates, &seed);
     if std::env::var_os("RUSTDL_JUSTIFY_DEBUG").is_some() {
@@ -1113,12 +1112,28 @@ fn localized_candidates<A: ForIRI>(
         );
     }
     if entails(&ontology_from(fixed, &module), q)? {
-        Ok(Some(module))
+        Ok(Some(canonical_order(module)))
     } else if entails(&ontology_from(fixed, all_candidates), q)? {
-        Ok(Some(all_candidates.to_vec())) // locality bug — safe fallback
+        // locality bug — safe fallback
+        Ok(Some(canonical_order(all_candidates.to_vec())))
     } else {
         Ok(None) // genuinely not entailed
     }
+}
+
+/// Put the search input in a canonical, content-derived order.
+///
+/// [`SetOntology`] is backed by a `HashSet`, and std's `RandomState` is seeded
+/// per PROCESS — so [`logical_axioms`] hands back the ontology's axioms in a
+/// different order on every run. `QuickXplain` and the HST both follow their
+/// input order, so without this the same query reports the same justification's
+/// axioms in a different order each run, and where several minimal
+/// justifications exist it can return a *different* (equally valid) one, or a
+/// different subset of them under a `max` cap. Sorting the (usually small)
+/// ⊥-module makes justify/justify-all/repair/report byte-reproducible.
+fn canonical_order<A: ForIRI>(mut axioms: Vec<Component<A>>) -> Vec<Component<A>> {
+    axioms.sort();
+    axioms
 }
 
 /// A minimal (on EL/Horn) responsible-axiom set for an entailment.

--- a/crates/owl-dl-reasoner/tests/justification.rs
+++ b/crates/owl-dl-reasoner/tests/justification.rs
@@ -1038,3 +1038,34 @@ fn prepared_justifier_matches_the_one_shot_functions() {
             .is_empty()
     );
 }
+
+#[test]
+fn justification_axioms_come_back_in_canonical_order() {
+    // `SetOntology` iterates a `HashSet` whose hasher is seeded per PROCESS, and
+    // QuickXplain/HST follow their input order — so without the canonical sort
+    // in `localized_candidates` the same query reports its axioms in a different
+    // order on every run (and can pick a different justification when several
+    // exist). Pin the sort here: `report`/`justify --json` diffability rests on it.
+    let o = onto(
+        "Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C)) Declaration(Class(:D))\n\
+                  SubClassOf(:A :B) SubClassOf(:B :C) SubClassOf(:A :D) SubClassOf(:D :C)",
+    );
+    let q = Entailment::SubClassOf {
+        sub: "http://t/A".into(),
+        sup: "http://t/C".into(),
+    };
+    let j = find_one_justification(&o, &q).unwrap().expect("entailed");
+    assert_eq!(j.axioms.len(), 2);
+    assert!(
+        j.axioms.is_sorted(),
+        "find-one justification must be in canonical order: {:?}",
+        j.axioms
+    );
+    for j in find_all_justifications(&o, &q, 10).unwrap() {
+        assert!(
+            j.axioms.is_sorted(),
+            "find-all justification must be in canonical order: {:?}",
+            j.axioms
+        );
+    }
+}


### PR DESCRIPTION
## The bug

`rustdl report` on an **unchanged** binary produced five different files across five runs. `justify` and `justify --all` likewise.

`SetOntology` is `SetIndex(HashSet<AnnotatedComponent>)`, and std seeds `RandomState` per process — so `logical_axioms` yields the ontology's axioms in a fresh order on every run. `extract_bot_module` preserves that order (its membership is a fixpoint, so only the order follows the input), and QuickXplain/HST both walk their candidate list in order. The order reached the output.

Display order is the visible symptom. The one that matters more is **selection** — on a fixture with four independent derivations of `A ⊑ C`, ten runs of one pre-change binary on one file returned **four different justifications**:

```
$ for i in $(seq 10); do rustdl justify twojust.ofn subclass http://t/A http://t/C; done | sort | uniq -c
   2   A SubClassOf E   E SubClassOf C
   2   A SubClassOf D   D SubClassOf C
   2   A SubClassOf B   B SubClassOf C
   1   F SubClassOf C   A SubClassOf F      <- same axioms, different order
   1   E SubClassOf C   A SubClassOf E
   1   D SubClassOf C   A SubClassOf D
   1   A SubClassOf F   F SubClassOf C
```

Each is a valid minimal justification, so this was never a soundness bug — but "why is this entailed?" answered differently each time you asked, and under a `max` cap in find-all, *which* subset you got could shift too.

## The fix

`localized_candidates` sorts what it returns (`Component: Ord`), at all three exit points. Fixing it at the search input rather than in a renderer means `justify`, `justify --all`, `repair`, `report` and the Python surface all become reproducible from one place — and selection is stabilized, not just presentation.

After: the same 10 runs return the same justification 10/10.

Cost is shaped right: the common path sorts the ⊥-module, which is small by construction. The two full-candidate branches (non-localizable queries such as `inconsistent`, and the rare locality-bug fallback) sort the whole logical-axiom vector, but both already run a full-ontology entailment check that dominates the sort.

## Verification

Against two binaries built from this branch with and without the sort, each pinned immediately after its build and **confirmed by a discriminating control** (pre-change: 3 runs, 3 different hashes; post-change: 3 runs, 1 hash):

- **Completeness preserved.** On the 4-justification fixture, `justify --all` enumerates all 4 before and after, and the *set of justification sets* is identical.
- **Sets unchanged on real ontologies.** 6 queries over `pizza.ofn` and `sio.ofn`, pre vs post: identical set-of-sets every time.
- **Reproducible.** `report` on pizza byte-identical across 3 runs (was 5-for-5 different); same for `justify` and `justify --all`.
- **Suites green.** `owl-dl-reasoner` + `owl-dl-cli`: 110 suites, 995 tests, 0 failed — including `json_output` and `text_output`, which render these surfaces. Python 64 passed / 1 skipped. `fmt` + `clippy -D warnings` clean.
- **No measurable cost.** `sio.ofn` justify timings unmoved (5 entailed queries, 0.292 s total vs 0.284–0.350 s before).

New canary `justification_axioms_come_back_in_canonical_order`, **sabotage-checked**: deleting the `sort()` makes it fail.

## Note for reviewers

This nondeterminism predates the change, so any earlier byte-comparison of justify/report output between two binaries was comparing noise — set-based comparison was the only valid method until now. Found while verifying #58; kept separate from it since it touches output for every justification consumer. Expect a trivial `CHANGELOG.md` conflict with #58 for whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)