### PR TITLE
fix(justify): repair + laconic reuse the prepared state; document `prepare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to rustdl are documented here. Format is based on
 
 ## [Unreleased]
 
+### Changed — repair/laconic reuse the prepared justification state
+
+`find_repairs` derived the logical-axiom split **twice** per call (once inside
+`find_all_justifications`, once again to verify candidate repairs), and
+`find_all_laconic_justifications` re-split the whole ontology once per regular
+justification. Both now take the split from one `PreparedJustifier`. New
+`find_repairs_prepared(&PreparedJustifier, q, max)` lets a batch caller reuse it
+across queries too, and `rustdl report` uses it — one prepared justifier now serves
+both the justify and the repair half of every root, where it previously re-derived
+per root and per half. Results are identical (`report` output byte-identical on the
+multi-root fixtures; a canary pins prepared repairs to the one-shot ones). No wall
+change is claimed: on ontologies small enough for `report`'s per-root loop to be
+reachable locally, this work is dominated by the entailment checks in repair
+verification, and interleaved timing is flat.
+
 ### Added — `PreparedOntology`: reuse justification state across queries
 
 `justify`/`justify_all` reload and re-derive per-ontology state (parse,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1116,6 +1116,26 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   roots/derived + per-root justification + repairs); presentation-only over the
   shipped reasoner output, read-only, no external resources. See
   `docs/superpowers/specs/2026-06-21-html-report-design.md`.
+
+> **JUSTIFY/REPORT OUTPUT WAS NOT RUN-TO-RUN REPRODUCIBLE BEFORE 2026-08-17 (#59).
+> Any byte-comparison of these surfaces recorded before that commit compared
+> noise.** `SetOntology` is `SetIndex(HashSet<AnnotatedComponent>)` and std seeds
+> `RandomState` per PROCESS, so `logical_axioms` yielded a different axiom order on
+> every run; `extract_bot_module` preserves that order and QuickXplain/HST walk their
+> input in order. Five runs of ONE unchanged binary produced **five different**
+> `report` files on `pizza.ofn`, and on a fixture with four independent derivations of
+> `A ⊑ C`, ten runs of `justify` returned **four different justifications** — each
+> valid and minimal, so this was never an FP, but the answer moved. `localized_candidates`
+> now sorts the search input (`canonical_order`), which stabilizes **selection**, not
+> just display: same justification, same order, same subset under a `max` cap.
+> Pinned by `justification_axioms_come_back_in_canonical_order`.
+>
+> Two consequences. (1) Byte comparison of `justify`/`justify --all`/`repair`/`report`
+> is now a valid A/B method — before, only comparing the axiom SETS was.
+> (2) A pre-#59 binary is still nondeterministic, so when one arm of a comparison is
+> old, compare sets. This is unrelated to the `--pair-timeout-ms` classify
+> nondeterminism documented under `owl-dl-tableau` — that one is budget-induced and
+> still live; this one was hash-order-induced and is closed.
   **Manchester (`.omn`) input** is wired (2026-06-22): the CLI (`detect_format`
   content-sniff: Manchester's colon-form `Prefix:`/`Class:`/… vs OFN's paren
   `Prefix(`; + extension fallback) and Python (`load.rs` extension /

--- a/README.md
+++ b/README.md
@@ -101,7 +101,17 @@ rustdl.classify("ontology.ofn", per_pair_timeout_ms=0, global_timeout_ms=0)   # 
 
 rustdl.is_consistent("ontology.ofn")   # -> bool
 rustdl.debug("ontology.ofn")           # consistency + root/derived unsat + justifications + repairs
+
+# justify one entailment, or many against the same ontology (prepare once, reuse):
+rustdl.justify("ontology.ofn", ["unsat", "http://ex.org/Bad"])   # -> list[str] (Manchester)
+onto = rustdl.prepare("ontology.ofn")            # parse + per-ontology justification state
+onto.justify(["subclass", sub, sup])             # same result, without re-deriving it
+onto.justify_all(["unsat", cls], max=10)         # up to `max` minimal justifications
 ```
+
+`prepare` pays the per-ontology setup once — use it whenever you justify more than
+one entailment of the same ontology (the returned object is single-threaded: use it
+from the thread that created it).
 
 More surface — inferred property assertions, subproperty axioms, existential
 successors, `justify`/`repair` — in the end-to-end

--- a/crates/owl-dl-cli/src/report.rs
+++ b/crates/owl-dl-cli/src/report.rs
@@ -12,9 +12,7 @@ use horned_owl::curie::PrefixMapping;
 use horned_owl::io::omn::AsManchester;
 use horned_owl::model::{Component, RcStr};
 use horned_owl::ontology::set::SetOntology;
-use owl_dl_reasoner::justify::{
-    Entailment, PreparedJustifier, component_entities, find_one_justification,
-};
+use owl_dl_reasoner::justify::{Entailment, PreparedJustifier, component_entities};
 use std::collections::HashMap;
 
 /// One root unsatisfiable class with its explanation and fixes.
@@ -277,11 +275,15 @@ pub(crate) fn build_report(
     // Inconsistent: one section (justify + repair the inconsistency).
     if !diag.consistent {
         let q = Entailment::Inconsistent;
-        let justification = find_one_justification(onto, &q)
+        // Two queries, one ontology — prepare once.
+        let prepared = PreparedJustifier::prepare(onto);
+        let justification = prepared
+            .find_one(&q)
             .context("justify inconsistency")?
             .map(|j| j.axioms)
             .unwrap_or_default();
-        let rep = owl_dl_reasoner::find_repairs(onto, &q, 10).context("repair inconsistency")?;
+        let rep = owl_dl_reasoner::find_repairs_prepared(&prepared, &q, 10)
+            .context("repair inconsistency")?;
         let repairs = rep.repairs.into_iter().map(|r| r.remove).collect();
         return Ok(Report {
             ontology_path,
@@ -309,19 +311,20 @@ pub(crate) fn build_report(
     let truncated_roots = n_root.saturating_sub(max_roots);
     let mut repairs_complete = true;
     let mut roots = Vec::new();
-    // Every root is justified against the SAME ontology, so the per-ontology
-    // state (axiom split + fragment) is derived once and reused. Built lazily so
-    // a report with no roots to justify doesn't pay for it.
+    // Every root is justified AND repaired against the SAME ontology, so the
+    // per-ontology state (axiom split + fragment) is derived once and reused by
+    // both halves. Built lazily so a report with no roots pays nothing.
     let mut justifier: Option<PreparedJustifier<RcStr>> = None;
     for iri in diag.roots.iter().take(max_roots) {
         let q = Entailment::Unsatisfiable { class: iri.clone() };
-        let justification = justifier
-            .get_or_insert_with(|| PreparedJustifier::prepare(onto))
+        let prepared = justifier.get_or_insert_with(|| PreparedJustifier::prepare(onto));
+        let justification = prepared
             .find_one(&q)
             .context("justify root")?
             .map(|j| j.axioms)
             .unwrap_or_default();
-        let rep = owl_dl_reasoner::find_repairs(onto, &q, 10).context("repair root")?;
+        let rep =
+            owl_dl_reasoner::find_repairs_prepared(prepared, &q, 10).context("repair root")?;
         repairs_complete &= rep.complete;
         let derives = diag.root_derives.get(iri).cloned().unwrap_or_default();
         roots.push(RootEntry {

--- a/crates/owl-dl-py/tests/python/test_tutorial.py
+++ b/crates/owl-dl-py/tests/python/test_tutorial.py
@@ -85,6 +85,17 @@ def test_step4_debug_partitions_root_and_derived(tmp_path):
     json.loads(json.dumps(d.to_dict()))
 
 
+def test_step5_prepare_matches_the_one_shot_calls(tmp_path):
+    # The tutorial claims `prepare()` gives the same answers as the one-shot
+    # functions, setup paid once. Mirror both snippets so the claim can't drift.
+    p = _write(tmp_path, BROKEN, "broken.omn")
+    onto = rustdl.prepare(p)
+    assert onto.justify(["unsat", ROOT]) == rustdl.justify(p, ["unsat", ROOT])
+    assert onto.justify_all(["unsat", ROOT], max=10) == rustdl.justify_all(
+        p, ["unsat", ROOT], 10
+    )
+
+
 def test_step6_fix_and_recheck(tmp_path):
     p = _write(tmp_path, FIXED, "fixed.omn")
     d = rustdl.debug(p)

--- a/crates/owl-dl-reasoner/src/justify.rs
+++ b/crates/owl-dl-reasoner/src/justify.rs
@@ -1170,6 +1170,17 @@ impl<A: ForIRI> PreparedJustifier<A> {
         }
     }
 
+    /// The non-logical background (declarations, imports, ontology metadata) —
+    /// never part of a justification, always part of the reasoned-over ontology.
+    pub(crate) fn background(&self) -> &[Component<A>] {
+        &self.fixed
+    }
+
+    /// Every logical axiom: the candidate pool a justification is drawn from.
+    pub(crate) fn logical(&self) -> &[Component<A>] {
+        &self.all_candidates
+    }
+
     /// One minimal justification for `q` (`None` if not entailed), reusing the
     /// prepared state.
     ///

--- a/crates/owl-dl-reasoner/src/laconic.rs
+++ b/crates/owl-dl-reasoner/src/laconic.rs
@@ -10,10 +10,7 @@ use horned_owl::model::{ClassExpression, Component, ForIRI, SubClassOf};
 use horned_owl::ontology::set::SetOntology;
 
 use crate::ReasonError;
-use crate::justify::{
-    Entailment, Justification, find_all_justifications, find_one_justification, logical_axioms,
-    quickxplain,
-};
+use crate::justify::{Entailment, Justification, PreparedJustifier, quickxplain};
 
 /// Decompose a superclass expression into top-level fragments whose CONJUNCTION
 /// is EQUIVALENT to the original (so the fragment set, as a whole, preserves every
@@ -109,15 +106,18 @@ fn weaken<A: ForIRI>(axiom: &Component<A>) -> Vec<Component<A>> {
 /// the background entail `q` on its own, collapsing the result to `∅`. This mirrors
 /// how `find_one_justification` itself calls `quickxplain` (fixed = non-logical,
 /// candidates = the axioms under consideration).
+///
+/// `background` comes from the caller's [`PreparedJustifier`] rather than a fresh
+/// `logical_axioms(onto)` — this runs once per regular justification, so deriving
+/// the split here made `find_all_laconic_justifications` re-split the whole
+/// ontology N times.
 fn laconic_from<A: ForIRI>(
-    onto: &SetOntology<A>,
+    background: &[Component<A>],
     q: &Entailment,
     j_axioms: &[Component<A>],
     fragment: crate::classify::FragmentClassification,
     minimal_guaranteed: bool,
 ) -> Result<Justification<A>, ReasonError> {
-    let (background, _logical) = logical_axioms(onto);
-
     // candidates = the union of the weakenings of the justification's axioms.
     let candidates: Vec<Component<A>> = j_axioms
         .iter()
@@ -134,7 +134,7 @@ fn laconic_from<A: ForIRI>(
     #[cfg(debug_assertions)]
     {
         let still_entails =
-            crate::justify::entails(&crate::justify::ontology_from(&background, &candidates), q)?;
+            crate::justify::entails(&crate::justify::ontology_from(background, &candidates), q)?;
         debug_assert!(
             still_entails,
             "laconic candidate set must still entail q — a weakening operator is not \
@@ -142,7 +142,7 @@ fn laconic_from<A: ForIRI>(
         );
     }
 
-    let laconic = quickxplain(&background, &candidates, q)?;
+    let laconic = quickxplain(background, &candidates, q)?;
     Ok(Justification {
         axioms: laconic,
         fragment,
@@ -158,11 +158,12 @@ pub fn find_laconic_justification<A: ForIRI>(
     onto: &SetOntology<A>,
     q: &Entailment,
 ) -> Result<Option<Justification<A>>, ReasonError> {
-    let Some(j) = find_one_justification(onto, q)? else {
+    let prepared = PreparedJustifier::prepare(onto);
+    let Some(j) = prepared.find_one(q)? else {
         return Ok(None);
     };
     Ok(Some(laconic_from(
-        onto,
+        prepared.background(),
         q,
         &j.axioms,
         j.fragment,
@@ -180,11 +181,18 @@ pub fn find_all_laconic_justifications<A: ForIRI>(
     q: &Entailment,
     max: usize,
 ) -> Result<Vec<Justification<A>>, ReasonError> {
-    let regular = find_all_justifications(onto, q, max)?;
+    let prepared = PreparedJustifier::prepare(onto);
+    let regular = prepared.find_all(q, max)?;
     let mut out = Vec::new();
     let mut seen: HashSet<BTreeSet<Component<A>>> = HashSet::new();
     for j in regular {
-        let lac = laconic_from(onto, q, &j.axioms, j.fragment, j.minimal_guaranteed)?;
+        let lac = laconic_from(
+            prepared.background(),
+            q,
+            &j.axioms,
+            j.fragment,
+            j.minimal_guaranteed,
+        )?;
         let key: BTreeSet<Component<A>> = lac.axioms.iter().cloned().collect();
         if seen.insert(key) {
             out.push(lac);

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -90,7 +90,7 @@ pub use realize::{
     is_instance_of_saturation_only, is_instance_of_saturation_only_internal, realize,
     realize_internal, realize_saturation_only, realize_saturation_only_internal,
 };
-pub use repair::{Repair, Repairs, find_repairs};
+pub use repair::{Repair, Repairs, find_repairs, find_repairs_prepared};
 
 /// Run the standalone `ABox` consequence-based saturator on `ontology` and return
 /// `true` iff a disjoint-class clash was detected under named-only semantics.

--- a/crates/owl-dl-reasoner/src/repair.rs
+++ b/crates/owl-dl-reasoner/src/repair.rs
@@ -10,7 +10,7 @@ use horned_owl::model::{Component, ForIRI};
 use horned_owl::ontology::set::SetOntology;
 
 use crate::ReasonError;
-use crate::justify::{Entailment, entails, find_all_justifications, logical_axioms, ontology_from};
+use crate::justify::{Entailment, PreparedJustifier, entails, ontology_from};
 
 /// Cap on justifications discovered for repair (independent of the user-facing
 /// `max` on repairs). Generous so the hitting sets are computed over as complete a
@@ -40,13 +40,34 @@ pub struct Repairs<A: ForIRI> {
 }
 
 /// Compute verified minimal repairs for `q` in `onto`.
+///
+/// Repairing several entailments of the SAME ontology? Prepare once and call
+/// [`find_repairs_prepared`] instead — this entry point derives the per-ontology
+/// state (axiom split + fragment) on every call.
 pub fn find_repairs<A: ForIRI>(
     onto: &SetOntology<A>,
     q: &Entailment,
     max: usize,
 ) -> Result<Repairs<A>, ReasonError> {
+    find_repairs_prepared(&PreparedJustifier::prepare(onto), q, max)
+}
+
+/// [`find_repairs`] over prepared per-ontology state, reused across queries.
+///
+/// Also cheaper for a single query than [`find_repairs`] used to be: the
+/// logical-axiom split happened TWICE per call (once inside
+/// `find_all_justifications`, once here for repair verification) and is now
+/// computed once, by [`PreparedJustifier::prepare`].
+///
+/// # Errors
+/// Propagates [`ReasonError`].
+pub fn find_repairs_prepared<A: ForIRI>(
+    prepared: &PreparedJustifier<A>,
+    q: &Entailment,
+    max: usize,
+) -> Result<Repairs<A>, ReasonError> {
     // All justifications (generous internal cap, independent of the repair `max`).
-    let justifications = find_all_justifications(onto, q, REPAIR_JUSTIFICATION_CAP)?;
+    let justifications = prepared.find_all(q, REPAIR_JUSTIFICATION_CAP)?;
     if justifications.is_empty() {
         return Ok(Repairs {
             entailed: false,
@@ -67,7 +88,7 @@ pub fn find_repairs<A: ForIRI>(
     candidates.sort_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
 
     // Verify each candidate by removing it and re-checking the entailment.
-    let (fixed, logical) = logical_axioms(onto);
+    let (fixed, logical) = (prepared.background(), prepared.logical());
     let mut repairs = Vec::new();
     let mut dropped_unverified = 0usize;
     for h in candidates {
@@ -75,7 +96,7 @@ pub fn find_repairs<A: ForIRI>(
             break;
         }
         let kept: Vec<Component<A>> = logical.iter().filter(|a| !h.contains(a)).cloned().collect();
-        let reduced = ontology_from(&fixed, &kept);
+        let reduced = ontology_from(fixed, &kept);
         if entails(&reduced, q)? {
             // An unfound justification survives — not a real repair.
             dropped_unverified += 1;

--- a/crates/owl-dl-reasoner/tests/repair_suggestions.rs
+++ b/crates/owl-dl-reasoner/tests/repair_suggestions.rs
@@ -2,8 +2,10 @@
 
 use horned_owl::model::{Build, ClassExpression as CE, DeclareClass, MutableOntology, SubClassOf};
 use horned_owl::ontology::set::SetOntology;
-use owl_dl_reasoner::find_repairs;
-use owl_dl_reasoner::justify::{Entailment, entails, logical_axioms, ontology_from};
+use owl_dl_reasoner::justify::{
+    Entailment, PreparedJustifier, entails, logical_axioms, ontology_from,
+};
+use owl_dl_reasoner::{find_repairs, find_repairs_prepared};
 
 // X unsat via TWO independent justifications:
 //   J1 = { X ⊑ A, X ⊑ B }   (A,B disjoint)
@@ -136,4 +138,55 @@ fn read_ofn_fixture(p: &std::path::Path) -> SetOntology<Rc> {
     let (o, _): (SetOntology<Rc>, _) =
         read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
     o
+}
+
+// `find_repairs` delegates to `find_repairs_prepared`, and `report` calls the
+// prepared form directly with a justifier it also justifies from — so pin that the
+// two entry points agree on every field, including the not-entailed verdict.
+#[test]
+fn prepared_repairs_match_the_one_shot_function() {
+    let b = Build::new_rc();
+    let cls = |iri: &str| CE::Class(b.class(iri));
+    let mut o = SetOntology::new();
+    for c in ["urn:X", "urn:A", "urn:B", "urn:C"] {
+        o.insert(DeclareClass(b.class(c)));
+    }
+    o.insert(horned_owl::model::DisjointClasses(vec![
+        cls("urn:A"),
+        cls("urn:B"),
+    ]));
+    o.insert(SubClassOf {
+        sub: cls("urn:X"),
+        sup: cls("urn:A"),
+    });
+    o.insert(SubClassOf {
+        sub: cls("urn:X"),
+        sup: cls("urn:B"),
+    });
+
+    let prepared = PreparedJustifier::prepare(&o);
+    for (label, q) in [
+        (
+            "entailed",
+            Entailment::Unsatisfiable {
+                class: "urn:X".to_string(),
+            },
+        ),
+        (
+            "not entailed",
+            Entailment::Unsatisfiable {
+                class: "urn:C".to_string(),
+            },
+        ),
+    ] {
+        let cold = find_repairs(&o, &q, 10).expect("repair");
+        let warm = find_repairs_prepared(&prepared, &q, 10).expect("prepared repair");
+        assert_eq!(cold.entailed, warm.entailed, "{label}: entailed");
+        assert_eq!(cold.complete, warm.complete, "{label}: complete");
+        assert_eq!(
+            cold.dropped_unverified, warm.dropped_unverified,
+            "{label}: dropped_unverified"
+        );
+        assert_eq!(cold.repairs, warm.repairs, "{label}: repairs");
+    }
 }

--- a/docs/python-ontology-qa.md
+++ b/docs/python-ontology-qa.md
@@ -140,6 +140,18 @@ rustdl.repair("broken.omn", ["unsat", "urn:pizza#CheeseyVegetableTopping"], 10)
 # every minimal repair, each verified by removal
 ```
 
+Justifying several entailments of the same ontology? `prepare()` does the
+per-ontology work (parse, axiom split, fragment classification) once and hands back
+an object you can query repeatedly — same answers, setup paid once:
+
+```python
+onto = rustdl.prepare("broken.omn")
+onto.justify(["unsat", "urn:pizza#CheeseyVegetableTopping"])   # == rustdl.justify(...)
+onto.justify_all(["unsat", "urn:pizza#CheeseyVegetableTopping"], max=10)
+```
+
+Use it from the thread that created it — the object is deliberately single-threaded.
+
 The same workflow is available on the command line, including a richer
 `justify --laconic` (which pinpoints the responsible *part* of each axiom) and a
 self-contained HTML report:


### PR DESCRIPTION
Follow-ups to #58 / #59, found by re-reading the call sites after they merged.

## repair — the same pattern #58 fixed, one call site down

`find_repairs` derived the logical-axiom split **twice per call**: once inside `find_all_justifications`, and again to verify candidate repairs. `rustdl report` then called it once per root, so a 50-root report re-derived the whole-ontology split ~100 times.

New `find_repairs_prepared(&PreparedJustifier, q, max)` takes the split from one prepared justifier, and `find_repairs` delegates to it — so even a single call now splits once. `build_report` uses **one** justifier for both the justify and the repair half of every root, and for the inconsistency section's two queries.

## laconic — N+1 splits → 1

`laconic_from` called `logical_axioms(onto)` itself, and `find_all_laconic_justifications` calls it once per regular justification — so it re-split the whole ontology N times. It now takes `background` from the caller's prepared justifier.

## diagnose — inspected, nothing to do

It calls `logical_axioms` once and issues no per-class justification. My earlier note suggesting otherwise was wrong; recording it so nobody re-opens it.

## docs

`prepare`/`prepare_bytes` shipped in #58 but appeared only in the `.pyi` stub and the changelog — not in `README.md` or the QA tutorial. Both now cover it, and the tutorial snippet is mirrored in `test_tutorial.py` per that file's own contract, so "prepared == one-shot" cannot drift.

`CLAUDE.md` gains the measurement note for #59: justify/report output was not run-to-run reproducible before it (hash-seeded `SetOntology` iteration), so any byte-comparison of those surfaces recorded earlier compared noise — and byte comparison is valid from now on. Kept distinct from the still-live `--pair-timeout-ms` classify nondeterminism documented elsewhere in that file.

## No wall win is claimed

Interleaved min-of-6 on an 8-root fixture: **2.162 s → 2.142 s (−0.9%)** — flat. Two reasons, both worth recording:

- Per-root cost is dominated by the **entailment checks in repair verification**, not the split. Raising filler axioms 400 → 1500 took one report from 2.2 s to 96.7 s.
- The local ontologies large enough for the split to matter — `sio`, `ro` — are **coherent**, so `report` never enters the per-root loop on them.

The saving scales with ontology size (`prepare()` is ~20 ms on sio; ~1.3 s at the GO scale measured in #58). On this corpus this is redundant-work removal, not a speedup. An earlier run *appeared* to show a 10–15% slowdown; that was host drift from a 96 s measurement in the same shell, and interleaving removed it.

## Verification

Two release binaries from this branch, with and without the change, pinned immediately after each build:

- **12 CLI comparisons byte-identical** — `justify` plain / `--all` / `--laconic` / `--laconic --all` / `--json`, plus `repair`, over both pizza roots.
- `report` byte-identical on pizza (`1a0c9e7f`, the hash `main` produces) and on both multi-root fixtures.
- `owl-dl-reasoner` + `owl-dl-cli`: **112 suites, 1021 tests, 0 failed**. Python **65 passed / 1 skipped** (was 64 — the new tutorial guard). `fmt` + `clippy -D warnings` clean.
- New canary `prepared_repairs_match_the_one_shot_function` pins every `Repairs` field, including the not-entailed verdict.

**Method note for the record:** an apparent laconic difference turned out to be my harness — zsh does not word-split an unquoted `$mode`, so `--laconic --all` arrived as a single argument and clap errored; the error text embeds the binary name, so the two arms hashed differently *and* every class hashed identically. That second symptom is the tell. Compare with an argv array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)