### PR TITLE
fix(classify): report positions are not ClassIds — DKey id aliasing

### DIFF
--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -1513,7 +1513,14 @@ fn classify_internal_with_timeout_impl(
         }
     }
     let _ = satisfiable; // currently informational only
-    if probe_says_inconsistent(internal, &prepared, &unsatisfiable_idxs, n, &mut stats) {
+    if probe_says_inconsistent(
+        internal,
+        &prepared,
+        &reported,
+        &unsatisfiable_idxs,
+        n,
+        &mut stats,
+    ) {
         return Ok(classify_inconsistent(classes, index, stats.fragment));
     }
     Ok(Classification {
@@ -1708,6 +1715,7 @@ fn classify_pure_el(
 fn probe_says_inconsistent(
     internal: &InternalOntology,
     prepared: &PreparedOntology,
+    reported: &ReportedClasses,
     unsatisfiable_idxs: &HashSet<usize>,
     n_classes: usize,
     stats: &mut ClassificationStats,
@@ -1742,7 +1750,9 @@ fn probe_says_inconsistent(
     for ax in &internal.axioms {
         if let owl_dl_core::Axiom::ClassAssertion { class, .. } = ax
             && let owl_dl_core::ir::ConceptExpr::Atomic(c) = internal.concepts.get(*class)
-            && unsatisfiable_idxs.contains(&(c.index() as usize))
+            && reported
+                .report_pos(*c)
+                .is_some_and(|pos| unsatisfiable_idxs.contains(&pos))
         {
             return true;
         }
@@ -2286,7 +2296,7 @@ fn saturator_complete_fragment_impl(internal: &InternalOntology, skip_abox: bool
 /// nothing. The prelude (functional roles, `disjoint_ok`, bare declarations) is
 /// copied from [`saturator_complete_fragment_impl`] deliberately so the taint
 /// and the real gate cannot disagree about what "out of fragment" means.
-fn tainted_classes(internal: &InternalOntology, num_classes: usize) -> Vec<bool> {
+fn tainted_classes(internal: &InternalOntology, num_class_ids: usize) -> Vec<bool> {
     let functional_roles: HashSet<Role> = internal
         .axioms
         .iter()
@@ -2307,7 +2317,7 @@ fn tainted_classes(internal: &InternalOntology, num_classes: usize) -> Vec<bool>
         || inverse_functional_roles.iter().next().is_some();
     let disjoint_ok = !has_cardinality_role;
     let bare = BareRoleDecls::analyze(internal);
-    let mut tainted = vec![false; num_classes];
+    let mut tainted = vec![false; num_class_ids];
     let mut buf: Vec<owl_dl_core::ClassId> = Vec::new();
     for ax in &internal.axioms {
         if is_saturator_axiom(
@@ -2322,11 +2332,18 @@ fn tainted_classes(internal: &InternalOntology, num_classes: usize) -> Vec<bool>
         }
         buf.clear();
         owl_dl_core::locality::collect_classes_in_axiom(ax, &internal.concepts, &mut buf);
+        // ─── BEGIN report-position ↔ ClassId conversion boundary ─────────
+        // Pure id space on both sides: `collect_classes_in_axiom` yields
+        // `ClassId`s and `tainted` is sized by the CLASS-ID space (the caller
+        // passes `ReportedClasses::num_class_ids`, not the report count — it
+        // used to pass the report count `n`, which silently dropped every id
+        // above it and marked the wrong slot for any `DKey`).
         for c in &buf {
             if let Some(slot) = tainted.get_mut(c.index() as usize) {
                 *slot = true;
             }
         }
+        // ─── END report-position ↔ ClassId conversion boundary ───────────
     }
     tainted
 }
@@ -3128,6 +3145,12 @@ fn unsat_probe_budget(per_pair: Option<std::time::Duration>) -> Option<std::time
 ///
 /// Format, one line per class: `<idx> sat <label-idx>...` / `<idx> unsat` /
 /// `<idx> noverdict`, then a `#closure` section with `<idx> <subsumer-idx>...`.
+///
+/// INDEX SPACES (they differ — see `ReportedClasses`). The `<idx>` of the
+/// `#labels`, `#times` and `#closure` sections is a REPORT POSITION; every
+/// `<label-idx>` / `<subsumer-idx>` and the `#tainted` index are raw `ClassId`
+/// indices. A `DKey` in the vocabulary makes the two disagree, so do not join
+/// the sections on the bare number.
 /// Failure to write is reported and otherwise ignored — a diagnostic must not
 /// abort a classify.
 fn dump_label_cache(
@@ -3135,6 +3158,7 @@ fn dump_label_cache(
     closure: &owl_dl_saturation::Subsumers,
     times: &[std::sync::atomic::AtomicU64],
     tainted: &[bool],
+    reported: &ReportedClasses,
     n: usize,
     path: &std::path::Path,
 ) {
@@ -3176,7 +3200,7 @@ fn dump_label_cache(
     }
     out.push_str("#closure\n");
     for i in 0..n {
-        let cid = owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+        let cid = reported.class_id(i);
         let mut ids: Vec<u32> = closure
             .subsumers_of(cid)
             .into_iter()
@@ -3561,7 +3585,7 @@ fn classify_top_down_internal_impl(
             let mut failing: Option<usize> = None;
             for k in 0..scan {
                 let i = (k * stride).min(n - 1);
-                let id = owl_dl_core::ClassId::new(u32::try_from(i).expect("fits u32"));
+                let id = reported.class_id(i);
                 let r = prepared
                     .classify_labels(id, effective_deadline(global_deadline, Some(small_dur)));
                 if matches!(r, crate::LabelOracle::NoVerdict) {
@@ -3575,7 +3599,7 @@ fn classify_top_down_internal_impl(
                 // no evidence a larger one would buy anything. Keep the cheap budget.
                 None => cache_ms,
                 Some(i) => {
-                    let id = owl_dl_core::ClassId::new(u32::try_from(i).expect("fits u32"));
+                    let id = reported.class_id(i);
                     // DECIDE with a budget strictly larger than the one we would APPLY.
                     // The decision was otherwise marginal: measured, the deciding class on
                     // `ore_ont_5107` failed its 1000 ms retry in one build and succeeded in
@@ -3686,7 +3710,8 @@ fn classify_top_down_internal_impl(
             &label_cache,
             &closure,
             &label_times,
-            &tainted_classes(internal, n),
+            &tainted_classes(internal, reported.num_class_ids()),
+            &reported,
             n,
             std::path::Path::new(&path),
         );
@@ -4388,7 +4413,14 @@ fn classify_top_down_internal_impl(
         .saturating_sub(stats.sweep_wall_ms)
         .saturating_sub(stats.matrix_wall_ms);
 
-    if probe_says_inconsistent(internal, &prepared, &unsatisfiable_idxs, n, &mut stats) {
+    if probe_says_inconsistent(
+        internal,
+        &prepared,
+        &reported,
+        &unsatisfiable_idxs,
+        n,
+        &mut stats,
+    ) {
         return Ok(classify_inconsistent(classes, index, stats.fragment));
     }
     Ok(Classification {
@@ -4767,7 +4799,13 @@ fn subsumes_via_tableau(
     let wedge_start = Instant::now();
     let verdict = prepared.hyper_decide(sub, sup, hyper_deadline);
     let wedge_elapsed_ms = u64::try_from(wedge_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    // ─── BEGIN report-position ↔ ClassId conversion boundary ─────────────
+    // Genuinely id space, and it never leaves it: `pairs_per_sub` is a
+    // diagnostic histogram keyed by raw `ClassId` index whose keys are only
+    // ever summed/merged (`owl-dl-cli` reports quantiles of the VALUES and
+    // never maps a key back to a class). No report position is involved.
     *stats.pairs_per_sub.entry(sub.index()).or_insert(0) += 1;
+    // ─── END report-position ↔ ClassId conversion boundary ───────────────
     let bucket = match wedge_elapsed_ms {
         0 => 0,
         1 => 1,

--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -32,27 +32,131 @@ use crate::{PreparedOntology, ReasonError};
 /// pairwise subsumption check returned from the parallel work loop.
 type PairResult = (usize, usize, bool, bool, bool);
 
-/// Collect the IRIs of every *reportable* named class, in vocabulary
-/// interning order. Excludes the synthetic `DKey(range)` filler classes
+// ─── BEGIN report-position ↔ ClassId conversion boundary ─────────────────
+//
+// Everything between these sentinels is the ONLY code in this file allowed to
+// spell a raw `ClassId::new(...)` or `id.index() as usize`. The
+// `report_positions_are_never_cast_to_class_ids` test in
+// `tests/dkey_id_aliasing.rs` enforces that mechanically — a new raw cast
+// anywhere else in this file is a test failure with a pointer back here.
+
+/// The *reportable* named classes, in vocabulary interning order, together
+/// with the **bijection** between a position in that reported vector and the
+/// internal [`owl_dl_core::ClassId`] it stands for.
+///
+/// The reported vector excludes the synthetic `DKey(range)` filler classes
 /// introduced by the integer-facet data lowering
 /// ([`owl_dl_core::DKEY_IRI_PREFIX`]): they participate in the internal
 /// saturation/tableau reasoning (their told-subsumptions relay datatype
 /// containment through the existential machinery) but are NOT user
 /// classes, so they must never appear in the classified hierarchy, the
 /// unsatisfiable set, or any closure diff.
-fn reportable_class_iris(internal: &InternalOntology) -> Vec<String> {
-    (0..internal.vocabulary.num_classes())
-        .map(|i| {
-            internal
-                .vocabulary
-                .class_iri(owl_dl_core::ClassId::new(
-                    u32::try_from(i).expect("class count fits in u32"),
-                ))
-                .to_owned()
-        })
-        .filter(|iri| !iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX))
-        .collect()
+///
+/// # SOUNDNESS: a report position is NOT a `ClassId`
+///
+/// Because `DKey`s are *removed*, report position `i` equals `ClassId::new(i)`
+/// only while every `DKey` id happens to sit above every user class. That
+/// holds for ontologies whose every named class is `Declaration`-ed (all
+/// `DeclareClass` components sort before any axiom, so their ids are handed
+/// out first), and it does NOT hold in general — an undeclared class first
+/// mentioned in an axiom that sorts after a DKey-minting one lands *above*
+/// the `DKey`. Every reported class above such a `DKey` then read its
+/// subsumption row off a neighbour, producing FALSE POSITIVES in the public
+/// `classify()` (see `tests/dkey_id_aliasing.rs`).
+///
+/// So: this type owns the mapping in both directions and is the ONLY
+/// sanctioned way to cross between the two spaces —
+/// [`ReportedClasses::class_id`] and [`ReportedClasses::report_pos`].
+/// Re-deriving either with a raw `ClassId::new(i)` / `id.index() as usize`
+/// re-arms the bug silently; the
+/// `report_positions_are_never_cast_to_class_ids` test in this file rejects
+/// those spellings mechanically.
+struct ReportedClasses {
+    /// Report position → class IRI.
+    iris: Vec<String>,
+    /// Report position → internal class id.
+    ids: Vec<owl_dl_core::ClassId>,
+    /// Internal class-id index → report position; `None` for a `DKey`.
+    /// Length is `vocabulary.num_classes()`, so ids at or beyond that
+    /// (Tseitin / existential-marker synthetics) are out of range entirely.
+    pos_of_id: Vec<Option<u32>>,
 }
+
+impl ReportedClasses {
+    /// Walk the whole class-id space once, recording the reportable classes
+    /// and both directions of the mapping.
+    fn collect(internal: &InternalOntology) -> Self {
+        let num_class_ids = internal.vocabulary.num_classes();
+        let mut iris = Vec::with_capacity(num_class_ids);
+        let mut ids = Vec::with_capacity(num_class_ids);
+        let mut pos_of_id = Vec::with_capacity(num_class_ids);
+        for i in 0..num_class_ids {
+            let id = owl_dl_core::ClassId::new(u32::try_from(i).expect("class count fits in u32"));
+            let iri = internal.vocabulary.class_iri(id);
+            if iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX) {
+                pos_of_id.push(None);
+                continue;
+            }
+            pos_of_id.push(Some(
+                u32::try_from(iris.len()).expect("class count fits in u32"),
+            ));
+            iris.push(iri.to_owned());
+            ids.push(id);
+        }
+        Self {
+            iris,
+            ids,
+            pos_of_id,
+        }
+    }
+
+    /// Number of reported classes — the `n` every report-space vector,
+    /// bitset row, and index map is sized by.
+    fn len(&self) -> usize {
+        self.iris.len()
+    }
+
+    /// The reported class IRIs, in report order.
+    fn iris(&self) -> &[String] {
+        &self.iris
+    }
+
+    /// Size of the internal class-id space (reported classes + `DKey`s).
+    /// Ids at or beyond this are Tseitin / existential-marker synthetics.
+    fn num_class_ids(&self) -> usize {
+        self.pos_of_id.len()
+    }
+
+    /// Report position → internal class id.
+    ///
+    /// # Panics
+    /// If `report_pos` is not a valid report position.
+    fn class_id(&self, report_pos: usize) -> owl_dl_core::ClassId {
+        self.ids[report_pos]
+    }
+
+    /// Internal class id → report position. `None` for a `DKey` filler class
+    /// and for any synthetic id beyond the class vocabulary.
+    fn report_pos(&self, id: owl_dl_core::ClassId) -> Option<usize> {
+        self.pos_of_id
+            .get(id.index() as usize)
+            .copied()
+            .flatten()
+            .map(|p| p as usize)
+    }
+
+    /// `true` iff `id` lies past the end of the class vocabulary — a Tseitin
+    /// or existential-marker synthetic. Callers walking an ASCENDING id
+    /// sequence (e.g. `Subsumers::subsumers_of`) may stop at the first such
+    /// id. This is an id-space vs id-space comparison; it is NOT a substitute
+    /// for [`ReportedClasses::report_pos`], because a `DKey` id may sit
+    /// anywhere *inside* the vocabulary.
+    fn beyond_vocabulary(&self, id: owl_dl_core::ClassId) -> bool {
+        id.index() as usize >= self.num_class_ids()
+    }
+}
+
+// ─── END report-position ↔ ClassId conversion boundary ───────────────────
 
 /// Row-major subsumption matrix backing [`Classification::entails`].
 ///
@@ -338,11 +442,17 @@ pub struct ClassificationStats {
     /// entailment matrix — sound (never reports a false positive),
     /// but may under-report subsumption.
     pub timed_out_pairs: usize,
-    /// The `(sub, sup)` class-index pairs whose subsumption probe timed out
-    /// (defaulted to "not subsumed"). Parallel to `timed_out_pairs` (the
-    /// count); this is the *set*, used to verify the anytime calibration
-    /// claim (every miss is a flagged-undecided pair). Populated at the same
-    /// sites that bump `timed_out_pairs`.
+    /// The `(sub, sup)` pairs whose subsumption probe timed out (defaulted to
+    /// "not subsumed"). Parallel to `timed_out_pairs` (the count); this is the
+    /// *set*, used to verify the anytime calibration claim (every miss is a
+    /// flagged-undecided pair). Populated at the same sites that bump
+    /// `timed_out_pairs`.
+    ///
+    /// Indices are **report positions** — positions in
+    /// [`Classification::classes`], which is what
+    /// [`Classification::undecided_pairs`] indexes with them. They are NOT
+    /// `owl_dl_core::ClassId` indices: the two spaces differ whenever a
+    /// synthetic `DKey` id sits below a user class (see `ReportedClasses`).
     pub timed_out_pair_ids: Vec<(u32, u32)>,
     /// Subsumptions recovered by the defined-SUB sweep: a union-defined
     /// `C ≡ D₁ ⊔ … ⊔ Dₙ` ⊑ a primitive sup `X` where every `Dᵢ ⊑ X` holds
@@ -1131,8 +1241,9 @@ pub fn classify_saturation_only<A: ForIRI>(
 pub(crate) fn classify_saturation_only_internal(
     internal: &InternalOntology,
 ) -> Result<Classification, ReasonError> {
-    let classes: Vec<String> = reportable_class_iris(internal);
-    let index: HashMap<String, usize> = classes
+    let reported = ReportedClasses::collect(internal);
+    let index: HashMap<String, usize> = reported
+        .iris()
         .iter()
         .enumerate()
         .map(|(i, iri)| (iri.clone(), i))
@@ -1140,7 +1251,7 @@ pub(crate) fn classify_saturation_only_internal(
     let closure = saturate(internal);
     Ok(classify_pure_el(
         internal,
-        &classes,
+        &reported,
         &index,
         &closure,
         analyze_fragment(internal),
@@ -1177,8 +1288,11 @@ fn classify_internal_with_timeout_impl(
 ) -> Result<Classification, ReasonError> {
     // Snapshot the class IRIs before we clone the ontology into each
     // subsumption call. Order is the vocabulary's interning order.
-    let classes: Vec<String> = reportable_class_iris(internal);
-    let n = classes.len();
+    // `reported` also carries the report-position ↔ `ClassId` bijection —
+    // the two are NOT interchangeable (see `ReportedClasses`).
+    let reported = ReportedClasses::collect(internal);
+    let classes: Vec<String> = reported.iris().to_vec();
+    let n = reported.len();
     let index: HashMap<String, usize> = classes
         .iter()
         .enumerate()
@@ -1260,7 +1374,7 @@ fn classify_internal_with_timeout_impl(
         }
         return Ok(classify_pure_el(
             internal,
-            &classes,
+            &reported,
             &index,
             &closure,
             analyze_fragment(internal),
@@ -1287,8 +1401,7 @@ fn classify_internal_with_timeout_impl(
     let unsat_probe_results: Result<Vec<(usize, bool, bool)>, ReasonError> = (0..n)
         .into_par_iter()
         .map(|i| {
-            let class_id =
-                owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+            let class_id = reported.class_id(i);
             if closure.is_unsatisfiable(class_id) {
                 Ok((i, false, true))
             } else if let Some(timeout) = unsat_probe_budget(per_pair_timeout) {
@@ -1347,10 +1460,8 @@ fn classify_internal_with_timeout_impl(
     let pair_results: Result<Vec<PairResult>, ReasonError> = work
         .par_iter()
         .map(|&(i, j)| {
-            let sub_class =
-                owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
-            let super_class =
-                owl_dl_core::ClassId::new(u32::try_from(j).expect("class index fits in u32"));
+            let sub_class = reported.class_id(i);
+            let super_class = reported.class_id(j);
             if closure.contains(sub_class, super_class) {
                 // (i, j, entailed, used_saturation, timed_out)
                 return Ok((i, j, true, true, false));
@@ -1434,7 +1545,7 @@ fn classify_internal_with_timeout_impl(
 ///   `PureEl`/`Horn` verdict here would claim a completeness we just abandoned.
 fn classify_prep_timeout(
     internal: &InternalOntology,
-    classes: &[String],
+    reported: &ReportedClasses,
     index: &HashMap<String, usize>,
     closure: &owl_dl_saturation::Subsumers,
     phase: &str,
@@ -1444,7 +1555,7 @@ fn classify_prep_timeout(
     }
     let mut h = classify_pure_el(
         internal,
-        classes,
+        reported,
         index,
         closure,
         FragmentClassification::OutOfFragment,
@@ -1454,7 +1565,7 @@ fn classify_prep_timeout(
     // `undecided_pairs()` stays index-safe). With no classes there is no id to
     // record; the count alone still drives the `incomplete` signal.
     h.stats.timed_out_pairs += 1;
-    if !classes.is_empty() {
+    if !reported.iris().is_empty() {
         h.stats.timed_out_pair_ids.push((0, 0));
     }
     h
@@ -1472,12 +1583,12 @@ fn classify_prep_timeout(
 /// [`FragmentClassification::OutOfFragment`] instead.
 fn classify_pure_el(
     internal: &InternalOntology,
-    classes: &[String],
+    reported: &ReportedClasses,
     index: &HashMap<String, usize>,
     closure: &owl_dl_saturation::Subsumers,
     fragment: FragmentClassification,
 ) -> Classification {
-    let n = classes.len();
+    let n = reported.len();
     let mut stats = ClassificationStats {
         pure_el_mode: true,
         fragment,
@@ -1524,19 +1635,23 @@ fn classify_pure_el(
     //   matching the original counter semantics.
     let mut entailed = EntailmentMatrix::new(n);
     for i in 0..n {
-        let class_id =
-            owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+        let class_id = reported.class_id(i);
         if unsatisfiable_idxs.contains(&i) {
             continue; // row elided
         }
         entailed.insert(i, i); // reflexive
-        // `subsumers_of` is ascending by id (as `FixedBitSet::ones()` was), so
-        // the `>= n` break still terminates at the first synthetic id.
+        // `subsumers_of` is ascending by id, so once we pass the end of the
+        // class vocabulary every remaining id is a Tseitin / existential-marker
+        // synthetic and we can stop. Within the vocabulary a DKey id may sit
+        // ANYWHERE (including below user classes), so DKeys are skipped
+        // individually via `report_pos` — never by an id-vs-`n` comparison.
         for j_id in closure.subsumers_of(class_id) {
-            let j = j_id.index() as usize;
-            if j >= n {
-                break; // synthetic Tseitin/DKey id — outside user vocabulary
+            if reported.beyond_vocabulary(j_id) {
+                break; // synthetic Tseitin id — outside the class vocabulary
             }
+            let Some(j) = reported.report_pos(j_id) else {
+                continue; // DKey filler class — never reported
+            };
             if j == i || unsatisfiable_idxs.contains(&j) {
                 continue; // reflexive already set; unsat-j skipped per original
             }
@@ -1546,7 +1661,7 @@ fn classify_pure_el(
     }
     let _ = internal; // closure was built from this; nothing more to read
     Classification {
-        classes: classes.to_vec(),
+        classes: reported.iris().to_vec(),
         index: index.clone(),
         entailed,
         unsatisfiable_idxs,
@@ -3124,8 +3239,11 @@ fn classify_top_down_internal_impl(
     let classify_start = std::time::Instant::now();
     // RSS probe: entry — post-convert_ontology baseline.
     crate::rss_probe::probe("entry");
-    let classes: Vec<String> = reportable_class_iris(internal);
-    let n = classes.len();
+    // `reported` carries the report-position ↔ `ClassId` bijection — the two
+    // are NOT interchangeable (see `ReportedClasses`).
+    let reported = ReportedClasses::collect(internal);
+    let classes: Vec<String> = reported.iris().to_vec();
+    let n = reported.len();
     let index: HashMap<String, usize> = classes
         .iter()
         .enumerate()
@@ -3197,7 +3315,7 @@ fn classify_top_down_internal_impl(
         // The fixpoint was abandoned. Every derived edge is still entailed, so
         // read the partial closure off as the answer and flag it incomplete.
         return Ok(classify_prep_timeout(
-            internal, &classes, &index, &closure, "saturate",
+            internal, &reported, &index, &closure, "saturate",
         ));
     }
 
@@ -3263,7 +3381,7 @@ fn classify_top_down_internal_impl(
         let precheck_ms = elapsed_ms(t_precheck);
         let mut h = classify_pure_el(
             internal,
-            &classes,
+            &reported,
             &index,
             &closure,
             analyze_fragment(internal),
@@ -3299,7 +3417,7 @@ fn classify_top_down_internal_impl(
     else {
         return Ok(classify_prep_timeout(
             internal,
-            &classes,
+            &reported,
             &index,
             &closure,
             "from_internal",
@@ -3521,8 +3639,7 @@ fn classify_top_down_internal_impl(
                 if lc_deadline.is_some_and(|gd| Instant::now() >= gd) {
                     return crate::LabelOracle::NoVerdict;
                 }
-                let class_id =
-                    owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+                let class_id = reported.class_id(i);
                 // Effective deadline: earlier of the global deadline and the
                 // per-class cache budget. When global_deadline is None, this
                 // reproduces the pre-fix behaviour exactly.
@@ -3572,8 +3689,7 @@ fn classify_top_down_internal_impl(
     let unsat_probe_results: Result<Vec<(usize, bool, bool)>, ReasonError> = (0..n)
         .into_par_iter()
         .map(|i| {
-            let class_id =
-                owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+            let class_id = reported.class_id(i);
             if closure.is_unsatisfiable(class_id) {
                 return Ok((i, false, true));
             }
@@ -3663,7 +3779,7 @@ fn classify_top_down_internal_impl(
     // key fn O(n log n) times; pre-computing avoids repeated allocations.
     let subsumer_counts: Vec<usize> = (0..n)
         .map(|i| {
-            let id = owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+            let id = reported.class_id(i);
             closure.subsumers_count(id)
         })
         .collect();
@@ -3716,9 +3832,7 @@ fn classify_top_down_internal_impl(
             std::collections::HashSet::new()
         } else {
             (0..n)
-                .map(|i| {
-                    owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"))
-                })
+                .map(|i| reported.class_id(i))
                 .filter(|&c| {
                     prepared.data_counting_classes.contains(&c)
                         || closure
@@ -3753,6 +3867,7 @@ fn classify_top_down_internal_impl(
                 let mut local_stats = ClassificationStats::default();
                 let parents = find_direct_parents_top_down(
                     c,
+                    &reported,
                     &closure,
                     &prepared,
                     &direct_supers,
@@ -3846,8 +3961,11 @@ fn classify_top_down_internal_impl(
                     for c in ids {
                         if let owl_dl_core::ir::ConceptExpr::Atomic(cls) = internal.concepts.get(*c)
                         {
-                            let i = cls.index() as usize;
-                            if i < n && !unsatisfiable_idxs.contains(&i) {
+                            // `report_pos` is `None` for a DKey filler — a DKey
+                            // is never a reportable sup, so skipping is correct.
+                            if let Some(i) = reported.report_pos(*cls)
+                                && !unsatisfiable_idxs.contains(&i)
+                            {
                                 set.insert(i);
                             }
                         }
@@ -3871,8 +3989,9 @@ fn classify_top_down_internal_impl(
         for oracle in &label_cache {
             if let crate::LabelOracle::Sat { labels, .. } = oracle {
                 for &sup_id in labels {
-                    let i = sup_id.index() as usize;
-                    if i < n && !unsatisfiable_idxs.contains(&i) {
+                    if let Some(i) = reported.report_pos(sup_id)
+                        && !unsatisfiable_idxs.contains(&i)
+                    {
                         set.insert(i);
                     }
                 }
@@ -3921,8 +4040,7 @@ fn classify_top_down_internal_impl(
             break;
         }
         let sup_verify = defined_verify_mode && defined_set.contains(&sup);
-        let sup_id =
-            owl_dl_core::ClassId::new(u32::try_from(sup).expect("class index fits in u32"));
+        let sup_id = reported.class_id(sup);
         // Parallel test of candidate subs. Skip pairs already known via
         // closure or the existing direct-supers transitive closure.
         let already_known: std::collections::HashSet<usize> = {
@@ -3940,18 +4058,14 @@ fn classify_top_down_internal_impl(
             .filter(|&cand| cand != sup && !unsatisfiable_idxs.contains(&cand))
             .filter(|&cand| !already_known.contains(&cand))
             .filter(|&cand| {
-                let cand_id = owl_dl_core::ClassId::new(
-                    u32::try_from(cand).expect("class index fits in u32"),
-                );
+                let cand_id = reported.class_id(cand);
                 !closure.contains(cand_id, sup_id)
             })
             .collect();
         let probe_results: Vec<(usize, bool, ClassificationStats)> = candidates
             .par_iter()
             .map(|&cand| {
-                let cand_id = owl_dl_core::ClassId::new(
-                    u32::try_from(cand).expect("class index fits in u32"),
-                );
+                let cand_id = reported.class_id(cand);
                 let mut local_stats = ClassificationStats::default();
                 // Phase 7 label-heuristic gate — same logic as the tier
                 // walk's `find_direct_parents_top_down` inner loop.
@@ -3977,6 +4091,7 @@ fn classify_top_down_internal_impl(
                     local_stats.label_cache_misses += 1;
                     subsumes_via_tableau(
                         &prepared,
+                        &reported,
                         cand_id,
                         sup_id,
                         Some(sweep_budget),
@@ -3997,6 +4112,7 @@ fn classify_top_down_internal_impl(
                                 local_stats.label_cache_pass_through += 1;
                                 subsumes_via_tableau(
                                     &prepared,
+                                    &reported,
                                     cand_id,
                                     sup_id,
                                     Some(sweep_budget),
@@ -4023,6 +4139,7 @@ fn classify_top_down_internal_impl(
                             local_stats.label_cache_misses += 1;
                             subsumes_via_tableau(
                                 &prepared,
+                                &reported,
                                 cand_id,
                                 sup_id,
                                 Some(sweep_budget),
@@ -4102,12 +4219,15 @@ fn classify_top_down_internal_impl(
         let mut disjuncts: Option<Vec<usize>> = None;
         for cid in ids {
             match internal.concepts.get(*cid) {
-                owl_dl_core::ir::ConceptExpr::Atomic(cls) => name = Some(cls.index() as usize),
+                // `report_pos` is `None` for a DKey filler; a `None` here (or in
+                // any disjunct below) drops the axiom from the sweep, which only
+                // ever omits a recovery — sound.
+                owl_dl_core::ir::ConceptExpr::Atomic(cls) => name = reported.report_pos(*cls),
                 owl_dl_core::ir::ConceptExpr::Or(ds) => {
                     let atoms: Option<Vec<usize>> = ds
                         .iter()
                         .map(|d| match internal.concepts.get(*d) {
-                            owl_dl_core::ir::ConceptExpr::Atomic(dc) => Some(dc.index() as usize),
+                            owl_dl_core::ir::ConceptExpr::Atomic(dc) => reported.report_pos(*dc),
                             _ => None,
                         })
                         .collect();
@@ -4121,32 +4241,29 @@ fn classify_top_down_internal_impl(
         let (Some(c), Some(ds)) = (name, disjuncts) else {
             continue;
         };
-        if c >= n || ds.is_empty() || unsatisfiable_idxs.contains(&c) {
+        if ds.is_empty() || unsatisfiable_idxs.contains(&c) {
             continue;
         }
         // Candidate sups = intersection of the disjuncts' closure-subsumers.
         let mut cand: Option<std::collections::HashSet<usize>> = None;
         for &d in &ds {
-            let d_id =
-                owl_dl_core::ClassId::new(u32::try_from(d).expect("class index fits in u32"));
+            let d_id = reported.class_id(d);
             let subs: std::collections::HashSet<usize> = closure
                 .subsumers_of(d_id)
                 .into_iter()
-                .map(|s| s.index() as usize)
-                .filter(|&j| j < n)
+                .filter_map(|s| reported.report_pos(s))
                 .collect();
             cand = Some(match cand {
                 None => subs,
                 Some(prev) => prev.intersection(&subs).copied().collect(),
             });
         }
-        let c_id = owl_dl_core::ClassId::new(u32::try_from(c).expect("class index fits in u32"));
+        let c_id = reported.class_id(c);
         for x in cand.unwrap_or_default() {
             if x == c || unsatisfiable_idxs.contains(&x) {
                 continue;
             }
-            let x_id =
-                owl_dl_core::ClassId::new(u32::try_from(x).expect("class index fits in u32"));
+            let x_id = reported.class_id(x);
             // Skip subsumptions already on `C`'s closure ray (the entailment
             // matrix seeds those) or already recorded.
             if closure.contains(c_id, x_id) || direct_supers[c].contains(&x) {
@@ -4172,7 +4289,7 @@ fn classify_top_down_internal_impl(
     inject_backfold_derived_sups(
         &label_cache,
         &closure,
-        n,
+        &reported,
         &mut direct_supers,
         &mut direct_children,
         &mut stats,
@@ -4204,10 +4321,9 @@ fn classify_top_down_internal_impl(
         }
         entailed.insert(i, i);
         // Closure seed.
-        let i_id = owl_dl_core::ClassId::new(u32::try_from(i).expect("class index fits in u32"));
+        let i_id = reported.class_id(i);
         for j_id in closure.subsumers_of(i_id) {
-            let j = j_id.index() as usize;
-            if j < n {
+            if let Some(j) = reported.report_pos(j_id) {
                 entailed.insert(i, j);
             }
         }
@@ -4298,7 +4414,7 @@ fn classify_top_down_internal_impl(
 fn inject_backfold_derived_sups(
     label_cache: &[crate::LabelOracle],
     closure: &owl_dl_saturation::Subsumers,
-    n: usize,
+    reported: &ReportedClasses,
     direct_supers: &mut [Vec<usize>],
     direct_children: &mut [Vec<usize>],
     stats: &mut ClassificationStats,
@@ -4306,10 +4422,12 @@ fn inject_backfold_derived_sups(
     if !crate::classify_backfold_enabled() {
         return;
     }
+    let n = direct_supers.len();
     for (c, oracle) in label_cache.iter().enumerate() {
-        // Defensive: `direct_supers`/`direct_children` are indexed by class id in
-        // `0..n`; the loop should never see `c >= n` (label_cache.len() == n), but
-        // guard so a broken invariant is a skip, never an index panic.
+        // Defensive: `direct_supers`/`direct_children` are report-position
+        // indexed over `0..n`; the loop should never see `c >= n`
+        // (label_cache.len() == n), but guard so a broken invariant is a skip,
+        // never an index panic.
         if c >= n {
             continue;
         }
@@ -4319,10 +4437,14 @@ fn inject_backfold_derived_sups(
         if derived_sups.is_empty() {
             continue;
         }
-        let c_id = owl_dl_core::ClassId::new(u32::try_from(c).expect("class index fits in u32"));
+        let c_id = reported.class_id(c);
         for &d_id in derived_sups {
-            let d = d_id.index() as usize;
-            if d >= n || d == c {
+            // `derived_sups` are `ClassId`s: a DKey (or synthetic) has no report
+            // position and is never an injectable sup.
+            let Some(d) = reported.report_pos(d_id) else {
+                continue;
+            };
+            if d == c {
                 continue;
             }
             if closure.contains(c_id, d_id) || direct_supers[c].contains(&d) {
@@ -4348,6 +4470,7 @@ fn inject_backfold_derived_sups(
 #[allow(clippy::too_many_arguments)]
 fn find_direct_parents_top_down(
     c: usize,
+    reported: &ReportedClasses,
     closure: &owl_dl_saturation::Subsumers,
     prepared: &PreparedOntology,
     direct_supers: &[Vec<usize>],
@@ -4359,7 +4482,7 @@ fn find_direct_parents_top_down(
     counting_relevant: &std::collections::HashSet<owl_dl_core::ClassId>,
     stats: &mut ClassificationStats,
 ) -> Result<Vec<usize>, ReasonError> {
-    let c_id = owl_dl_core::ClassId::new(u32::try_from(c).expect("class index fits in u32"));
+    let c_id = reported.class_id(c);
     let n = direct_supers.len();
     // Global-deadline fast-exit BEFORE cloning `top_level`: under a tight budget
     // most classes stay unplaced/top-level, so `top_level` can be ~n; cloning it
@@ -4405,7 +4528,7 @@ fn find_direct_parents_top_down(
             ));
             break;
         }
-        let d_id = owl_dl_core::ClassId::new(u32::try_from(d).expect("class index fits in u32"));
+        let d_id = reported.class_id(d);
         let subsumed = if closure.contains(c_id, d_id) {
             stats.saturation_subsumption_hits += 1;
             true
@@ -4420,6 +4543,7 @@ fn find_direct_parents_top_down(
                         stats.label_cache_pass_through += 1;
                         subsumes_via_tableau(
                             prepared,
+                            reported,
                             c_id,
                             d_id,
                             per_pair_timeout,
@@ -4445,6 +4569,7 @@ fn find_direct_parents_top_down(
                     stats.label_cache_misses += 1;
                     subsumes_via_tableau(
                         prepared,
+                        reported,
                         c_id,
                         d_id,
                         per_pair_timeout,
@@ -4477,14 +4602,8 @@ fn find_direct_parents_top_down(
         .filter(|&d| {
             !accepted.iter().any(|&e| {
                 e != d
-                    && (closure.contains(
-                        owl_dl_core::ClassId::new(
-                            u32::try_from(e).expect("class index fits in u32"),
-                        ),
-                        owl_dl_core::ClassId::new(
-                            u32::try_from(d).expect("class index fits in u32"),
-                        ),
-                    ) || direct_supers[e].contains(&d))
+                    && (closure.contains(reported.class_id(e), reported.class_id(d))
+                        || direct_supers[e].contains(&d))
             })
         })
         .collect();
@@ -4515,6 +4634,41 @@ fn record_fallthrough_outcome(
     }
 }
 
+/// Records an undecided (timed-out) pair in **report-position** space.
+///
+/// `subsumes_via_tableau` works in `ClassId` space, but
+/// [`ClassificationStats::timed_out_pair_ids`] is read back by
+/// [`Classification::undecided_pairs`] as indices into
+/// `Classification::classes`. Pushing raw `ClassId` indices there mislabels
+/// (or panics on) the reported pair as soon as a `DKey` id sits below a user
+/// class.
+///
+/// # Panics
+///
+/// Both ids always originate from `ReportedClasses::class_id`, which only ever
+/// yields reportable classes, so `report_pos` is `Some` by construction.
+/// Panicking rather than skipping keeps the anytime invariant
+/// `undecided_pairs().len() == timed_out_pairs` (asserted by
+/// `undecided_pairs_reports_timed_out_subsumptions`) exact — a silent skip
+/// here would break it.
+fn push_undecided_pair(
+    stats: &mut ClassificationStats,
+    reported: &ReportedClasses,
+    sub: owl_dl_core::ClassId,
+    sup: owl_dl_core::ClassId,
+) {
+    let i = reported
+        .report_pos(sub)
+        .expect("undecided sub is a reportable class");
+    let j = reported
+        .report_pos(sup)
+        .expect("undecided sup is a reportable class");
+    stats.timed_out_pair_ids.push((
+        u32::try_from(i).expect("class index fits in u32"),
+        u32::try_from(j).expect("class index fits in u32"),
+    ));
+}
+
 /// Helper: ask the tableau whether `sub ⊑ sup`. Counts the call in
 /// `stats`, honours `per_pair_timeout`, returns:
 /// - `Ok(Some(true))` — subsumption holds
@@ -4523,6 +4677,7 @@ fn record_fallthrough_outcome(
 #[allow(clippy::too_many_arguments)]
 fn subsumes_via_tableau(
     prepared: &PreparedOntology,
+    reported: &ReportedClasses,
     sub: owl_dl_core::ClassId,
     sup: owl_dl_core::ClassId,
     per_pair_timeout: Option<std::time::Duration>,
@@ -4659,7 +4814,7 @@ fn subsumes_via_tableau(
             // timed-out pair so the INCOMPLETE banner stays honest.
             stats.diverged_tail_skips += 1;
             stats.timed_out_pairs += 1;
-            stats.timed_out_pair_ids.push((sub.index(), sup.index()));
+            push_undecided_pair(stats, reported, sub, sup);
             return Ok(None);
         }
         _ => {}
@@ -4728,7 +4883,7 @@ fn subsumes_via_tableau(
                 }
                 Ok(None) | Err(crate::ReasonError::NoVerdict) => {
                     stats.timed_out_pairs += 1;
-                    stats.timed_out_pair_ids.push((sub.index(), sup.index()));
+                    push_undecided_pair(stats, reported, sub, sup);
                     record_fallthrough_outcome(stats, stall_fallthrough, stall_diverged, None);
                     Ok(None)
                 }
@@ -5321,6 +5476,9 @@ Ontology(<http://rustdl.test/test>\n\
         ));
         let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
         let closure = owl_dl_saturation::saturate(&internal);
+        // Declarations only, no DKeys: report position == class id here, which
+        // is exactly why these unit tests can index by `id.index()`.
+        let reported = ReportedClasses::collect(&internal);
         let iri = |s: &str| format!("http://rustdl.test/{s}");
         let a = internal.vocabulary.class_id(&iri("A")).expect("A id");
         let c = internal.vocabulary.class_id(&iri("C")).expect("C id");
@@ -5343,7 +5501,7 @@ Ontology(<http://rustdl.test/test>\n\
         inject_backfold_derived_sups(
             &label_cache,
             &closure,
-            n,
+            &reported,
             &mut direct_supers,
             &mut direct_children,
             &mut stats,
@@ -5357,7 +5515,7 @@ Ontology(<http://rustdl.test/test>\n\
         inject_backfold_derived_sups(
             &label_cache,
             &closure,
-            n,
+            &reported,
             &mut direct_supers,
             &mut direct_children,
             &mut stats,
@@ -5387,6 +5545,9 @@ Ontology(<http://rustdl.test/test>\n\
         ));
         let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
         let closure = owl_dl_saturation::saturate(&internal);
+        // Declarations only, no DKeys: report position == class id here, which
+        // is exactly why these unit tests can index by `id.index()`.
+        let reported = ReportedClasses::collect(&internal);
         let iri = |s: &str| format!("http://rustdl.test/{s}");
         let a = internal.vocabulary.class_id(&iri("A")).expect("A id");
         let c = internal.vocabulary.class_id(&iri("C")).expect("C id");
@@ -5408,7 +5569,7 @@ Ontology(<http://rustdl.test/test>\n\
         inject_backfold_derived_sups(
             &label_cache,
             &closure,
-            n,
+            &reported,
             &mut direct_supers,
             &mut direct_children,
             &mut stats,
@@ -5434,6 +5595,9 @@ Ontology(<http://rustdl.test/test>\n\
         ));
         let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
         let closure = owl_dl_saturation::saturate(&internal);
+        // Declarations only, no DKeys: report position == class id here, which
+        // is exactly why these unit tests can index by `id.index()`.
+        let reported = ReportedClasses::collect(&internal);
         let iri = |s: &str| format!("http://rustdl.test/{s}");
         let a = internal.vocabulary.class_id(&iri("A")).expect("A id");
         let c = internal.vocabulary.class_id(&iri("C")).expect("C id");
@@ -5457,7 +5621,7 @@ Ontology(<http://rustdl.test/test>\n\
         inject_backfold_derived_sups(
             &label_cache,
             &closure,
-            n,
+            &reported,
             &mut direct_supers,
             &mut direct_children,
             &mut stats,

--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -1612,13 +1612,22 @@ fn classify_pure_el(
         stats.inconsistent = true;
     }
 
-    // Pass 1 — identify unsatisfiable classes (O(n) via the closure bitset).
-    // Build the unsatisfiable bitset directly for O(1) per-bit membership test
-    // in the subsumption read-off below.
+    // Pass 1 — identify unsatisfiable classes (O(n) closure lookups).
+    //
+    // MUST go through `Subsumers::is_unsatisfiable`, which takes a `ClassId`.
+    // The raw `Subsumers::unsatisfiable_bitset()` is CLASS-ID indexed ("bit `i`
+    // set iff `class_i ⊑ ⊥`"), so probing it with a report position `i` made a
+    // satisfiable class inherit a neighbour's `⊥` flag — and because
+    // `Classification::entails` short-circuits on `unsatisfiable_idxs` to
+    // supply `⊥ ⊑ *`, that one mis-indexed bit turned EVERY pair involving the
+    // class into a false positive (and `unsatisfiable_classes()` named the
+    // wrong class). See `tests/dkey_id_aliasing.rs::UNSAT_BODY`. This is the
+    // same report-position/`ClassId` conflation as the rest of this file, but
+    // spelled with no cast at all — which is why the source-level guard in that
+    // test file did not see it.
     let mut unsatisfiable_idxs: HashSet<usize> = HashSet::new();
-    let unsat_bs = closure.unsatisfiable_bitset();
     for i in 0..n {
-        if i < unsat_bs.len() && unsat_bs.contains(i) {
+        if closure.is_unsatisfiable(reported.class_id(i)) {
             unsatisfiable_idxs.insert(i);
             stats.saturation_unsat_hits += 1;
         }

--- a/crates/owl-dl-reasoner/src/realize.rs
+++ b/crates/owl-dl-reasoner/src/realize.rs
@@ -754,6 +754,13 @@ pub fn realize_saturation_only_internal(
     internal: &InternalOntology,
 ) -> Result<Realization, ReasonError> {
     let hierarchy = classify_saturation_only_internal(internal)?;
+    // Enumerated over the FULL class-id space, so `enumerate()` below yields a
+    // genuine `ClassId` index (the DKey filter that makes `classify`'s report
+    // vector shorter is deliberately NOT applied here — applying it before the
+    // `enumerate` would alias the two spaces, which is the classify.rs bug).
+    // Consequence: `class_iris` DOES contain `urn:rustdl-dkey:` entries and
+    // `unsat` does not remove them, so a `DKey` can reach the candidate-type
+    // probe. Unreproduced; see the note in `realize_via_saturation_internal`.
     let class_iris: Vec<String> = (0..internal.vocabulary.num_classes())
         .map(|i| {
             internal
@@ -959,8 +966,23 @@ pub(crate) fn realize_via_saturation_internal(
             continue;
         }
         // Entailed named types = subsumers of the individual's nominal class,
-        // restricted to declared user classes (synthetic Tseitin / nominal ids
-        // are ≥ num_user_classes) and to satisfiable classes.
+        // restricted to ids inside the class vocabulary (synthetic Tseitin /
+        // nominal ids are ≥ num_user_classes) and to satisfiable classes.
+        //
+        // NOTE what this does NOT do: `num_user_classes` is
+        // `vocabulary.num_classes()`, which COUNTS the synthetic `DKey(range)`
+        // filler classes of the integer-facet data lowering — they live INSIDE
+        // the class vocabulary, not above it (see `ReportedClasses` in
+        // classify.rs). So the `< num_user_classes` bound excludes only
+        // Tseitin/nominal synthetics; a `DKey` subsumer would pass straight
+        // through and be reported as an entailed type with a
+        // `urn:rustdl-dkey:` IRI. No reproducer is known — a `DKey` becomes a
+        // subsumer of a VALUE node reached through a role, not of an
+        // individual's nominal class — and `unsat` does not filter it either.
+        // Left as-is deliberately rather than hardened blind; if you are here
+        // because a `urn:rustdl-dkey:` IRI escaped into `realize` output, the
+        // fix is a `!iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX)` guard here
+        // and at the two `class_iris` builders below.
         let types: Vec<String> = nominal_by_ind
             .get(&ind)
             .map(|&nom| {
@@ -1089,6 +1111,9 @@ pub(crate) fn realize_tableau_internal(
         pair_deadline_ms.map(std::time::Duration::from_millis),
         None,
     )?;
+    // Full class-id space — see the note in `realize_saturation_only_internal`:
+    // `enumerate()` must stay aligned with `ClassId`, so no DKey filter here,
+    // and `class_iris` therefore includes `urn:rustdl-dkey:` entries.
     let class_iris: Vec<String> = (0..internal.vocabulary.num_classes())
         .map(|i| {
             internal

--- a/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
@@ -17,18 +17,26 @@
 //! the aliasing is invisible. The fixtures below instead reference classes
 //! that are NOT declared, so they are interned *after* a `DKey`.
 //!
+//! `bench-corpus/pizza.ofn` DOES have the hazardous layout (five user classes
+//! above its first `DKey`), but every one of them is hierarchy-isolated, so it
+//! shows no observable difference either way — see
+//! `inert_declarations_do_not_change_the_hierarchy_pizza`. No tracked corpus
+//! file can currently fail on this bug class; the hand-built fixtures are the
+//! real net.
+//!
 //! Run: `cargo test -p owl-dl-reasoner --test dkey_id_aliasing`.
 
 #![allow(clippy::unwrap_used)]
 
 use horned_owl::io::ParserConfiguration;
 use horned_owl::io::ofn::reader::read as read_ofn;
-use horned_owl::model::RcStr;
+use horned_owl::model::{Build, DeclareClass, MutableOntology, RcStr};
 use horned_owl::ontology::set::SetOntology;
 use std::io::Cursor;
 use std::time::Duration;
 
 const PFX: &str = r"Prefix(:=<http://t/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
 Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 ";
 
@@ -63,6 +71,87 @@ SubClassOf(:Yy :Ww)
 DisjointClasses(:Uu :Ppp)
 ";
 
+/// Same `DKey`-at-id-0 shape, plus an **unsatisfiable** class.
+///
+/// This is the fixture the first round of this file was missing, and the gap
+/// let a live false positive survive the fix: `classify_pure_el`'s Pass 1 read
+/// `Subsumers::unsatisfiable_bitset()` — which is `ClassId`-indexed ("bit `i`
+/// set iff `class_i ⊑ ⊥`") — with a REPORT POSITION. A satisfiable class
+/// inherited its neighbour's `⊥` flag, its row was elided, and
+/// `Classification::entails` then supplied `⊥ ⊑ *` for it, so EVERY pair
+/// involving it became a false positive and `unsatisfiable_classes()` named
+/// the wrong class.
+///
+/// Ground truth: `Aaa ⊑ ⊥` (and only `Aaa`), `Ccc ⊑ Ddd ⊑ Eee`.
+const UNSAT_BODY: &str = r"
+SubClassOf(ObjectSomeValuesFrom(:op DataSomeValuesFrom(:dp xsd:integer)) :Aaa)
+SubClassOf(:Aaa owl:Nothing)
+SubClassOf(:Ccc :Ddd)
+SubClassOf(:Ddd :Eee)
+";
+
+/// Add `Declaration(Class(C))` for every class the ontology already mentions.
+///
+/// Semantically inert (OWL 2 treats a used class as declared), but it moves
+/// every named class BELOW every `DKey` in the id space — every `DeclareClass`
+/// component sorts before every axiom — i.e. into the configuration where the
+/// aliasing is invisible. Generated from the lowered vocabulary rather than
+/// hand-listed so this works on a real corpus file too.
+fn with_all_classes_declared(onto: &SetOntology<RcStr>) -> SetOntology<RcStr> {
+    let internal = owl_dl_core::convert::convert_ontology(onto).expect("convert");
+    let build: Build<RcStr> = Build::new();
+    let mut out = onto.clone();
+    for i in 0..internal.vocabulary.num_classes() {
+        let iri = internal
+            .vocabulary
+            .class_iri(owl_dl_core::ClassId::new(u32::try_from(i).unwrap()));
+        if iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX) {
+            continue;
+        }
+        out.insert(DeclareClass(build.class(iri)));
+    }
+    out
+}
+
+/// Load a tracked `bench-corpus/` fixture.
+fn corpus(name: &str) -> SetOntology<RcStr> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../bench-corpus")
+        .join(name);
+    let src = std::fs::read_to_string(&path).expect("read corpus fixture");
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse corpus fixture");
+    onto
+}
+
+/// `true` iff some `DKey` id sits BELOW some user-class id — the configuration
+/// in which a report position stops equalling its `ClassId`.
+///
+/// NOTE the predicate: `first_dkey < last_user`, NOT `last_dkey < last_user`.
+/// Round 1 of this file used the latter, which is wrong — a run of `DKey`s that
+/// *straddles* the top of the user range (pizza: first `DKey` at 87, last user
+/// class at 95, last `DKey` at 103) is hazardous but reports `false` under it.
+fn dkey_sits_below_a_user_class(onto: &SetOntology<RcStr>) -> bool {
+    let internal = owl_dl_core::convert::convert_ontology(onto).expect("convert");
+    let iris: Vec<String> = (0..internal.vocabulary.num_classes())
+        .map(|i| {
+            internal
+                .vocabulary
+                .class_iri(owl_dl_core::ClassId::new(u32::try_from(i).unwrap()))
+                .to_string()
+        })
+        .collect();
+    let is_dkey = |s: &String| s.starts_with(owl_dl_core::DKEY_IRI_PREFIX);
+    match (
+        iris.iter().position(is_dkey),
+        iris.iter().rposition(|s| !is_dkey(s)),
+    ) {
+        (Some(first_dkey), Some(last_user)) => first_dkey < last_user,
+        _ => false,
+    }
+}
+
 /// The whole point of the fixtures: they must actually place a `DKey` BELOW at
 /// least one reported class. If a future change to `convert_ontology`'s
 /// component ordering pushes every `DKey` to the top of the id space again,
@@ -71,33 +160,44 @@ DisjointClasses(:Uu :Ppp)
 /// ever go green for a suspicious reason.
 #[test]
 fn fixtures_really_put_a_dkey_below_a_user_class() {
-    for (name, body) in [("EL", EL_BODY), ("hybrid", HYBRID_BODY)] {
+    for (name, body) in [
+        ("EL", EL_BODY),
+        ("hybrid", HYBRID_BODY),
+        ("unsat", UNSAT_BODY),
+    ] {
         let onto = parse(body);
-        let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
-        let n = internal.vocabulary.num_classes();
-        let iris: Vec<String> = (0..n)
-            .map(|i| {
-                internal
-                    .vocabulary
-                    .class_iri(owl_dl_core::ClassId::new(u32::try_from(i).unwrap()))
-                    .to_string()
-            })
-            .collect();
-        let is_dkey = |s: &str| s.starts_with(owl_dl_core::DKEY_IRI_PREFIX);
-        let last_dkey = iris.iter().rposition(|s| is_dkey(s));
-        let last_user = iris.iter().rposition(|s| !is_dkey(s));
         assert!(
-            last_dkey.is_some(),
-            "{name} fixture minted no DKey at all — the hazard is not exercised; \
-             iris = {iris:#?}"
-        );
-        assert!(
-            last_dkey < last_user,
+            dkey_sits_below_a_user_class(&onto),
             "{name} fixture puts every DKey ABOVE every user class, so report \
-             position == ClassId and the aliasing oracles below are VACUOUS. \
-             iris = {iris:#?}"
+             position == ClassId and the aliasing oracles below are VACUOUS"
         );
     }
+}
+
+/// The corpus counterpart. `bench-corpus/pizza.ofn` exhibits the hazard in its
+/// id layout (first `DKey` at id 87, five user classes interned above it, last
+/// user class at 95); `mie.ofn` does not (all 84 classes declared, so all 17
+/// `DKey`s land at ids 84..=100, above everything).
+///
+/// Neither can currently FAIL on this bug class — see
+/// `inert_declarations_do_not_change_the_hierarchy_pizza` for why pizza's
+/// hazard is inert. This test pins the two structural facts so that a future
+/// change to either file, or to `convert_ontology`'s ordering, is visible
+/// rather than silent.
+#[test]
+fn pizza_corpus_exhibits_the_hazard_and_mie_does_not() {
+    assert!(
+        dkey_sits_below_a_user_class(&corpus("pizza.ofn")),
+        "pizza.ofn no longer interns a user class above a DKey — the corpus \
+         oracle `inert_declarations_do_not_change_the_hierarchy_pizza` is now \
+         VACUOUS and needs a new corpus fixture"
+    );
+    assert!(
+        !dkey_sits_below_a_user_class(&corpus("mie.ofn")),
+        "mie.ofn now exhibits the hazard — it is worth promoting back to a \
+         reproducer (round 1 verified it did NOT, contradicting the original \
+         finding)"
+    );
 }
 
 /// Oracle 1 — `classify()` must agree with `is_subclass_of()`.
@@ -164,11 +264,22 @@ fn classify_agrees_with_direct_query_on_hybrid_fixture() {
     assert_classify_agrees_with_direct_query("classify/hybrid", &onto, &cls, true);
 }
 
+#[test]
+fn classify_agrees_with_direct_query_on_unsat_fixture() {
+    let onto = parse(UNSAT_BODY);
+    let cls = owl_dl_reasoner::classify(&onto).expect("classify");
+    assert_classify_agrees_with_direct_query("classify/unsat", &onto, &cls, true);
+}
+
 /// The naive `n²` pair sweep has its own copy of the report-index → `ClassId`
 /// mapping, so it needs its own cross-check.
 #[test]
 fn classify_n2_agrees_with_direct_query() {
-    for (label, body) in [("n2/EL", EL_BODY), ("n2/hybrid", HYBRID_BODY)] {
+    for (label, body) in [
+        ("n2/EL", EL_BODY),
+        ("n2/hybrid", HYBRID_BODY),
+        ("n2/unsat", UNSAT_BODY),
+    ] {
         let onto = parse(body);
         let cls = owl_dl_reasoner::classify_n2(&onto).expect("classify_n2");
         assert_classify_agrees_with_direct_query(label, &onto, &cls, true);
@@ -179,7 +290,11 @@ fn classify_n2_agrees_with_direct_query() {
 /// the false-positive direction is asserted.
 #[test]
 fn classify_saturation_only_has_no_false_positives() {
-    for (label, body) in [("sat/EL", EL_BODY), ("sat/hybrid", HYBRID_BODY)] {
+    for (label, body) in [
+        ("sat/EL", EL_BODY),
+        ("sat/hybrid", HYBRID_BODY),
+        ("sat/unsat", UNSAT_BODY),
+    ] {
         let onto = parse(body);
         let cls =
             owl_dl_reasoner::classify_saturation_only(&onto).expect("classify_saturation_only");
@@ -189,7 +304,11 @@ fn classify_saturation_only_has_no_false_positives() {
 
 #[test]
 fn classify_top_down_agrees_with_direct_query() {
-    for (label, body) in [("td/EL", EL_BODY), ("td/hybrid", HYBRID_BODY)] {
+    for (label, body) in [
+        ("td/EL", EL_BODY),
+        ("td/hybrid", HYBRID_BODY),
+        ("td/unsat", UNSAT_BODY),
+    ] {
         let onto = parse(body);
         let cls = owl_dl_reasoner::classify_top_down_with_timeout(&onto, Duration::from_secs(5))
             .expect("classify_top_down");
@@ -208,11 +327,16 @@ fn classify_top_down_agrees_with_direct_query() {
 /// which is exactly the configuration where the aliasing is invisible. So
 /// under the bug the declared variant is CORRECT and the undeclared one is
 /// BROKEN, and the two hierarchies differ.
-fn assert_inert_declarations_are_inert(label: &str, body: &str, declarations: &str) {
-    let bare = parse(body);
-    let declared = parse(&format!("{declarations}{body}"));
+///
+/// This is the strongest oracle in the file: it needs no ground truth, no
+/// second reasoner, and it generalises to any future id-assignment-sensitive
+/// defect. It is also cheap enough to run on a real corpus file, which the
+/// `is_subclass_of` cross-check is NOT (its n² of fresh tableau probes is
+/// minutes of work on pizza).
+fn assert_inert_declarations_are_inert(label: &str, bare: &SetOntology<RcStr>) {
+    let declared = with_all_classes_declared(bare);
 
-    let bare_cls = owl_dl_reasoner::classify(&bare).expect("classify bare");
+    let bare_cls = owl_dl_reasoner::classify(bare).expect("classify bare");
     let declared_cls = owl_dl_reasoner::classify(&declared).expect("classify declared");
 
     let mut bare_names: Vec<String> = bare_cls.classes().iter().map(|s| (*s).clone()).collect();
@@ -226,6 +350,15 @@ fn assert_inert_declarations_are_inert(label: &str, body: &str, declarations: &s
     assert_eq!(
         bare_names, declared_names,
         "[{label}] inert declarations changed the reported CLASS SET"
+    );
+
+    let mut bare_unsat = bare_cls.unsatisfiable_classes();
+    let mut declared_unsat = declared_cls.unsatisfiable_classes();
+    bare_unsat.sort_unstable();
+    declared_unsat.sort_unstable();
+    assert_eq!(
+        bare_unsat, declared_unsat,
+        "[{label}] inert declarations changed the UNSATISFIABLE set"
     );
 
     let mut differences: Vec<String> = Vec::new();
@@ -243,55 +376,152 @@ fn assert_inert_declarations_are_inert(label: &str, body: &str, declarations: &s
     assert!(
         differences.is_empty(),
         "[{label}] adding Declaration(Class(..)) axioms that entail NOTHING changed \
-         the reported hierarchy — impossible for a correct classifier:\n{}",
-        differences.join("\n")
+         the reported hierarchy — impossible for a correct classifier ({} pair(s), \
+         first 40 shown):\n{}",
+        differences.len(),
+        differences
+            .iter()
+            .take(40)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
     );
 }
 
 #[test]
 fn inert_declarations_do_not_change_the_hierarchy_el() {
-    assert_inert_declarations_are_inert(
-        "EL",
-        EL_BODY,
-        "Declaration(Class(:Aaa))\n\
-         Declaration(Class(:Zzz))\n\
-         Declaration(Class(:Yy))\n\
-         Declaration(Class(:Uu))\n",
-    );
+    assert_inert_declarations_are_inert("EL", &parse(EL_BODY));
 }
 
 #[test]
 fn inert_declarations_do_not_change_the_hierarchy_hybrid() {
-    assert_inert_declarations_are_inert(
-        "hybrid",
-        HYBRID_BODY,
-        "Declaration(Class(:Aaa))\n\
-         Declaration(Class(:Zzz))\n\
-         Declaration(Class(:Yy))\n\
-         Declaration(Class(:Uu))\n\
-         Declaration(Class(:Ww))\n\
-         Declaration(Class(:Ppp))\n",
-    );
+    assert_inert_declarations_are_inert("hybrid", &parse(HYBRID_BODY));
 }
 
-/// General soundness cross-check on a tracked corpus fixture. `mie.ofn` does
-/// NOT currently exercise the aliasing (all 84 classes are declared, so its
-/// `DKey`s sit at ids 84..=100) — see the module doc. It is here as a
-/// real-ontology FP oracle, not as a reproducer.
 #[test]
-fn classify_agrees_with_direct_query_on_mie_corpus() {
-    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../bench-corpus/mie.ofn");
-    let src = std::fs::read_to_string(&path).expect("read mie.ofn");
-    let mut reader = Cursor::new(src);
-    let (onto, _): (SetOntology<RcStr>, _) =
-        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse mie.ofn");
-    let cls = owl_dl_reasoner::classify(&onto).expect("classify");
+fn inert_declarations_do_not_change_the_hierarchy_unsat() {
+    assert_inert_declarations_are_inert("unsat", &parse(UNSAT_BODY));
+}
+
+/// The corpus oracle — a LATENT-HAZARD CANARY, not a reproducer. Read this
+/// before trusting it.
+///
+/// `bench-corpus/pizza.ofn` genuinely exhibits the hazard in its ID LAYOUT:
+/// five user classes (`pro/ContainedRole`, `pro/DevelopmentRole`,
+/// `pro/OnTopPositionRole`, `pro/PersistingRole`, `sulo/Collection`) are
+/// interned ABOVE its first `DKey` at id 87 (12 `DKey`s, last user class at 95,
+/// 104 class ids). So pre-fix those five report positions did read `DKey` rows.
+///
+/// But it produces NO OBSERVABLE DELTA, measured: all five are
+/// hierarchy-isolated (zero reported subsumers, zero reported subclasses) and
+/// pizza's unsatisfiable set is empty, so the rows they misread were empty
+/// too. A full hierarchy + unsat dump over `pizza.ofn`, `mie.ofn` and
+/// `paper5.ofn` is BYTE-IDENTICAL between `c1f44d8` and the fixed tree (377
+/// lines, validated against a sentinel fixture that does differ). This test
+/// therefore passes both pre- and post-fix and CANNOT currently fail on this
+/// bug class — same practical status as `mie.ofn`, for a different reason
+/// (hazard present but inert, vs hazard absent).
+///
+/// It is kept because it is nearly free (~0.4 s) and because the day pizza's
+/// aliased classes gain a hierarchy edge, or an unsatisfiable class appears
+/// anywhere in it, this becomes a live oracle on a real ontology with no test
+/// change needed. The fixtures above are what actually holds the line today.
+///
+/// Deliberately the inert-declaration oracle and not the `is_subclass_of`
+/// cross-check: the latter's n² of fresh tableau probes does not finish on
+/// pizza inside any reasonable test budget.
+///
+/// # Release-only, and why
+///
+/// `classify()` on `pizza.ofn` trips a PRE-EXISTING `debug_assert!` in a crate
+/// this work does not touch — `crates/owl-dl-tableau/src/hyper.rs:3677`,
+/// "≤1 violation reached `find_open_at_most` under `inverse_func_merge`".
+/// Verified
+/// pre-existing: a bare `classify(pizza.ofn)` panics there on `c1f44d8` too,
+/// with none of this branch's code in the picture. Fixing an unrelated tableau
+/// invariant is out of scope for a soundness fix to the report projection, and
+/// papering over it with `catch_unwind` would hide a real defect. So this test
+/// is `ignore`d under `debug_assertions` — it shows up as `ignored` rather than
+/// silently absent — and runs for real in `--release`. Delete the gate once
+/// hyper.rs:3677 is resolved.
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "classify(pizza.ofn) trips the pre-existing debug_assert at \
+              owl-dl-tableau/src/hyper.rs:3677 (inverse_func_merge); runs in --release"
+)]
+fn inert_declarations_do_not_change_the_hierarchy_pizza() {
+    assert_inert_declarations_are_inert("pizza", &corpus("pizza.ofn"));
+}
+
+/// The unsatisfiable set must name the class that is ACTUALLY `⊑ ⊥`.
+///
+/// A projection bug here is worse than a wrong subsumption: `Classification::
+/// entails` short-circuits on `unsatisfiable_idxs`, so a class wrongly flagged
+/// `⊥` is reported as subsuming EVERY other class — an unbounded fan-out of
+/// false positives from one mis-indexed bit. Pinned on all four entry points
+/// because each builds the unsat set through a different path.
+#[test]
+fn unsatisfiable_set_names_the_right_class() {
+    let onto = parse(UNSAT_BODY);
+    let expected = vec!["http://t/Aaa"];
+    let variants: Vec<(&str, owl_dl_reasoner::Classification)> = vec![
+        (
+            "classify",
+            owl_dl_reasoner::classify(&onto).expect("classify"),
+        ),
+        (
+            "classify_n2",
+            owl_dl_reasoner::classify_n2(&onto).expect("classify_n2"),
+        ),
+        (
+            "classify_saturation_only",
+            owl_dl_reasoner::classify_saturation_only(&onto).expect("classify_saturation_only"),
+        ),
+        (
+            "classify_top_down",
+            owl_dl_reasoner::classify_top_down_with_timeout(&onto, Duration::from_secs(5))
+                .expect("classify_top_down"),
+        ),
+    ];
+    for (name, cls) in &variants {
+        let mut unsat = cls.unsatisfiable_classes();
+        unsat.sort_unstable();
+        assert_eq!(
+            unsat, expected,
+            "[{name}] wrong unsatisfiable set — a satisfiable class flagged ⊥ \
+             subsumes everything, so every pair involving it is a false positive"
+        );
+    }
+}
+
+/// Downstream blast radius: `realize` builds its unsatisfiable-class filter
+/// from `classify_saturation_only_internal` (`realize.rs:669`), so the same
+/// mis-indexed bit silently deletes a satisfiable class from every
+/// individual's entailed types.
+#[test]
+fn realize_types_survive_the_unsat_projection() {
+    let onto = parse(&format!(
+        "{UNSAT_BODY}Declaration(NamedIndividual(:i1))\nClassAssertion(:Ccc :i1)\n"
+    ));
+    let r = owl_dl_reasoner::realize(&onto).expect("realize");
+    let types = r.entailed_types("http://t/i1");
+    for expected in ["http://t/Ccc", "http://t/Ddd", "http://t/Eee"] {
+        assert!(
+            types.contains(&expected.to_string()),
+            "realize() lost the entailed type {expected} for :i1 — got {types:?}"
+        );
+    }
     assert!(
-        cls.classes().len() > 50,
-        "mie.ofn should report ~84 classes, got {}",
-        cls.classes().len()
+        !types.iter().any(|t| t == "http://t/Aaa"),
+        "realize() reported the genuinely unsatisfiable Aaa as a type — got {types:?}"
     );
-    assert_classify_agrees_with_direct_query("mie", &onto, &cls, false);
+    assert!(
+        !types
+            .iter()
+            .any(|t| t.starts_with(owl_dl_core::DKEY_IRI_PREFIX)),
+        "realize() leaked a synthetic DKey IRI into the entailed types — got {types:?}"
+    );
 }
 
 /// Mechanical guard: the two raw spellings that re-arm this bug —
@@ -303,6 +533,31 @@ fn classify_agrees_with_direct_query_on_mie_corpus() {
 /// The file's own inline `mod tests` is excluded: its hand-built fixtures are
 /// declaration-only, so report position and `ClassId` genuinely coincide there
 /// and it indexes by `id.index()` deliberately.
+///
+/// # This guard is NOT a proof — know exactly what it misses
+///
+/// It matches TWO TEXTUAL SPELLINGS. It says nothing about the many ways the
+/// same conflation can be written with **no cast at all**: handing a report
+/// position to anything that is `ClassId`-indexed under the hood. That is not
+/// hypothetical — it is how a live false positive survived round 1 of this
+/// fix:
+///
+/// ```ignore
+/// let unsat_bs = closure.unsatisfiable_bitset();  // bit i <=> class_i ⊑ ⊥
+/// for i in 0..n {                                // i is a REPORT POSITION
+///     if i < unsat_bs.len() && unsat_bs.contains(i) { /* wrong class */ }
+/// ```
+///
+/// No `ClassId::new`, no `as usize`, guard green, hierarchy unsound. Other
+/// invisible shapes: indexing any `Vec`/bitset/slice that the saturator or
+/// tableau sized and filled by `ClassId`; passing a report position to a
+/// function whose `usize` parameter means a class id; arithmetic that
+/// reconstructs an id.
+///
+/// So treat this as a lint against the *known* regression, and treat the
+/// behavioural oracles above — the `is_subclass_of` cross-check and especially
+/// `assert_inert_declarations_are_inert` — as the actual safety net. Only they
+/// caught the bitset bug. Only they can catch the next one.
 #[test]
 fn report_positions_are_never_cast_to_class_ids() {
     const BEGIN: &str = "BEGIN report-position ↔ ClassId conversion boundary";

--- a/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
@@ -333,11 +333,21 @@ fn classify_top_down_agrees_with_direct_query() {
 /// defect. It is also cheap enough to run on a real corpus file, which the
 /// `is_subclass_of` cross-check is NOT (its n² of fresh tableau probes is
 /// minutes of work on pizza).
-fn assert_inert_declarations_are_inert(label: &str, bare: &SetOntology<RcStr>) {
+///
+/// `classifier` is a parameter so the same property can be pinned on whichever
+/// entry point is actually runnable in the profile CI uses — see
+/// `inert_declarations_do_not_change_the_hierarchy_pizza_saturation_only`.
+fn assert_inert_declarations_are_inert(
+    label: &str,
+    bare: &SetOntology<RcStr>,
+    classifier: fn(
+        &SetOntology<RcStr>,
+    ) -> Result<owl_dl_reasoner::Classification, owl_dl_reasoner::ReasonError>,
+) {
     let declared = with_all_classes_declared(bare);
 
-    let bare_cls = owl_dl_reasoner::classify(bare).expect("classify bare");
-    let declared_cls = owl_dl_reasoner::classify(&declared).expect("classify declared");
+    let bare_cls = classifier(bare).expect("classify bare");
+    let declared_cls = classifier(&declared).expect("classify declared");
 
     let mut bare_names: Vec<String> = bare_cls.classes().iter().map(|s| (*s).clone()).collect();
     let mut declared_names: Vec<String> = declared_cls
@@ -390,17 +400,35 @@ fn assert_inert_declarations_are_inert(label: &str, bare: &SetOntology<RcStr>) {
 
 #[test]
 fn inert_declarations_do_not_change_the_hierarchy_el() {
-    assert_inert_declarations_are_inert("EL", &parse(EL_BODY));
+    assert_inert_declarations_are_inert("EL", &parse(EL_BODY), owl_dl_reasoner::classify);
 }
 
 #[test]
 fn inert_declarations_do_not_change_the_hierarchy_hybrid() {
-    assert_inert_declarations_are_inert("hybrid", &parse(HYBRID_BODY));
+    assert_inert_declarations_are_inert("hybrid", &parse(HYBRID_BODY), owl_dl_reasoner::classify);
 }
 
 #[test]
 fn inert_declarations_do_not_change_the_hierarchy_unsat() {
-    assert_inert_declarations_are_inert("unsat", &parse(UNSAT_BODY));
+    assert_inert_declarations_are_inert("unsat", &parse(UNSAT_BODY), owl_dl_reasoner::classify);
+}
+
+/// Same three fixtures through `classify_saturation_only`, i.e. through
+/// `classify_pure_el` specifically — the function the round-2 unsat-projection
+/// false positive lived in.
+#[test]
+fn inert_declarations_do_not_change_the_saturation_only_hierarchy() {
+    for (label, body) in [
+        ("sat/EL", EL_BODY),
+        ("sat/hybrid", HYBRID_BODY),
+        ("sat/unsat", UNSAT_BODY),
+    ] {
+        assert_inert_declarations_are_inert(
+            label,
+            &parse(body),
+            owl_dl_reasoner::classify_saturation_only,
+        );
+    }
 }
 
 /// The corpus oracle — a LATENT-HAZARD CANARY, not a reproducer. Read this
@@ -451,7 +479,36 @@ fn inert_declarations_do_not_change_the_hierarchy_unsat() {
               owl-dl-tableau/src/hyper.rs:3677 (inverse_func_merge); runs in --release"
 )]
 fn inert_declarations_do_not_change_the_hierarchy_pizza() {
-    assert_inert_declarations_are_inert("pizza", &corpus("pizza.ofn"));
+    assert_inert_declarations_are_inert("pizza", &corpus("pizza.ofn"), owl_dl_reasoner::classify);
+}
+
+/// The corpus canary that ACTUALLY RUNS IN CI.
+///
+/// `.github/workflows/ci.yml` runs `cargo test --workspace --all-targets
+/// --exclude owl-dl-py` — **debug only, no release job**. So the `classify`
+/// variant above, gated off under `debug_assertions` to dodge the pre-existing
+/// `hyper.rs:3677` assert, never executes in CI: its "becomes a live oracle the
+/// day pizza gains an edge" promise would be empty as configured.
+///
+/// `classify_saturation_only` fixes that. It does not reach the hypertableau,
+/// so it does not trip that assert, and it runs over the same 92-class pizza
+/// file in ~0.04 s in debug. Better still, it routes straight through
+/// `classify_pure_el` — the exact function the round-2 unsat-projection false
+/// positive lived in — so this is the corpus-level guard on the more recently
+/// broken path, in the profile CI actually builds.
+///
+/// Sound to compare for equality even though `classify_saturation_only` is a
+/// documented under-approximation: the property asserted is not "the hierarchy
+/// is complete" but "adding semantically inert axioms does not change whatever
+/// this entry point reports". An under-approximation must still be STABLE under
+/// an inert change.
+#[test]
+fn inert_declarations_do_not_change_the_hierarchy_pizza_saturation_only() {
+    assert_inert_declarations_are_inert(
+        "pizza/saturation_only",
+        &corpus("pizza.ofn"),
+        owl_dl_reasoner::classify_saturation_only,
+    );
 }
 
 /// The unsatisfiable set must name the class that is ACTUALLY `⊑ ⊥`.

--- a/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
@@ -1,0 +1,352 @@
+//! SOUNDNESS regression: a report position must never be confused with an
+//! `owl_dl_core::ClassId`.
+//!
+//! `classify()` reports only *user* classes — the synthetic `DKey(range)`
+//! filler classes minted by the integer-facet data lowering are excluded.
+//! That exclusion used to be a `.filter()` applied AFTER enumerating
+//! `0..num_classes()`, so report position `i` stopped being `ClassId::new(i)`
+//! as soon as a `DKey` id was dropped from below it, and every reported class
+//! above that `DKey` read its subsumption row off a NEIGHBOUR — producing
+//! false positives in the public API.
+//!
+//! Why the curated corpus never caught it: `convert_ontology` sorts components
+//! before lowering, and every `DeclareClass` sorts before every axiom, so in a
+//! fully-`Declaration`-ed ontology all named classes are interned before any
+//! axiom can mint a `DKey`. `bench-corpus/mie.ofn` declares all 84 of its
+//! classes, so its 17 `DKey`s land at ids 84..=100 — above everything, where
+//! the aliasing is invisible. The fixtures below instead reference classes
+//! that are NOT declared, so they are interned *after* a `DKey`.
+//!
+//! Run: `cargo test -p owl-dl-reasoner --test dkey_id_aliasing`.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+use std::time::Duration;
+
+const PFX: &str = r"Prefix(:=<http://t/>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+";
+
+fn parse(body: &str) -> SetOntology<RcStr> {
+    let src = format!("{PFX}Ontology(<http://t/x>\n{body}\n)\n");
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    onto
+}
+
+/// A `DKey` is minted while lowering the FIRST axiom (its `sup` is the
+/// earliest-sorting `ClassExpression::Class`, and `SubClassOf` derives `Ord`
+/// over `(sup, sub)`), so it takes class id 0. `Zzz`/`Yy`/`Uu` are undeclared
+/// and get ids 1.. — every one of them above the `DKey`.
+///
+/// Ground truth: `Uu ⊑ Zzz ⊑ Yy` and nothing else.
+const EL_BODY: &str = r"
+SubClassOf(ObjectSomeValuesFrom(:op DataSomeValuesFrom(:dp xsd:integer)) :Aaa)
+SubClassOf(:Zzz :Yy)
+SubClassOf(:Uu :Zzz)
+";
+
+/// Same shape, but a disjointness axiom drags the input out of the EL /
+/// saturator-complete fragment so the tier walk + tableau path runs instead of
+/// the pure-EL fast path. Keeps the `DKey`-below-user-classes hazard.
+const HYBRID_BODY: &str = r"
+SubClassOf(ObjectSomeValuesFrom(:op DataSomeValuesFrom(:dp xsd:integer)) :Aaa)
+SubClassOf(:Zzz ObjectUnionOf(:Yy :Ww))
+SubClassOf(:Uu :Zzz)
+SubClassOf(:Yy :Ww)
+DisjointClasses(:Uu :Ppp)
+";
+
+/// The whole point of the fixtures: they must actually place a `DKey` BELOW at
+/// least one reported class. If a future change to `convert_ontology`'s
+/// component ordering pushes every `DKey` to the top of the id space again,
+/// the oracles below would still pass — but they would be VACUOUS. This test
+/// is the non-vacuity guard, and it is what to look at first if the oracles
+/// ever go green for a suspicious reason.
+#[test]
+fn fixtures_really_put_a_dkey_below_a_user_class() {
+    for (name, body) in [("EL", EL_BODY), ("hybrid", HYBRID_BODY)] {
+        let onto = parse(body);
+        let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
+        let n = internal.vocabulary.num_classes();
+        let iris: Vec<String> = (0..n)
+            .map(|i| {
+                internal
+                    .vocabulary
+                    .class_iri(owl_dl_core::ClassId::new(u32::try_from(i).unwrap()))
+                    .to_string()
+            })
+            .collect();
+        let is_dkey = |s: &str| s.starts_with(owl_dl_core::DKEY_IRI_PREFIX);
+        let last_dkey = iris.iter().rposition(|s| is_dkey(s));
+        let last_user = iris.iter().rposition(|s| !is_dkey(s));
+        assert!(
+            last_dkey.is_some(),
+            "{name} fixture minted no DKey at all — the hazard is not exercised; \
+             iris = {iris:#?}"
+        );
+        assert!(
+            last_dkey < last_user,
+            "{name} fixture puts every DKey ABOVE every user class, so report \
+             position == ClassId and the aliasing oracles below are VACUOUS. \
+             iris = {iris:#?}"
+        );
+    }
+}
+
+/// Oracle 1 — `classify()` must agree with `is_subclass_of()`.
+///
+/// `is_subclass_of` resolves both IRIs to `ClassId`s itself and never goes
+/// through the report projection, so a disagreement is the projection lying.
+/// Both directions are checked: a `classify`-yes / direct-no is a FALSE
+/// POSITIVE (unacceptable), a `classify`-no / direct-yes is a MISSED
+/// subsumption.
+fn assert_classify_agrees_with_direct_query(
+    label: &str,
+    onto: &SetOntology<RcStr>,
+    cls: &owl_dl_reasoner::Classification,
+    check_missed: bool,
+) {
+    // `check_missed == false` also means "only probe the pairs classify reported"
+    // — on a real ontology the full n² of fresh `is_subclass_of` calls is
+    // minutes of tableau work, and the FP direction only needs the positives.
+    let names: Vec<String> = cls.classes().iter().map(|s| (*s).clone()).collect();
+    let mut fps: Vec<(String, String)> = Vec::new();
+    let mut missed: Vec<(String, String)> = Vec::new();
+    for sub in &names {
+        for sup in &names {
+            if sub == sup {
+                continue;
+            }
+            let reported = cls.is_subclass(sub, sup);
+            if !reported && !check_missed {
+                continue;
+            }
+            let direct = owl_dl_reasoner::is_subclass_of(onto, sub, sup).expect("is_subclass_of");
+            if reported && !direct {
+                fps.push((sub.clone(), sup.clone()));
+            } else if direct && !reported {
+                missed.push((sub.clone(), sup.clone()));
+            }
+        }
+    }
+    assert!(
+        fps.is_empty(),
+        "[{label}] classify() reported subsumptions that is_subclass_of() denies \
+         — FALSE POSITIVES: {fps:#?}"
+    );
+    if check_missed {
+        assert!(
+            missed.is_empty(),
+            "[{label}] classify() lost subsumptions is_subclass_of() confirms \
+             — MISSED: {missed:#?}"
+        );
+    }
+}
+
+#[test]
+fn classify_agrees_with_direct_query_on_el_fixture() {
+    let onto = parse(EL_BODY);
+    let cls = owl_dl_reasoner::classify(&onto).expect("classify");
+    assert_classify_agrees_with_direct_query("classify/EL", &onto, &cls, true);
+}
+
+#[test]
+fn classify_agrees_with_direct_query_on_hybrid_fixture() {
+    let onto = parse(HYBRID_BODY);
+    let cls = owl_dl_reasoner::classify(&onto).expect("classify");
+    assert_classify_agrees_with_direct_query("classify/hybrid", &onto, &cls, true);
+}
+
+/// The naive `n²` pair sweep has its own copy of the report-index → `ClassId`
+/// mapping, so it needs its own cross-check.
+#[test]
+fn classify_n2_agrees_with_direct_query() {
+    for (label, body) in [("n2/EL", EL_BODY), ("n2/hybrid", HYBRID_BODY)] {
+        let onto = parse(body);
+        let cls = owl_dl_reasoner::classify_n2(&onto).expect("classify_n2");
+        assert_classify_agrees_with_direct_query(label, &onto, &cls, true);
+    }
+}
+
+/// The saturation-only path is a documented sound UNDER-approximation, so only
+/// the false-positive direction is asserted.
+#[test]
+fn classify_saturation_only_has_no_false_positives() {
+    for (label, body) in [("sat/EL", EL_BODY), ("sat/hybrid", HYBRID_BODY)] {
+        let onto = parse(body);
+        let cls =
+            owl_dl_reasoner::classify_saturation_only(&onto).expect("classify_saturation_only");
+        assert_classify_agrees_with_direct_query(label, &onto, &cls, false);
+    }
+}
+
+#[test]
+fn classify_top_down_agrees_with_direct_query() {
+    for (label, body) in [("td/EL", EL_BODY), ("td/hybrid", HYBRID_BODY)] {
+        let onto = parse(body);
+        let cls = owl_dl_reasoner::classify_top_down_with_timeout(&onto, Duration::from_secs(5))
+            .expect("classify_top_down");
+        assert_classify_agrees_with_direct_query(label, &onto, &cls, true);
+    }
+}
+
+/// Oracle 2 — the INERT-DECLARATION property, and the one that generalises.
+///
+/// `Declaration(Class(:C))` for a `C` the ontology already mentions entails
+/// NOTHING: OWL 2 treats a used-but-undeclared class as declared, so the two
+/// ontologies have identical models. A correct classifier must therefore
+/// report the identical hierarchy. Adding the declarations *does* change
+/// `ClassId` assignment though — `DeclareClass` sorts before every axiom, so
+/// the declared classes are interned first and every `DKey` moves above them,
+/// which is exactly the configuration where the aliasing is invisible. So
+/// under the bug the declared variant is CORRECT and the undeclared one is
+/// BROKEN, and the two hierarchies differ.
+fn assert_inert_declarations_are_inert(label: &str, body: &str, declarations: &str) {
+    let bare = parse(body);
+    let declared = parse(&format!("{declarations}{body}"));
+
+    let bare_cls = owl_dl_reasoner::classify(&bare).expect("classify bare");
+    let declared_cls = owl_dl_reasoner::classify(&declared).expect("classify declared");
+
+    let mut bare_names: Vec<String> = bare_cls.classes().iter().map(|s| (*s).clone()).collect();
+    let mut declared_names: Vec<String> = declared_cls
+        .classes()
+        .iter()
+        .map(|s| (*s).clone())
+        .collect();
+    bare_names.sort();
+    declared_names.sort();
+    assert_eq!(
+        bare_names, declared_names,
+        "[{label}] inert declarations changed the reported CLASS SET"
+    );
+
+    let mut differences: Vec<String> = Vec::new();
+    for sub in &bare_names {
+        for sup in &bare_names {
+            let before = bare_cls.is_subclass(sub, sup);
+            let after = declared_cls.is_subclass(sub, sup);
+            if before != after {
+                differences.push(format!(
+                    "{sub} <= {sup}: without declarations = {before}, with = {after}"
+                ));
+            }
+        }
+    }
+    assert!(
+        differences.is_empty(),
+        "[{label}] adding Declaration(Class(..)) axioms that entail NOTHING changed \
+         the reported hierarchy — impossible for a correct classifier:\n{}",
+        differences.join("\n")
+    );
+}
+
+#[test]
+fn inert_declarations_do_not_change_the_hierarchy_el() {
+    assert_inert_declarations_are_inert(
+        "EL",
+        EL_BODY,
+        "Declaration(Class(:Aaa))\n\
+         Declaration(Class(:Zzz))\n\
+         Declaration(Class(:Yy))\n\
+         Declaration(Class(:Uu))\n",
+    );
+}
+
+#[test]
+fn inert_declarations_do_not_change_the_hierarchy_hybrid() {
+    assert_inert_declarations_are_inert(
+        "hybrid",
+        HYBRID_BODY,
+        "Declaration(Class(:Aaa))\n\
+         Declaration(Class(:Zzz))\n\
+         Declaration(Class(:Yy))\n\
+         Declaration(Class(:Uu))\n\
+         Declaration(Class(:Ww))\n\
+         Declaration(Class(:Ppp))\n",
+    );
+}
+
+/// General soundness cross-check on a tracked corpus fixture. `mie.ofn` does
+/// NOT currently exercise the aliasing (all 84 classes are declared, so its
+/// `DKey`s sit at ids 84..=100) — see the module doc. It is here as a
+/// real-ontology FP oracle, not as a reproducer.
+#[test]
+fn classify_agrees_with_direct_query_on_mie_corpus() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../bench-corpus/mie.ofn");
+    let src = std::fs::read_to_string(&path).expect("read mie.ofn");
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse mie.ofn");
+    let cls = owl_dl_reasoner::classify(&onto).expect("classify");
+    assert!(
+        cls.classes().len() > 50,
+        "mie.ofn should report ~84 classes, got {}",
+        cls.classes().len()
+    );
+    assert_classify_agrees_with_direct_query("mie", &onto, &cls, false);
+}
+
+/// Mechanical guard: the two raw spellings that re-arm this bug —
+/// `ClassId::new(...)` over a report position, and `id.index() as usize` used
+/// as one — must appear ONLY inside `classify.rs`'s declared conversion
+/// boundary (the `ReportedClasses` struct + impl). Anywhere else in the
+/// production body of that file they are the bug.
+///
+/// The file's own inline `mod tests` is excluded: its hand-built fixtures are
+/// declaration-only, so report position and `ClassId` genuinely coincide there
+/// and it indexes by `id.index()` deliberately.
+#[test]
+fn report_positions_are_never_cast_to_class_ids() {
+    const BEGIN: &str = "BEGIN report-position ↔ ClassId conversion boundary";
+    const END: &str = "END report-position ↔ ClassId conversion boundary";
+    let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/classify.rs"));
+    let production = src
+        .split_once("\n#[cfg(test)]")
+        .map_or(src, |(before, _)| before);
+
+    let mut inside_boundary = false;
+    let mut offenders: Vec<String> = Vec::new();
+    for (lineno, line) in production.lines().enumerate() {
+        if line.contains(BEGIN) {
+            inside_boundary = true;
+            continue;
+        }
+        if line.contains(END) {
+            inside_boundary = false;
+            continue;
+        }
+        if inside_boundary {
+            continue;
+        }
+        let code = line.trim_start();
+        if code.starts_with("//") {
+            continue; // doc comment / prose
+        }
+        // Split so this test's own source never matches itself.
+        let mint = concat!("ClassId::new", "(");
+        let cast = concat!(".index() as", " usize");
+        if code.contains(mint) || code.contains(cast) {
+            offenders.push(format!("classify.rs:{}: {}", lineno + 1, line.trim_end()));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "raw report-position ↔ ClassId conversion(s) outside the declared \
+         boundary in classify.rs. A report position is NOT a ClassId (DKey \
+         filler classes are removed from the report vector, so the two spaces \
+         differ as soon as a DKey id sits below a user class — that is the \
+         false-positive bug this file guards). Use \
+         `ReportedClasses::class_id` / `ReportedClasses::report_pos` instead, \
+         or move the code inside the boundary sentinels if it genuinely \
+         operates in id space.\n{}",
+        offenders.join("\n")
+    );
+}

--- a/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_id_aliasing.rs
@@ -90,6 +90,45 @@ SubClassOf(:Ccc :Ddd)
 SubClassOf(:Ddd :Eee)
 ";
 
+/// The `probe_says_inconsistent` fixture — a THIRD conflation shape, found while
+/// rebasing this fix onto `main` (2026-08-21).
+///
+/// `classify`'s gated consistency probe (`RUSTDL_CLASSIFY_CONSISTENCY_PROBE`,
+/// **default ON**) walks the asserted `ClassAssertion`s and asks whether the
+/// asserted class is one classify already proved unsatisfiable. It asked with a
+/// raw `ClassId` against `unsatisfiable_idxs`, which is REPORT-indexed. On a
+/// `DKey`-below-a-user-class layout the two disagree, a satisfiable class
+/// inherits a stranger's `⊥`, and the probe answers "the KB is inconsistent" —
+/// which returns `classify_inconsistent`, i.e. EVERY class unsatisfiable and
+/// therefore (via the `entails` short-circuit) EVERY pair a false positive.
+///
+/// The layout this fixture pins, and why each line is load-bearing:
+///
+/// | id | report pos | class |
+/// |----|-----------|-------|
+/// | 0  | —         | `DKey` (minted by the first axiom) |
+/// | 1  | 0         | `Aaa` |
+/// | 2  | 1         | `Ccc` |
+/// | 3  | 2         | **`Fff`** — satisfiable, and the ASSERTED class |
+/// | 4  | 3         | **`Eee`** — the only unsatisfiable class |
+/// | 5  | 4         | `Bbb` |
+/// | 6  | 5         | `Ddd` |
+///
+/// `Fff`'s `ClassId` is 3 and `Eee`'s REPORT POSITION is 3, so the misread hits.
+/// The `ObjectUnionOf` keeps the ontology off the pure-EL fast path (the probe
+/// runs only on the hybrid path); `Eee ⊑ ⊥` satisfies the probe's admission gate
+/// (it declines outright on an empty unsat set); and the `ClassAssertion` is what
+/// the misread loop iterates.
+///
+/// Ground truth: the KB is CONSISTENT and `Eee` is the ONLY unsatisfiable class.
+const CONSISTENCY_PROBE_BODY: &str = r"
+SubClassOf(ObjectSomeValuesFrom(:op DataSomeValuesFrom(:dp xsd:integer)) :Aaa)
+SubClassOf(:Bbb ObjectUnionOf(:Ccc :Ddd))
+SubClassOf(:Eee owl:Nothing)
+SubClassOf(:Ccc :Fff)
+ClassAssertion(:Fff :ind)
+";
+
 /// Add `Declaration(Class(C))` for every class the ontology already mentions.
 ///
 /// Semantically inert (OWL 2 treats a used class as declared), but it moves
@@ -149,6 +188,94 @@ fn dkey_sits_below_a_user_class(onto: &SetOntology<RcStr>) -> bool {
     ) {
         (Some(first_dkey), Some(last_user)) => first_dkey < last_user,
         _ => false,
+    }
+}
+
+/// NON-VACUITY GUARD for [`CONSISTENCY_PROBE_BODY`], kept separate from the
+/// oracle below so a layout drift is reported as a layout failure rather than as
+/// a soundness pass. If interning order ever changes, the oracle would still be
+/// GREEN while testing nothing — this is what fails instead.
+#[test]
+fn consistency_probe_fixture_really_aliases_the_asserted_class() {
+    let onto = parse(CONSISTENCY_PROBE_BODY);
+    let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
+    let mut report_pos_of = std::collections::HashMap::new();
+    let mut id_of = std::collections::HashMap::new();
+    let mut pos = 0usize;
+    for i in 0..internal.vocabulary.num_classes() {
+        let iri = internal
+            .vocabulary
+            .class_iri(owl_dl_core::ClassId::new(u32::try_from(i).unwrap()))
+            .to_string();
+        if iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX) {
+            continue;
+        }
+        id_of.insert(iri.clone(), i);
+        report_pos_of.insert(iri, pos);
+        pos += 1;
+    }
+    let asserted_id = id_of["http://t/Fff"];
+    let unsat_pos = report_pos_of["http://t/Eee"];
+    assert_ne!(
+        "http://t/Fff", "http://t/Eee",
+        "the aliased pair must be two DIFFERENT classes"
+    );
+    assert_eq!(
+        asserted_id, unsat_pos,
+        "fixture no longer aliases: the asserted class `Fff` has ClassId \
+         {asserted_id} and the unsatisfiable class `Eee` has report position \
+         {unsat_pos}. They must COINCIDE for the consistency probe's misread to \
+         be observable — see CONSISTENCY_PROBE_BODY for the required layout."
+    );
+    assert!(
+        dkey_sits_below_a_user_class(&onto),
+        "fixture puts every DKey above every user class, so report position and \
+         ClassId agree and the hazard cannot fire"
+    );
+}
+
+/// SOUNDNESS ORACLE: the gated consistency probe must not turn one aliased bit
+/// into "the whole KB is inconsistent".
+///
+/// Before the fix this returned all SIX classes as unsatisfiable on both hybrid
+/// entry points — and an unsatisfiable class subsumes everything, so that is
+/// every pair in the ontology reported as an entailment that does not hold.
+#[test]
+fn consistency_probe_does_not_invent_an_inconsistency() {
+    let onto = parse(CONSISTENCY_PROBE_BODY);
+    let expected = vec!["http://t/Eee"];
+    let variants: Vec<(&str, owl_dl_reasoner::Classification)> = vec![
+        (
+            "classify",
+            owl_dl_reasoner::classify(&onto).expect("classify"),
+        ),
+        (
+            "classify_n2",
+            owl_dl_reasoner::classify_n2(&onto).expect("classify_n2"),
+        ),
+        (
+            "classify_top_down",
+            owl_dl_reasoner::classify_top_down_with_timeout(&onto, Duration::from_secs(5))
+                .expect("classify_top_down"),
+        ),
+    ];
+    for (name, cls) in &variants {
+        let mut unsat = cls.unsatisfiable_classes();
+        unsat.sort_unstable();
+        assert_eq!(
+            unsat, expected,
+            "[{name}] the consistency probe read the report-indexed unsat set \
+             with a raw ClassId and declared the KB inconsistent, so every class \
+             is now ⊥ and every pair is a false positive"
+        );
+        assert!(
+            !cls.stats().inconsistent,
+            "[{name}] KB reported inconsistent; it is consistent (only `Eee` is ⊥)"
+        );
+        assert!(
+            !cls.is_subclass("http://t/Aaa", "http://t/Ddd"),
+            "[{name}] false positive Aaa ⊑ Ddd — no such entailment holds"
+        );
     }
 }
 
@@ -620,13 +747,43 @@ fn report_positions_are_never_cast_to_class_ids() {
     const BEGIN: &str = "BEGIN report-position ↔ ClassId conversion boundary";
     const END: &str = "END report-position ↔ ClassId conversion boundary";
     let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/classify.rs"));
-    let production = src
-        .split_once("\n#[cfg(test)]")
-        .map_or(src, |(before, _)| before);
+
+    // Skip `#[cfg(test)]` modules WITHOUT truncating the file.
+    //
+    // This used to be `src.split_once("\n#[cfg(test)]")`, which stops at the
+    // FIRST test module. classify.rs has an inline one at ~line 1039, so the
+    // scan silently covered 1,038 of 6,800 lines and passed vacuously — it
+    // missed two real report-position/`ClassId` conflations that were sitting
+    // in plain sight further down. A scanner that can go blind without failing
+    // is worse than no scanner, so the coverage floor below is asserted too.
+    let total_lines = src.lines().count();
+    let mut scanned_lines = 0usize;
+    let mut skipping_test_mod = false;
 
     let mut inside_boundary = false;
     let mut offenders: Vec<String> = Vec::new();
-    for (lineno, line) in production.lines().enumerate() {
+    for (lineno, line) in src.lines().enumerate() {
+        // Both test modules in this file are top level, so their closing brace
+        // is a `}` in column 0. An INDENTED `#[cfg(test)]` would break that
+        // assumption, so fail loudly rather than guess.
+        if skipping_test_mod {
+            if line == "}" {
+                skipping_test_mod = false;
+            }
+            continue;
+        }
+        if line == "#[cfg(test)]" {
+            skipping_test_mod = true;
+            continue;
+        }
+        assert!(
+            line.trim_start() != "#[cfg(test)]",
+            "classify.rs:{}: indented `#[cfg(test)]` — this scanner only knows \
+             how to skip TOP-LEVEL test modules (it finds their end by a `}}` in \
+             column 0). Teach it the nested case before landing this.",
+            lineno + 1
+        );
+        scanned_lines += 1;
         if line.contains(BEGIN) {
             inside_boundary = true;
             continue;
@@ -660,5 +817,14 @@ fn report_positions_are_never_cast_to_class_ids() {
          or move the code inside the boundary sentinels if it genuinely \
          operates in id space.\n{}",
         offenders.join("\n")
+    );
+
+    // COVERAGE FLOOR — the guard on the guard. If a future edit makes the
+    // skip logic swallow the file again, this fails instead of passing empty.
+    assert!(
+        scanned_lines * 100 >= total_lines * 60,
+        "the conversion scan covered only {scanned_lines} of {total_lines} \
+         lines of classify.rs — it has gone (partly) blind. Fix the \
+         `#[cfg(test)]` skip before trusting a green result here."
     );
 }

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -2535,12 +2535,25 @@ impl Subsumers {
             .collect()
     }
 
-    /// A reference to the raw unsatisfiable bitset.
-    /// Bit `i` set iff `class_i ⊑ ⊥` according to saturation.
-    #[must_use]
-    pub fn unsatisfiable_bitset(&self) -> &FixedBitSet {
-        &self.unsatisfiable
-    }
+    // REMOVED 2026-08-20: `pub fn unsatisfiable_bitset(&self) -> &FixedBitSet`.
+    //
+    // It handed out a CLASS-ID-indexed bitset as a bare `FixedBitSet`, whose
+    // `contains(usize)` accepts any index the caller has lying around. Its one
+    // caller in this workspace — `classify_pure_el` — probed it with a REPORT
+    // POSITION (which excludes the synthetic `DKey` filler classes, so the two
+    // index spaces diverge as soon as a `DKey` id sits below a user class).
+    // That shipped a false positive: a satisfiable class inherited a
+    // neighbour's `⊥` flag, and because `Classification::entails` reintroduces
+    // `⊥ ⊑ *` for anything flagged unsatisfiable, that one mis-indexed bit made
+    // the class subsume EVERY class in the ontology while hiding the genuinely
+    // unsatisfiable one.
+    //
+    // Nothing in the workspace calls it now. Use the typed accessors instead —
+    // they take/return `ClassId`, so the mistake cannot be spelled:
+    //   * `is_unsatisfiable(c: ClassId) -> bool`   — single membership test
+    //   * `unsatisfiable_classes() -> Vec<ClassId>` — enumeration
+    // Removing it also stops `fixedbitset` leaking into this crate's public
+    // API, where it was the only occurrence.
 
     /// True iff saturation proved `c` is empty in every model (i.e.
     /// `c ⊑ ⊥`).

--- a/docs/dkey-id-aliasing-fix-resolution.md
+++ b/docs/dkey-id-aliasing-fix-resolution.md
@@ -1,0 +1,130 @@
+# RESOLVED: DKey id aliasing — two false positives in `classify()`, both fixed
+
+**Date:** 2026-08-20
+**Branch:** `fix/dkey-id-aliasing` (based on `feat/complex-class-expression-queries-48` @ `c1f44d8`)
+**Commits:** `132dd21` (29 sites) → `954bc7e` (the 30th, and the severe one) → `822a8d5` (CI canary + foot-gun)
+**Severity:** was FP ≠ 0 in the public `classify()` — the failure mode this project treats as
+never acceptable.
+**Status:** fixed and verified. Corpus FP=0 / MISSED=0 re-validation is still the owner's gate.
+
+Supersedes the reproduction instructions in
+`docs/known-limitations/dkey-id-aliasing-classify-fp.md` (written on the P1 branch, **wrong** —
+see §1). That file should be updated or replaced when the branches reconcile.
+
+## 1. CORRECTION: the trigger is a used-but-undeclared class, not `mie.ofn`
+
+The original write-up said `bench-corpus/mie.ofn` exhibits the bug. **It does not.** Measured:
+mie declares all 84 of its classes, so all 17 DKeys land at ids 84–100 — above every user class —
+and `classify` agrees with `is_subclass_of` on all 241 positives.
+
+The actual trigger: **a class that is used but not declared.** Every `DeclareClass` component sorts
+before every axiom in `convert_ontology`, so a declared class is always interned before any DKey.
+An *undeclared* class is interned when first used — which can be after a DKey.
+
+This reconciles the earlier report, which claimed FPs on "a half of `mie.ofn`": **splitting** an
+ontology drops `Declaration` axioms for classes the retained axioms still use, manufacturing the
+undeclared-but-used condition mechanically. It also means the trigger is not exotic — plenty of
+real ontologies do not declare every class they use, and any tool that subsets one creates it.
+
+The correct non-vacuity predicate for a fixture is `first_dkey_id < last_user_class_id`.
+
+## 2. Two defects, not one
+
+**(a) 29 report-position ↔ `ClassId` conflations in `classify.rs`**, in *both* directions —
+`ClassId::new(i)` over a report index (21 sites) and `id.index() as usize` guarded by `if i < n`
+(8 sites, including the entailment-matrix closure seed). Fixed in `132dd21` by a `ReportedClasses`
+type owning the bijection both ways.
+
+**(b) A 30th site, and the severe one: `classify_pure_el` Pass 1** probed the ClassId-indexed
+`Subsumers::unsatisfiable_bitset()` with a report position. Fixed in `954bc7e`
+(`closure.is_unsatisfiable(reported.class_id(i))`).
+
+(b) is worse than (a) because of amplification: `Classification::entails` short-circuits on
+`unsatisfiable_idxs` to supply `⊥ ⊑ *`, so **one** mis-indexed bit makes the wrong class subsume
+**everything**. Reproduced on all four entry points (`classify`, `classify_n2`,
+`classify_saturation_only`, `classify_top_down_with_timeout`), plus a corrupted `realize()` and a
+wrong `unsatisfiable_classes()`.
+
+Verified by independent build-and-measure across three separately compiled trees:
+
+| tree | EL fixture | UNSAT fixture |
+|---|---|---|
+| `c1f44d8` | FP `Yy ⊑ Uu` | FP `Ccc ⊑ Aaa`, unsat=[Ccc] |
+| `132dd21` | correct | **FP still present** |
+| `954bc7e` | correct | correct, unsat=[Aaa] |
+
+## 3. What the owner should expect from the corpus re-validation
+
+**No delta on `bench-corpus`.** Measured three ways: the class/unsat/entailed-pair dump over
+`mie.ofn`, `paper5.ofn` and `pizza.ofn` is byte-identical from `c1f44d8` through `132dd21` to
+`954bc7e`, from three independently built binaries, with a sentinel that *does* diff.
+
+`bench-corpus/pizza.ofn` **is** hazardous by layout (first DKey id 87, last user class id 95) but
+the consequence is nil: all five aliased report positions have empty supers and subs, the rows they
+misread were also empty, and its unsat set is empty on every commit. An intermediate review claimed
+a "12 pairs pre-fix" delta on pizza — **that delta does not exist; disregard it.**
+
+If the sweep *does* show a `bench-corpus` delta, trust the delta and treat this analysis as broken.
+A delta on untracked `ontologies/` is possible and would need per-class analysis.
+
+## 4. Why both defects shipped, and what now guards them
+
+The source-level guard (`report_positions_are_never_cast_to_class_ids`) catches two spellings —
+`ClassId::new(i)` and `.index() as usize`. Defect (b) has **no cast at all**: it is an implicit
+report-position-as-bitset-index. So the guard was green on a file with a live FP path. Its doc now
+carries an explicit blind-spot section quoting the bitset bug.
+
+**Only behavioural oracles caught (b).** The load-bearing ones now:
+- `assert_inert_declarations_are_inert` — adding axioms that entail nothing must not change the
+  hierarchy. Parameterised over the classifier, with `classify_saturation_only` variants that run
+  in **debug** in 0.04 s through `classify_pure_el` (the function defect (b) lived in).
+- Non-vacuity measured across revisions: 16 pass at `954bc7e`, **8 FAILED at `132dd21`**,
+  **13 FAILED at `c1f44d8`** — the fixture-based saturation-only oracle fails on both buggy
+  revisions.
+
+`Subsumers::unsatisfiable_bitset()` was **deleted** (zero callers; a `pub`, ClassId-indexed
+foot-gun that had already caused one shipped FP). This also removes `fixedbitset` from that crate's
+public API.
+
+## 5. Open decision for the owner
+
+**The deletion in §4 is this branch's only semver-visible change.** `owl-dl-saturation` has no
+`publish = false`, so it defaults to publishable. At 0.4.x a breaking change is semver-legal in a
+minor bump but not a patch. If you would rather keep the symbol, renaming it to
+`unsatisfiable_bitset_by_class_id` is a one-line revert.
+
+## 6. Follow-ups (filed, not started)
+
+1. **A tracked corpus fixture with the hazard shape** — used-but-undeclared class, a DKey below it,
+   and an unsatisfiable class. Rated **above** the newtype below in value, because it would put the
+   bench/ORE sweeps on this bug class permanently. Today the entire net is 4–6-class hand fixtures,
+   and **no tracked corpus fixture can fail on this bug class.**
+2. **A `ReportIdx` newtype.** Declined in round 1 on risk grounds, then recommended by the same
+   implementer after defect (b) — a newtype would have made `unsat_bs.contains(i)` a type error,
+   which is exactly the shape the source guard cannot see. Does not block. Two design constraints
+   or it buys nothing: iterate `(0..n).map(ReportIdx)` rather than `0..n`, and give it **no**
+   `Deref` and no `From<ReportIdx> for usize`. It is one-directional: it will not catch a `ClassId`
+   indexing a report-space `Vec` unless those containers are keyed by `ReportIdx` too.
+3. **`hyper.rs:3677`** — a `debug_assert!` fires on a bare `classify(bench-corpus/pizza.ofn)` in any
+   debug build, on `c1f44d8` too. Pre-existing, not a regression, but it is a soundness-adjacent
+   tableau invariant violated on a curated corpus file, and it is what forces the release-only gate
+   on the `classify`-based pizza oracle.
+4. **`realize` has no DKey exclusion anywhere.** `realize.rs:686`'s comment claimed one; the comment
+   is now corrected to match the code. `realize_saturation_only_internal` and `realize_internal`'s
+   `class_iris` build the full id space with no filter. Latent — no reproducer was constructible,
+   since a DKey lives on a value node rather than as a nominal subsumer.
+5. **`pairs_per_sub`** (`classify.rs:463`) stays ClassId-keyed while every other pair stat is
+   report-space. Verified safe today (its only consumer reads `.values()`), but it will mis-attribute
+   for any consumer that indexes `classes()` with it.
+
+## 7. Method notes worth keeping
+
+Two ways a cross-revision comparison manufactures a false IDENTICAL, both encountered here:
+
+1. **A shared `CARGO_TARGET_DIR`** — cargo silently reuses the other tree's binary ("Finished in
+   0.12s", no `Compiling` lines).
+2. **`cargo test -q`** — suppresses `Compiling` lines, so a genuine rebuild looks like a cache hit.
+
+They are indistinguishable from the outside and both invert the conclusion. The protocol is
+per-tree target dirs **and** positive per-comparison confirmation that a rebuild occurred — not
+the absence of a cache-hit signal.


### PR DESCRIPTION
Fixes a soundness bug on `main`: `classify()` names the wrong class as unsatisfiable, and silently never probes the highest-id user classes, whenever a DKey is interned below a reported class.

## The defect

`reportable_class_iris` filters DKey IRIs out of a `0..num_classes()` enumeration, while ~29 sites map the report index back to a class id. The two index spaces then diverge.

**Trigger: a used-but-undeclared class.** Declared classes always intern before DKeys (`DeclareClass` sorts first), so an ontology that *uses* a class without declaring it can put a DKey below a reported class. That is legal OWL and common in the wild.

Observed on a fixture against stock `main`:

- `unsatisfiable_classes()` returns `[":N"]` — but `:N` is satisfiable and `:M` is the unsatisfiable one
- with one DKey present, `SubClassOf(:Unsat :B)` + `SubClassOf(:Unsat ObjectComplementOf(:B))` yields `unsatisfiable_classes() == []`, because the unsat probe loops `0..n` over raw `ClassId`s while `n` counts *reported* classes — the top ids are never probed at all

Every `Classification` consumer indexing `unsatisfiable_idxs` into `classes` inherits this (`is_subclass`, `equivalent_classes`, `direct_subsumers`, and others).

## The fix

A `ReportedClasses` type with `class_id(report_pos)` and `report_pos(ClassId)`, making the two spaces distinct types so the confusion cannot be spelled. All producers and consumers move **together** — that coupling is essential: applying the consumer half alone to `main` *introduces* a false positive (see #67), and the producer half alone leaves the defect live. Neither may be cherry-picked.

Also fixed: a latent `ClassId::new(report_pos)` in the label-cache escalation probe, and two diagnostic-only conflations.

**A shipped source-scanning guard was passing vacuously.** `report_positions_are_never_cast_to_class_ids` truncated the file at `split_once("\n#[cfg(test)]")`, and `main` has an inline test module at line 1039 — so it scanned 1,038 of 6,800 lines, and both defects above sat below the cut. It now skips test modules by brace matching, fails loudly on an indented `#[cfg(test)]` it cannot bound, and asserts a coverage floor so it can never again go blind while reporting green.

## Gates

**Tests** — `cargo test -p owl-dl-reasoner` on the tree composed with v0.4.22: **110/110 binaries, 1003 passed, 0 failed**, 74 ignored.

**Corpus differential — measured twice, same verdict.** Two arms, 4 runs per ontology (base, base', dkey, dkey') so a self-inconsistent row can never be reported as a difference:

| | first | re-measure (authoritative) |
|---|---|---|
| base | `b796bec` | `9a16697` (v0.4.22) |
| coverage | 663/663 | **663/663** |
| IDENTICAL | 634 | **634** |
| **DIFFER / REGRESSION / RECOVERY** | 0/0/0 | **0/0/0** |

Scope is the **data-property-bearing** frame, and that is the load-bearing choice: a DKey is a *data* key, so in a non-bearing ontology `report_pos` is the identity and this defect class cannot arise. Those 663 are the only ontologies that can discriminate, and they are exhaustively covered. All 8 NONDET rows in the re-measure adjudicated serially (3 runs × both arms) to 3/3 identical with the same hash — contention artifacts, not answer differences.

Stated limit: ~87% of the 1,258 non-bearing ontologies are unmeasured *for this branch* and rest on that structural argument. Prior art's 1,269-ontology inertness result covers the DKey seeding flags, not this refactor, so it does not transfer.

Full account incl. four instrumentation findings: `docs/2026-08-22-dkey-reportedclasses-differential.md` (on `docs/session-handoff-2026-08-21`).

## Reviewer notes

- **`Subsumers::unsatisfiable_bitset()` is deleted.** Decided deliberately: `owl-dl-saturation` is published only through **0.3.0** while the workspace is at 0.4.22, and no workflow runs `cargo publish` — so the "consumer pinned at 0.4.x" cannot exist. A rename would be no safer (it removes the old symbol identically) while keeping a `FixedBitSet` whose `contains(usize)` accepts any index in scope. In-tree callers already use the typed `is_unsatisfiable(ClassId)` / `unsatisfiable_classes()`.
- **A `ReportIdx` newtype is agreed as a follow-up**, deliberately not on this branch: it is a mechanical whole-file retype that would invalidate both the test run and the corpus differential above. All eight bare-`usize` boundaries are private and the public API is string-based, so it carries no semver impact.
- Base is 2 commits behind `main`; both comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWtgfyEhjW5vmzx29kavwu