### PR TITLE
fix(convert): restore doc/attribute adjacency for the two feature-gate fns

### DIFF
--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -2513,7 +2513,11 @@ fn derive_inverse_pair_functionality(out: &mut InternalOntology) {
 /// shape is whitelisted (`classify::is_derived_functional_max`). Both need a corpus
 /// sweep before this becomes a default.
 #[must_use]
-/// Skip a DKey disjointness component wholesale when every one of its pairs is provably
+pub fn inverse_functional_max_enabled() -> bool {
+    std::env::var_os("RUSTDL_INVERSE_FUNC_MAX").is_some_and(|v| v == "1")
+}
+
+/// Skip a `DKey` disjointness component wholesale when every one of its pairs is provably
 /// droppable (`RUSTDL_DKEY_GROUP_SKIP`, **default OFF** pending measurement).
 ///
 /// The drop condition is component-level, not per-pair, so the O(k²) walk can be replaced
@@ -2523,10 +2527,6 @@ fn derive_inverse_pair_functionality(out: &mut InternalOntology) {
 #[must_use]
 pub fn dkey_group_skip_enabled() -> bool {
     std::env::var_os("RUSTDL_DKEY_GROUP_SKIP").is_some_and(|v| v == "1")
-}
-
-pub fn inverse_functional_max_enabled() -> bool {
-    std::env::var_os("RUSTDL_INVERSE_FUNC_MAX").is_some_and(|v| v == "1")
 }
 
 /// Emit a derived role-triggered `≤1` GCI for every (forward) functional


### PR DESCRIPTION
`main` (`c137909`) is red. Not just clippy — `unused_attributes` is deny-by-default under `-D warnings`, so the plain build fails too. All three `build & test` matrix legs plus the `clippy` job:

```
error: duplicated attribute                        crates/owl-dl-core/src/convert.rs:2523
error: unused attribute                            crates/owl-dl-core/src/convert.rs:2523
error: item in documentation is missing backticks  crates/owl-dl-core/src/convert.rs:2516
error: could not compile `owl-dl-core` (lib) due to 3 previous errors
```

## Cause

The `dkey_group_skip_enabled` block landed *between* `inverse_functional_max_enabled`'s doc comment + `#[must_use]` and its `fn`, orphaning the attribute above a doc comment:

```rust
/// …doc for inverse_functional_max_enabled…
#[must_use]                                        // ← 2515, orphaned
/// Skip a DKey disjointness component wholesale…  // ← 2516, DKey unbackticked
#[must_use]                                        // ← 2523, now a duplicate
pub fn dkey_group_skip_enabled() -> bool { … }

pub fn inverse_functional_max_enabled() -> bool { … }   // ← lost its #[must_use]
```

So `inverse_functional_max_enabled` had also quietly lost both its `#[must_use]` and its adjacency to the doc comment written for it.

## Fix

Move the whole `dkey_group_skip_enabled` block (doc + `#[must_use]` + fn) below `inverse_functional_max_enabled`, so each function sits with its own doc comment and attribute again, and backtick `DKey` for `clippy::doc_markdown`.

No behaviour change — both functions are untouched env-var reads, and `#[must_use]` is restored to the function it was written for.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — **exit 0**
- `cargo build --workspace --all-targets --exclude owl-dl-py` — clean

Caveat: verified on `stable` (1.96.0), not the repo's pinned 1.95.0 — my local 1.95.0 toolchain is missing its `cargo` binary. Both lints exist in both versions, and CI on this PR is the authoritative check.

Found while opening #64, whose red checks are this breakage rather than anything in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)