### PR TITLE
fix(test): the 1 ms prep-deadline canary was host-speed-dependent (root cause + fix)

### DIFF
--- a/crates/owl-dl-reasoner/tests/prep_deadline.rs
+++ b/crates/owl-dl-reasoner/tests/prep_deadline.rs
@@ -196,26 +196,42 @@ fn prep_timeout_is_reported_incomplete() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _flag = SetEnvGuard::set("RUSTDL_PREP_DEADLINE", "1");
     let onto = parse(&chain_ontology(500));
+
+    // BUDGET SIZING IS LOAD-BEARING — it was 1 ms and that made this canary
+    // HOST-SPEED-DEPENDENT (failed on macOS CI 2026-08-17 run 32038310446 and
+    // 2026-08-18 run 32122945274, passed on re-run, passed everywhere locally).
+    //
+    // `classify_with_budget` takes `t0` BEFORE `convert_ontology` and only then
+    // evaluates `prep_bounding_active(t0, budget)`, so the elapsed time at that gate
+    // INCLUDES the whole conversion. A budget smaller than conversion cost therefore
+    // reads as already-blown and prep is deliberately left unbounded (see
+    // `classify::budget_origin` and docs/2026-08-17-prep-deadline-default-decision.md)
+    // — the classify then runs to completion and reports COMPLETE, which is what the
+    // CI failures showed: a 20.3 s wall under a 1 ms budget with timed_out_pairs=0.
+    // Conversion of this fixture is sub-millisecond on a fast host and >1 ms on the
+    // macOS runner, which is the entire flake.
+    //
+    // Proof of the mechanism, reproducible on any host: set the budget BELOW local
+    // conversion cost (`Duration::from_micros(1)`) and this test fails with exactly
+    // the CI signature — a multi-second wall, pure_el_mode=true, timed_out_pairs=0.
+    //
+    // So the budget must sit comfortably ABOVE conversion (~ms, host-dependent) and
+    // far BELOW prep (~10-20 s unbounded on this fixture). 250 ms gives both margins
+    // by more than an order of magnitude in each direction.
+    let budget = Duration::from_millis(250);
     let started = std::time::Instant::now();
-    let h = classify_with_budget(&onto, None, Some(Duration::from_millis(1)))
-        .expect("classify under 1 ms budget");
+    let h = classify_with_budget(&onto, None, Some(budget)).expect("classify under budget");
     let wall = started.elapsed();
 
