### PR TITLE
fix(protege): pin guava/slf4j import ranges to what Protégé actually ships (#63)

### DIFF
--- a/protege/pom.xml
+++ b/protege/pom.xml
@@ -174,6 +174,21 @@
               org.protege.editor.owl.*,
               org.semanticweb.owlapi.*,
               org.osgi.framework,
+              <!-- Ranges pinned by hand, NOT left to bnd (issue #63). bnd infers them
+                   from the build classpath, where owlapi-distribution supplies guava
+                   33.0.0-jre and slf4j 2.x; it therefore wrote [33.0,34) and [2.0,3).
+                   Protégé 5.6.x actually exports com.google.common.collect 18.0.0
+                   (bundles/guava.jar) and org.slf4j 1.7.36 (bundles/slf4j-api.jar),
+                   so those ranges left the bundle unresolvable in a stock install.
+                   Both imports come from the embedded telemetry jar's
+                   TelemetryXMLWriter, which only needs Lists.newArrayList(Iterable),
+                   LoggerFactory.getLogger and Logger.error — available since guava 2
+                   and slf4j 1.0 — so the lower bounds are safe. Upper bounds keep the
+                   compile-time major, so a future Protégé on guava 34 / slf4j 3 would
+                   need them raised (the verify-bundle-contents guard below pins
+                   both clauses so that stays a deliberate, tested change). -->
+              com.google.common.collect;version="[18.0,34)",
+              org.slf4j;version="[1.7,3)",
               *
             </Import-Package>
             <!-- Deliberately NOT embedded (unlike gson/owlexplanation/telemetry above): the
@@ -256,6 +271,40 @@
                     <resourcecount when="greater" count="0">
                       <fileset dir="${project.build.directory}/jar-check" includes="protege-proof-justification-*.jar"/>
                     </resourcecount>
+                  </condition>
+                </fail>
+                <!-- Issue #63: the bundle must resolve against a *stock* Protégé.
+                     bnd derives Import-Package ranges from the build classpath, which
+                     is not what Protégé ships: owlapi-distribution drags in guava
+                     33.0.0-jre and slf4j 2.x, so bnd generated [33.0,34) and [2.0,3).
+                     Every Protégé 5.6.x bundles/ dir instead exports
+                     com.google.common.collect 18.0.0 and org.slf4j 1.7.36, so those
+                     generated ranges made the plugin unresolvable on 5.6.6/5.6.8/5.6.9
+                     alike (BundleException at startup, plugin silently absent).
+                     Both imports trace to one embedded class, telemetry's
+                     TelemetryXMLWriter, whose entire usage is
+                     Lists.newArrayList(Iterable), LoggerFactory.getLogger and
+                     Logger.error — all present in guava 18.0 and slf4j 1.7. Hence the
+                     hand-pinned ranges in Import-Package above; this guard fails the
+                     build if they are ever dropped and bnd regenerates them.
+                     Manifest headers wrap at 72 chars, so unfold before matching. -->
+                <loadfile property="bundle.manifest"
+                          srcFile="${project.build.directory}/jar-check/META-INF/MANIFEST.MF">
+                  <filterchain>
+                    <tokenfilter>
+                      <filetokenizer/>
+                      <replaceregex pattern="\r?\n " replace="" flags="gs"/>
+                    </tokenfilter>
+                  </filterchain>
+                </loadfile>
+                <fail message="Import-Package must accept the guava Protégé ships (18.0.0) - expected com.google.common.collect;version=&quot;[18.0,34)&quot;">
+                  <condition>
+                    <not><contains string="${bundle.manifest}" substring="com.google.common.collect;version=&quot;[18.0,34)&quot;"/></not>
+                  </condition>
+                </fail>
+                <fail message="Import-Package must accept the slf4j Protégé ships (1.7.36) - expected org.slf4j;version=&quot;[1.7,3)&quot;">
+                  <condition>
+                    <not><contains string="${bundle.manifest}" substring="org.slf4j;version=&quot;[1.7,3)&quot;"/></not>
                   </condition>
                 </fail>
                 <fail message="rustdl proof-service extension missing from plugin.xml">


### PR DESCRIPTION
Fixes #63.

## Diagnosis

The reporter is right that Guava is the culprit, but there are **two** unresolvable imports, and this is **not a 5.6.9 regression**.

| Import in `rustdl-protege-0.4.19.jar` | Protégé 5.6.6 / 5.6.8 / 5.6.9 export | |
|---|---|---|
| `com.google.common.collect;version="[33.0,34)"` | `18.0.0` (`bundles/guava.jar`) | ✗ |
| `org.slf4j;version="[2.0,3)"` | `1.7.36` (`bundles/slf4j-api.jar`) | ✗ |

Every other import resolves cleanly. Felix only reports the first unresolved requirement, so Guava was masking an identical slf4j failure behind it — fixing Guava alone would just have moved the error.

**Why the ranges are wrong.** bnd derives `Import-Package` ranges from the *build* classpath, where `owlapi-distribution` 4.5.29 drags in guava `33.0.0-jre` and slf4j 2.x. Protégé's own build pins guava to `18.0` in `protege-parent`'s dependencyManagement, so what it actually bundles is guava 18.0.0 and slf4j 1.7.36 — identical across 5.6.6, 5.6.8 and 5.6.9. The build classpath and the runtime container disagreed, and nothing caught it.

**When it broke.** `v0.4.4` has `Bundle-ClassPath: .,gson-2.11.0.jar` and neither bad import. `v0.4.5` (commit `dcac504`, justifications/laconic) added `owlexplanation-2.0.1.jar,telemetry-2.0.0.jar` and both appeared. So **v0.4.5 is the first broken release; v0.4.4 the last working one** — the plugin has been unloadable on all of Protégé 5.6.x since then, not just on 5.6.9.

## Fix

Both imports trace to a *single* embedded class — telemetry's `TelemetryXMLWriter`. Its entire usage is:

- `com.google.common.collect.Lists.newArrayList(Iterable)` — present in guava 18.0
- `LoggerFactory.getLogger`, `Logger.error` — present in slf4j 1.7.36

Neither `owlexplanation`, `gson`, nor the plugin's own classes reference guava or slf4j at all. So the ranges are simply pinned by hand to what Protégé ships:

```xml
com.google.common.collect;version="[18.0,34)",
org.slf4j;version="[1.7,3)",
```

Widening rather than embedding guava: embedding would add ~3 MB and stand up a rival guava class space beside the one `owlapi-osgidistribution` imports, whose exported packages carry `uses:="com.google.common..."` constraints — a `LinkageError` risk wherever guava types cross the bundle boundary. The code genuinely runs on guava 18, so widening is the honest fix.

Upper bounds keep the compile-time major, so a future Protégé on guava 34 / slf4j 3 would need them raised — the guard below makes that a deliberate, tested change rather than a silent break.

## Regression guard

`verify-bundle-contents` previously validated jar *contents* but never that the manifest could actually resolve — which is why this shipped. It now unfolds the built `MANIFEST.MF` (headers wrap at 72 chars, so substring matching needs it) and fails the build if either clause is missing. This runs in `mvn verify`, so existing CI covers it with no new job and no distribution download.

The guard was confirmed **red on the unpatched pom** before the fix was applied:

```
[ERROR] Import-Package must accept the guava Protégé ships (18.0.0)
        - expected com.google.common.collect;version="[18.0,34)"
```

## Verification

- Resolved the built bundle's full `Import-Package` header against the union of `Export-Package` from **all 34 bundles** in the stock Protégé 5.6.6, 5.6.8 and 5.6.9 distributions. Before: 2 hard failures in each. After: **no unresolved mandatory imports in any of the three.**
- Confirmed `Lists.newArrayList(Iterable)` exists in Protégé's own `bundles/guava.jar` via `javap`.
- `mvn verify -Dtest='*Test,*IT'` — **114 tests, 0 failures**, smoke IT included.
- Diffed the built manifest: exactly the two clauses changed, nothing else.

Not verified: launching the GUI and clicking through the reasoner. The resolution check covers the reported failure, which is a startup-time OSGi resolution error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)