-    // This canary failed once on macOS CI (2026-08-17, run 32038310446) and did
-    // not reproduce locally: not under load, not with the fixture shrunk 500 -> 40
-    // (it still overran), and not through a cached-flag race (`prep_deadline_enabled`
-    // reads the env live). `prep_bounding_active` is evaluated ~2 lines after the
-    // `t0` it compares against, so an unmeetable-budget skip does not explain it
-    // either. So report what would DISCRIMINATE the remaining candidates instead of
-    // asserting bare: a sub-1 ms wall means the fixture got too cheap to overrun the
-    // budget, while a wall far above 1 ms means prep ran long and the flag/phase
-    // simply did not fire — a real defect, and a different one.
+    // Kept self-diagnosing: on failure, say which side of the budget the wall fell on,
+    // because the two sides are different bugs.
     assert!(
         h.stats().prep_timed_out,
-        "prep_timed_out must be set — classify wall was {wall:?} against a 1 ms \
-         budget (< 1 ms ⇒ fixture too cheap to overrun it; >> 1 ms ⇒ prep overran \
-         but the signal did not fire), pure_el_mode={}, fragment={}, \
-         timed_out_pairs={}",
+        "prep_timed_out must be set — classify wall was {wall:?} against a {budget:?} \
+         budget (wall < budget ⇒ the fixture got too cheap to overrun it; wall >> \
+         budget ⇒ prep overran but the signal did not fire, e.g. conversion alone \
+         exceeded the budget so `prep_bounding_active` declined to bound prep), \
+         pure_el_mode={}, fragment={}, timed_out_pairs={}",
         h.stats().pure_el_mode,
         h.stats().fragment,
         h.stats().timed_out_pairs

--- a/crates/owl-dl-reasoner/tests/prep_deadline.rs
+++ b/crates/owl-dl-reasoner/tests/prep_deadline.rs
@@ -196,10 +196,30 @@ fn prep_timeout_is_reported_incomplete() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _flag = SetEnvGuard::set("RUSTDL_PREP_DEADLINE", "1");
     let onto = parse(&chain_ontology(500));
+    let started = std::time::Instant::now();
     let h = classify_with_budget(&onto, None, Some(Duration::from_millis(1)))
         .expect("classify under 1 ms budget");
+    let wall = started.elapsed();
 
-    assert!(h.stats().prep_timed_out, "prep_timed_out must be set");
+    // This canary failed once on macOS CI (2026-08-17, run 32038310446) and did
+    // not reproduce locally: not under load, not with the fixture shrunk 500 -> 40
+    // (it still overran), and not through a cached-flag race (`prep_deadline_enabled`
+    // reads the env live). `prep_bounding_active` is evaluated ~2 lines after the
+    // `t0` it compares against, so an unmeetable-budget skip does not explain it
+    // either. So report what would DISCRIMINATE the remaining candidates instead of
+    // asserting bare: a sub-1 ms wall means the fixture got too cheap to overrun the
+    // budget, while a wall far above 1 ms means prep ran long and the flag/phase
+    // simply did not fire — a real defect, and a different one.
+    assert!(
+        h.stats().prep_timed_out,
+        "prep_timed_out must be set — classify wall was {wall:?} against a 1 ms \
+         budget (< 1 ms ⇒ fixture too cheap to overrun it; >> 1 ms ⇒ prep overran \
+         but the signal did not fire), pure_el_mode={}, fragment={}, \
+         timed_out_pairs={}",
+        h.stats().pure_el_mode,
+        h.stats().fragment,
+        h.stats().timed_out_pairs
+    );
     assert!(
         h.stats().timed_out_pairs > 0,
         "timed_out_pairs must be bumped — it is what drives `\"incomplete\": true` \


### PR DESCRIPTION
## Root cause found — and the diagnostic found it

`prep_deadline.rs::prep_timeout_is_reported_incomplete` failed on macOS CI on 2026-08-17, passed on re-run, and would not reproduce locally. This PR started as *just* a better failure message. That message then paid for itself on its **first** CI run (2026-08-18, run 32122945274):

```
prep_timed_out must be set — classify wall was 20.309347583s against a 1 ms budget
… pure_el_mode=true, fragment=pure-EL …, timed_out_pairs=0
```

A 20-second wall under a 1 ms budget means prep ran **entirely unbounded** and the answer was served as complete.

**Why:** `classify_with_budget` takes `t0`, runs `convert_ontology`, and *then* evaluates `prep_bounding_active(t0, budget)`. The elapsed time at that gate includes the whole conversion, so a budget smaller than conversion cost reads as already-blown and prep is deliberately left unbounded (`budget_origin`, and `docs/2026-08-17-prep-deadline-default-decision.md`). Conversion of `chain_ontology(500)` is **sub-millisecond on a fast host and >1 ms on the macOS runner** — that is the entire flake. Not a scheduling race, not a cheap fixture, not an env race.

**Reproduced deterministically on a fast host** by putting the budget below local conversion cost (`Duration::from_micros(1)`): fails with the exact CI signature — 9.86 s wall, `pure_el_mode=true`, `timed_out_pairs=0`. That recipe is in the test comment so the next reader can re-derive it in one command.

## Fix

Budget **1 ms → 250 ms**: more than an order of magnitude above conversion (~ms, host-dependent) and more than an order below prep (~10–20 s unbounded on this fixture).

**Every assertion is unchanged.** The canary still requires the bounded path and still guards "a partial closure is never served as complete" — the point was never to weaken it, and a disjunction over bounded/unbounded would have done exactly that.

I also **retract** the claim in this PR's first commit that the meetability gate was refuted as a cause. It was correct; I had missed that `convert_ontology` sits inside the measured window.

## Left alone deliberately — your call

`classify_with_budget(1 ms)` can legitimately run 20 s and report `complete`, because the gate declines to bound an already-blown budget. The decision doc argues for precisely that (better a complete answer than `ore_ont_7192` burning 18 s to return 0 rows), so this is documented behaviour rather than a defect. Worth knowing, though: **a caller passing a budget smaller than conversion cost gets no prep bounding at all, silently.** If you want that surfaced (a trace line, or a floor under the gate), that is a product change and I did not make it here.

## Verification

- 5/5 in-suite; **6/6 under 14-way CPU load** — the configuration that could not reproduce the original failure either, now with the fix in place.
- `fmt` + `clippy -D warnings` clean.
- Sabotage: the `from_micros(1)` variant fails with the CI signature; the shipped 250 ms variant passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)