### PR TITLE
fix(datatypes): rdf:langString — a value the reasoner never received (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1049,6 +1049,16 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   commands to 14** — every command that ANSWERS an entailment question — because
   `instances-expr` printed NOTHING on an ontology whose only two axioms were
   dropped while `classify` on the same file reported them.
+  **AND THE PYTHON STUB WENT STALE WITH CI GREEN.** `data_property_values`'
+  hand-written `__init__.pyi` kept declaring a 4-tuple after the runtime returned
+  5, and BOTH python jobs passed: `test_stubs.py` guards `__all__` NAME drift
+  only, stubs are not checked at runtime, and `test_queries.py` read `q[0]`/`q[1]`
+  so it passed at ANY tuple width. Fixed, plus
+  `test_tuple_returning_stubs_match_runtime_arity`, which parses the declared
+  `list[tuple[...]]` arity out of the stub and compares it against a real call
+  (sabotage-verified: reverting the stub to 4 fails it). **A passing pytest job is
+  NOT evidence the Python surface is correct** — check that the assertion depends
+  on the thing you changed.
 
   **Phase D11 (2026-06-09)** — `DataAllValuesFrom` (unblocked by the D10
   Horn-shortcircuit fix; data-`∀` now routes to the complete hybrid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1007,6 +1007,49 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   corpus-wide (sio 8904, wine 653, ore-15672 142, ore-10908 6001,
   shoiq-knowledge 449, sulo, ro, bibtex, galen, notgalen, pizza).
 
+  **`rdf:langString` bucket (2026-08-26, #72)** — the 8th DKey bucket, `lang:`,
+  and the one D9 explicitly left out ("language-tagged literals … rejected at
+  parse"). That rejection was a silent DROP, not a sound narrowing you could
+  observe: `data_point_some` fell through every arm to `exact_string_literal`,
+  which refuses `Literal::Language`, so the whole axiom failed conversion.
+  **A language-tagged value was therefore unconfirmable by ANY route** — the
+  reasoning path had no such fact, and `property-values` (a STRUCTURAL pass that
+  never converts) reported it with the tag stripped.
+  **The key is the PAIR `(lexical form, language tag)`**, not the lexical form:
+  `"bonjour"@fr` and `"bonjour"@de` are distinct literals, and both are distinct
+  from the `xsd:string` `"bonjour"`. Tags are LOWERCASED at parse (RDF 1.1 §3.3
+  compares per BCP47, case-insensitively) — a completeness matter, never an FP.
+  Members encode as `hex(lex).hex(tag)`, joined by `:`: BOTH halves hex, so
+  neither delimiter can occur inside one and the two-level decode is unambiguous.
+  **Why a separate bucket rather than members in `str:`** — `rdf:langString` and
+  `xsd:string` are disjoint datatypes (the `Family::LangString` arm already said
+  so), so a shared bucket would let `"bonjour"` and `"bonjour"@fr` subsume one
+  another. That is the SAME defect shape as the v0.4.6–v0.4.9 `xsd:float`/
+  `xsd:double` FP, and bucket separation is what makes it unconstructible rather
+  than merely unlikely. Both parser matrices now cover it (14 buckets);
+  **`numeric_oneof_parser_matrix_exclusivity` was hitting `unreachable!()` on the
+  new bucket until fixed, i.e. that half of the FP check was silently NOT RUNNING** —
+  when extending `sample_iris()`, extend BOTH probes.
+  **Evidence, and the corpus is not part of it.** The FP=0 net is 11 VERIFIED /
+  closures exact, but `datatype_value_membership.rs` says the curated corpus has
+  no clash of this kind, so that shows **non-regression only**. The real gate is
+  8 negatives-first canaries + 3 unit tests + a **Konclude ∪ HermiT adjudication**
+  on 4 probes, all three reasoners agreeing 4/4 — including the DISCRIMINATING
+  CONTROL (identical tagged literals ⇒ both oracles report `EquivalentClasses`),
+  without which their silence on the negative probes would be ambiguous, since
+  Konclude is documented to under-report. **4 sabotages run, 4 caught**: keying on
+  the lexical form alone, routing langString into `str:`, restoring the
+  lang-dropping dedup, and skipping tag lowercasing.
+  Companion fixes in the same change: `inferred_data_property_values` dropped
+  `lang` and THEN deduped, so two tagged assertions on one subject sharing a
+  lexical form **collapsed into one row — losing an assertion, not just a tag**
+  (`quads()` → `quints()`, and `property-values` gains a 5th column, empty for
+  non-langString, kept uniform so consumers splitting on tab do not see a
+  datatype-dependent row width); and `warn_if_dropped` went from **3 of 27 CLI
+  commands to 14** — every command that ANSWERS an entailment question — because
+  `instances-expr` printed NOTHING on an ontology whose only two axioms were
+  dropped while `classify` on the same file reported them.
+
   **Phase D11 (2026-06-09)** — `DataAllValuesFrom` (unblocked by the D10
   Horn-shortcircuit fix; data-`∀` now routes to the complete hybrid
   tableau). Two halves:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1049,6 +1049,28 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   commands to 14** — every command that ANSWERS an entailment question — because
   `instances-expr` printed NOTHING on an ontology whose only two axioms were
   dropped while `classify` on the same file reported them.
+  **FULL TWO-ARM ORE SWEEP (2026-08-26): 1,920 ontologies, 0 regressions, 0 answer
+  changes.** Pinned binaries, both arms per ontology, 60 s cap, single-thread, **arm
+  order ALTERNATED by index** so the ~3.4% page-cache phantom the #70 sweep hit cancels
+  by construction: **1,764 IDENTICAL / 123 BOTH_FAIL / 33 DIFFER / 0 REGRESSED / 0
+  RECOVERED**, and over the identical set **24,922,547 `direct_subsumptions`, 204,090
+  `unsatisfiable`, 407,829 `equivalent_groups` — diff 0 on every one**. Wall flat
+  (aggregate −1.81%; the order split brackets it, AFTER-led +0.88% vs BEFORE-led
+  −3.60%, so the positional term still dominates and the sign is not meaningful).
+  **All 33 DIFFERs adjudicated: 27 differ ONLY in the `dropped` reporting block** — the
+  intended effect, a langString axiom that used to be discarded now converts — 5 do not
+  reproduce, 1 is noise. **Zero entailments lost, zero gained.**
+  **THE HEADLINE IS THAT NOTHING MOVED**: langString axioms now enter the KB on 27 real
+  ORE ontologies and NO answer changes, because those values participate in no
+  subsumption there. That is precisely why the corpus could never have validated this
+  fix, and why the Konclude ∪ HermiT adjudication is the evidence that counts — the same
+  inertness `datatype_value_membership.rs` warns about, demonstrated at corpus scale.
+  **TWO RUNS CANNOT ESTABLISH STABILITY on a budget-truncated ontology.** `ore_ont_1508`
+  flagged as LOSING entailments; a 2-run same-binary control said "self-consistent,
+  byte-identical" and I reported that — **the THIRD run refuted it** (13928, 13928,
+  **13926**), while AFTER was stable at 13928 across three. Run at least three, and note
+  the ontology has ZERO language literals, so the change is provably inert on it — the
+  inertness argument is what makes the noise reading safe rather than convenient.
   **AND THE PYTHON STUB WENT STALE WITH CI GREEN.** `data_property_values`'
   hand-written `__init__.pyi` kept declaring a 4-tuple after the runtime returned
   5, and BOTH python jobs passed: `test_stubs.py` guards `__all__` NAME drift

--- a/crates/owl-dl-cli/src/json_out.rs
+++ b/crates/owl-dl-cli/src/json_out.rs
@@ -368,7 +368,7 @@ pub(crate) struct PropertyValuesJson {
     pub(crate) schema_version: u32,
     pub(crate) incomplete: bool,
     pub(crate) object_property_values: Vec<[String; 3]>,
-    pub(crate) data_property_values: Vec<[String; 4]>,
+    pub(crate) data_property_values: Vec<[String; 5]>,
 }
 
 #[must_use]
@@ -383,10 +383,12 @@ pub(crate) fn build_property_values_json(
         .collect();
     object_property_values.sort();
 
-    let mut data_property_values: Vec<[String; 4]> = data
-        .quads()
+    // 5 elements: the language tag is part of the literal's identity (issue
+    // #72). Empty string for every non-`rdf:langString` value.
+    let mut data_property_values: Vec<[String; 5]> = data
+        .quints()
         .iter()
-        .map(|(s, p, lex, dt)| [s.clone(), p.clone(), lex.clone(), dt.clone()])
+        .map(|(s, p, lex, dt, lang)| [s.clone(), p.clone(), lex.clone(), dt.clone(), lang.clone()])
         .collect();
     data_property_values.sort();
 

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -726,9 +726,23 @@ fn warn_if_incomplete(timed_out_pairs: usize, pair_timeout_ms: u64, global_timeo
 /// (unsupported constructs — see `owl_dl_reasoner::dropped_axioms`). Those
 /// axioms are simply absent from reasoning, so the result is a sound
 /// under-approximation: nothing false is reported, but something may be
-/// missing. Mirrors `warn_if_incomplete`'s placement (human path only —
-/// under `--json`, the `dropped` block itself is the signal, keeping stdout
-/// a single JSON object).
+/// missing.
+///
+/// Called from every command that ANSWERS an entailment question. It used to
+/// be called from three (`consistent`, `classify`, `realize`) out of 27, which
+/// is how issue #72 could happen: `instances-expr` on an ontology whose only
+/// two axioms were dropped printed NOTHING — no answer and no warning — while
+/// `classify` on the same file reported the drop. `CLAUDE.md`'s own rule is
+/// that a sound under-approximation the caller cannot detect is the defect.
+///
+/// Pure diagnostics (`tbox-stats`, `clause-stats`, `locality-stats`,
+/// `residual-*`, `hyper-*`) are deliberately NOT included: they report on the
+/// conversion itself rather than answering a question about the ontology, and
+/// `dropped_block` costs one extra `convert_ontology` per call.
+///
+/// Goes to stderr, so it is emitted on the `--json` paths too: stdout stays a
+/// single JSON object, and for the commands whose JSON carries no `dropped`
+/// block this is the only signal available.
 fn warn_if_dropped(dropped: &std::collections::BTreeMap<String, u64>) {
     let total: u64 = dropped.values().sum();
     if total == 0 {
@@ -952,6 +966,7 @@ fn main() -> Result<()> {
             json,
         } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let deadline =
                 (pair_timeout_ms > 0).then(|| std::time::Duration::from_millis(pair_timeout_ms));
             let classes =
@@ -993,6 +1008,7 @@ fn main() -> Result<()> {
             json,
         } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let deadline =
                 (pair_timeout_ms > 0).then(|| std::time::Duration::from_millis(pair_timeout_ms));
             let same =
@@ -1028,6 +1044,7 @@ fn main() -> Result<()> {
             json,
         } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let deadline =
                 (pair_timeout_ms > 0).then(|| std::time::Duration::from_millis(pair_timeout_ms));
             let obj = inferred_object_property_values(&onto, deadline)
@@ -1048,8 +1065,12 @@ fn main() -> Result<()> {
                 println!("{s}\t{p}\t{o}");
             }
             println!("# data property values");
-            for (s, p, lex, dt) in data.quads() {
-                println!("{s}\t{p}\t{lex}\t{dt}");
+            // The lang tag is part of the literal's IDENTITY (issue #72), so it
+            // is printed as a fifth column rather than dropped: `"bonjour"@fr`
+            // and `"bonjour"@de` are distinct literals and must not render
+            // identically. Empty for every non-`rdf:langString` value.
+            for (s, p, lex, dt, lang) in data.quints() {
+                println!("{s}\t{p}\t{lex}\t{dt}\t{lang}");
             }
             if obj.incomplete() || data.incomplete() {
                 eprintln!(
@@ -1059,6 +1080,7 @@ fn main() -> Result<()> {
         }
         Command::PropertyHierarchy { file, json } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let obj = owl_dl_reasoner::classify_object_property_hierarchy(&onto)
                 .context("classify_object_property_hierarchy")?;
             let data = owl_dl_reasoner::classify_data_property_hierarchy(&onto)
@@ -1081,6 +1103,7 @@ fn main() -> Result<()> {
         }
         Command::Sat { file, class_iri } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let verdict =
                 is_class_satisfiable(&onto, &class_iri).context("is_class_satisfiable")?;
             println!("{}", if verdict { "sat" } else { "unsat" });
@@ -1092,6 +1115,7 @@ fn main() -> Result<()> {
             saturation_only,
         } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let verdict = if saturation_only {
                 is_subclass_of_saturation_only(&onto, &sub, &sup)
                     .context("is_subclass_of_saturation_only")?
@@ -1175,6 +1199,7 @@ fn main() -> Result<()> {
             saturation_only,
         } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let verdict = if saturation_only {
                 is_instance_of_saturation_only(&onto, &class_iri, &individual_iri)
                     .context("is_instance_of_saturation_only")?
@@ -1189,6 +1214,7 @@ fn main() -> Result<()> {
             saturation_only,
         } => {
             let onto = parse_ofn(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let members = if saturation_only {
                 instances_of_saturation_only(&onto, &class_iri)
                     .context("instances_of_saturation_only")?
@@ -1201,6 +1227,7 @@ fn main() -> Result<()> {
         }
         Command::SatExpr { file, ce, json } => {
             let (onto, pm) = parse_ofn_with_pm(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let ce = parse_ce(&pm, &ce)?;
             let v = owl_dl_reasoner::class_expression_satisfiable(&onto, &ce)
                 .context("class_expression_satisfiable")?;
@@ -1230,6 +1257,7 @@ fn main() -> Result<()> {
             json,
         } => {
             let (onto, pm) = parse_ofn_with_pm(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let sub_ce = parse_ce(&pm, &sub_ce)?;
             let sup_ce = parse_ce(&pm, &sup_ce)?;
             let v = owl_dl_reasoner::class_expression_entailed_subclass(&onto, &sub_ce, &sup_ce)
@@ -1248,6 +1276,7 @@ fn main() -> Result<()> {
         }
         Command::InstancesExpr { file, ce, json } => {
             let (onto, pm) = parse_ofn_with_pm(&file)?;
+            warn_if_dropped(&json_out::dropped_block(&onto));
             let ce = parse_ce(&pm, &ce)?;
             let r = owl_dl_reasoner::class_expression_instances(&onto, &ce)
                 .context("class_expression_instances")?;

--- a/crates/owl-dl-cli/tests/text_output.rs
+++ b/crates/owl-dl-cli/tests/text_output.rs
@@ -122,11 +122,18 @@ fn individuals_text_output() {
 }
 
 /// `property-values` (no `--json`): section headers + tab-separated triples/
-/// quads. `:r` is symmetric and `r(a,b)` is asserted, so the seed alone
+/// quints. `:r` is symmetric and `r(a,b)` is asserted, so the seed alone
 /// (`materialize_object_property_assertions`, which already closes symmetric
 /// roles) surfaces both `r(a,b)` and the derived `r(b,a)` — no extension
 /// candidates remain unresolved by the seed, so this fixture is complete
 /// (no stderr warning).
+///
+/// The data row carries a FIFTH field, the language tag, EMPTY here because
+/// the value is `xsd:integer` — hence the trailing tab (issue #72). The width
+/// is deliberately uniform: a language tag is part of a literal's identity, so
+/// it needs its own column, and emitting it only for `rdf:langString` would
+/// make the row width vary by datatype and break any consumer splitting on
+/// tab. This test caught the format change, which is what it is for.
 #[test]
 fn property_values_text_output() {
     let out = rustdl()
@@ -141,7 +148,7 @@ fn property_values_text_output() {
          http://ex/#a\thttp://ex/#r\thttp://ex/#b\n\
          http://ex/#b\thttp://ex/#r\thttp://ex/#a\n\
          # data property values\n\
-         http://ex/#a\thttp://ex/#dp\t5\thttp://www.w3.org/2001/XMLSchema#integer\n"
+         http://ex/#a\thttp://ex/#dp\t5\thttp://www.w3.org/2001/XMLSchema#integer\t\n"
     );
     assert!(
         out.stderr.is_empty(),

--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -16,9 +16,9 @@ use thiserror::Error;
 use crate::ConceptPool;
 use crate::Vocabulary;
 use crate::data_axioms::{
-    DataIntersectionDkey, DateKey, DateTimeKey, Decimal, FloatRange, IntegerRange, OrdRange,
-    RangeBucket, StrSet, exact_string_literal, parse_data_intersection_dkey, parse_date,
-    parse_datetime, parse_decimal,
+    DataIntersectionDkey, DateKey, DateTimeKey, Decimal, FloatRange, IntegerRange, LangSet,
+    OrdRange, RangeBucket, StrSet, exact_lang_literal, exact_string_literal,
+    parse_data_intersection_dkey, parse_date, parse_datetime, parse_decimal,
 };
 use crate::ir::{ClassId, ConceptExpr, ConceptId, IndividualId, Role};
 use crate::ontology::{Axiom, InternalOntology, SubRolePath};
@@ -480,6 +480,76 @@ fn lower_str_data_to_some(
     pool.some(Role::named(role_id), filler)
 }
 
+// ── Issue #72 (2026-08-26): rdf:langString value-set DKey bucket ─────────
+//
+// `rdf:langString` is equality-typed like `xsd:string`, but a literal's
+// identity is the PAIR (lexical form, language tag). Its own `lang:` tag,
+// strictly disjoint from `str:` and from the six numeric/temporal buckets —
+// the datatypes really are disjoint (see `Family::LangString`), so sharing a
+// bucket with `str:` would make `"bonjour"` and `"bonjour"@fr` subsume each
+// other, a false positive.
+//
+// Member encoding is `hex(lexical).hex(tag)`: BOTH halves hex-encoded, joined
+// by `.`, members joined by `:`. Since hex is `[0-9a-f]*`, neither separator
+// can occur inside a half, so the two-level decode is unambiguous for
+// arbitrary content — the same reason D9 hex-encodes at all. `*` marks `Top`.
+const DKEY_LANG_TAG: &str = "lang:";
+
+fn lang_dkey_iri(set: &LangSet) -> String {
+    match set {
+        LangSet::Top => format!("{DKEY_IRI_PREFIX}{DKEY_LANG_TAG}*"),
+        LangSet::Set(members) => {
+            let body = members
+                .iter()
+                .map(|(lex, tag)| {
+                    format!(
+                        "{}.{}",
+                        hex_encode(lex.as_bytes()),
+                        hex_encode(tag.as_bytes())
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(":");
+            format!("{DKEY_IRI_PREFIX}{DKEY_LANG_TAG}{body}")
+        }
+    }
+}
+
+/// Public single-point decode of a LANGSTRING `DKey` IRI into its [`LangSet`].
+/// Returns `None` for any non-langString-bucket or malformed `DKey` IRI,
+/// mirroring [`decode_string_dkey`].
+#[must_use]
+pub fn decode_lang_dkey(iri: &str) -> Option<LangSet> {
+    parse_lang_dkey_iri(iri)
+}
+
+fn parse_lang_dkey_iri(iri: &str) -> Option<LangSet> {
+    let rest = iri
+        .strip_prefix(DKEY_IRI_PREFIX)?
+        .strip_prefix(DKEY_LANG_TAG)?;
+    if rest == "*" {
+        return Some(LangSet::Top);
+    }
+    let mut set = std::collections::BTreeSet::new();
+    for tok in rest.split(':') {
+        let (lex, tag) = tok.split_once('.')?;
+        set.insert((hex_decode(lex)?, hex_decode(tag)?));
+    }
+    Some(LangSet::Set(set))
+}
+
+fn lower_lang_data_to_some(
+    set: &LangSet,
+    dp_iri: &str,
+    vocab: &mut Vocabulary,
+    pool: &mut ConceptPool,
+) -> ConceptId {
+    let role_id = vocab.intern_role(dp_iri);
+    let dkey_class = vocab.intern_class(&lang_dkey_iri(set));
+    let filler = pool.atomic(dkey_class);
+    pool.some(Role::named(role_id), filler)
+}
+
 // ── Numeric DataOneOf DKey buckets (Phase D-numeric-oneof) ───────────────
 //
 // Five new ONEOF tags, each strictly disjoint from each other and from all
@@ -721,6 +791,12 @@ fn data_range_dkey<A: ForIRI>(
         ord_dkey_iri(DKEY_DATETIME_TAG, &r, datetime_key)
     } else if let Some(s) = crate::data_axioms::parse_string_range(dr) {
         str_dkey_iri(&s)
+    } else if let Some(s) = crate::data_axioms::parse_lang_range(dr) {
+        // Issue #72: bare `rdf:langString` (→ Top) or a `DataOneOf` of
+        // language-tagged literals. Placed AFTER the string arm, which cannot
+        // match a language-tagged member (`exact_string_literal` rejects them),
+        // so the two are disjoint by construction rather than by ordering.
+        lang_dkey_iri(&s)
     } else if let Some(s) = crate::data_axioms::parse_integer_oneof(dr) {
         int_oneof_iri(&s)
     } else if let Some(s) = crate::data_axioms::parse_xsd_float_oneof(dr) {
@@ -819,6 +895,18 @@ fn data_point_some<A: ForIRI>(
             &OrdRange::point(v),
             DKEY_DATETIME_TAG,
             datetime_key,
+            dp_iri,
+            vocab,
+            pool,
+        ))
+    } else if let Some((lex, tag)) = exact_lang_literal(l) {
+        // Issue #72. Must come BEFORE the `xsd:string` arm — not because the
+        // arms could both match (they cannot: `exact_string_literal` rejects
+        // `Literal::Language`), but so the ordering states the intent that a
+        // language-tagged literal is its own datatype and never falls through
+        // to the string bucket.
+        Some(lower_lang_data_to_some(
+            &LangSet::singleton(lex, tag),
             dp_iri,
             vocab,
             pool,
@@ -2762,6 +2850,14 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
         .classes()
         .filter_map(|(cid, iri)| parse_string_dkey_iri(iri).map(|r| (cid, r)))
         .collect();
+    // Issue #72: `rdf:langString`, its own bucket — never mixed with `str:`,
+    // since the two datatypes are disjoint and a shared bucket would make
+    // `"x"` and `"x"@fr` subsume one another.
+    let lang_dkeys: Vec<(ClassId, LangSet)> = out
+        .vocabulary
+        .classes()
+        .filter_map(|(cid, iri)| parse_lang_dkey_iri(iri).map(|r| (cid, r)))
+        .collect();
     // ── The six NUMERIC `DataOneOf` buckets (`io:` / `fo:` / `dbo:` / `deo:` /
     // `dao:` / `dto:`) ────────────────────────────────────────────────────────
     // These were minted by `data_range_dkey` but NEVER collected here, so they
@@ -2813,6 +2909,13 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
     } else {
         seed_bucket(out, &str_dkeys, StrSet::subset);
     }
+    // Issue #72. Deliberately NOT routed through `seed_str_bucket_indexed`:
+    // that optimisation is exact only under the cardinality argument that
+    // every `str:` DKey reaching it from a `DataPropertyAssertion` is a
+    // SINGLETON, and it is keyed on `StrSet`. The langString population is
+    // tiny by comparison (tags are few), so the plain O(k²) walk is correct
+    // and cheap; revisit only if a corpus ever shows otherwise.
+    seed_bucket(out, &lang_dkeys, LangSet::subset);
     // Numeric-oneof `⊑`: `DKey(S1) ⊑ DKey(S2)` iff `S1 ⊆ S2` (exact set
     // inclusion — every member of `S1` is a member of `S2`, so any value in
     // `S1` is in `S2`). Empty when the flag is off ⟹ these are no-ops.
@@ -2870,6 +2973,7 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
     seed_disjoint_bucket(out, &date_dkeys, OrdRange::disjoint, comp);
     seed_disjoint_bucket(out, &dt_dkeys, OrdRange::disjoint, comp);
     seed_disjoint_bucket(out, &str_dkeys, StrSet::disjoint, comp);
+    seed_disjoint_bucket(out, &lang_dkeys, LangSet::disjoint, comp);
     // Numeric-oneof disjointness. FP-CRITICAL DIRECTION: emitting a
     // `DisjointClasses` ADDS clashes, so a wrong "disjoint" is a false UNSAT,
     // not a miss. `BTreeSet::is_disjoint` is exact here because every bucket's
@@ -4898,6 +5002,17 @@ mod tests {
                         .collect(),
                 )),
             ),
+            (
+                "lang",
+                lang_dkey_iri(&LangSet::Set(
+                    [
+                        ("bonjour".to_string(), "fr".to_string()),
+                        ("bonjour".to_string(), "de".to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )),
+            ),
         ]
     }
 
@@ -4918,6 +5033,7 @@ mod tests {
                 "date" => parse_date_dkey_iri(iri).is_some(),
                 "dt" => parse_datetime_dkey_iri(iri).is_some(),
                 "str" => parse_string_dkey_iri(iri).is_some(),
+                "lang" => parse_lang_dkey_iri(iri).is_some(),
                 _ => unreachable!(),
             }
         };
@@ -4990,9 +5106,11 @@ mod tests {
         let mut all = sample_iris();
         all.extend(oneof.iter().cloned());
 
-        // Decoders for ALL thirteen buckets (7 interval/string + 6 oneof).
-        // `db:` (double interval) vs `dbo:` (double oneof) is the newest
-        // near-collision the matrix has to rule out.
+        // Decoders for ALL fourteen buckets (8 interval/string/lang + 6 oneof).
+        // `db:` (double interval) vs `dbo:` (double oneof) is one
+        // near-collision the matrix has to rule out; `lang:` vs `str:`
+        // (issue #72) is the other, and the FP it prevents is concrete —
+        // a shared bucket would make `"x"` and `"x"@fr` subsume each other.
         let probe = |bucket: &str, iri: &str| -> bool {
             match bucket {
                 "int" => parse_dkey_iri(iri).is_some(),
@@ -5002,6 +5120,7 @@ mod tests {
                 "date" => parse_date_dkey_iri(iri).is_some(),
                 "dt" => parse_datetime_dkey_iri(iri).is_some(),
                 "str" => parse_string_dkey_iri(iri).is_some(),
+                "lang" => parse_lang_dkey_iri(iri).is_some(),
                 "io" => parse_int_oneof_iri(iri).is_some(),
                 "fo" => parse_float_oneof_iri(iri).is_some(),
                 "dbo" => parse_double_oneof_iri(iri).is_some(),
@@ -5131,6 +5250,37 @@ mod tests {
         // Chronological tuple order.
         assert!(parse_date("2019-12-31") < parse_date("2020-01-01"));
         assert!(parse_datetime("2020-01-15T08:00:00") < parse_datetime("2020-01-15T08:00:01"));
+    }
+
+    /// Issue #72: the `lang:` bucket round-trips arbitrary content through
+    /// its TWO-level encoding. Both halves are hex, joined by `.`, members by
+    /// `:` — so a lexical form containing either delimiter cannot forge a
+    /// member boundary. That is the reason for hex, and the reason the pair
+    /// key is safe to put in an IRI at all.
+    #[test]
+    fn lang_dkey_iri_round_trips_including_delimiters() {
+        let set = LangSet::Set(
+            [
+                ("a:b.c".to_string(), "fr".to_string()),
+                ("naïve — ünïcode".to_string(), "de-ch".to_string()),
+                (String::new(), "en".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        assert_eq!(parse_lang_dkey_iri(&lang_dkey_iri(&set)), Some(set));
+        assert_eq!(
+            parse_lang_dkey_iri(&lang_dkey_iri(&LangSet::Top)),
+            Some(LangSet::Top)
+        );
+        // A langString IRI must NOT decode as a string IRI, or the two
+        // datatypes would cross-seed. (The full matrix is
+        // `parser_matrix_mutual_exclusivity`; this is the pair that motivated
+        // the separate bucket.)
+        let lang_iri = lang_dkey_iri(&LangSet::singleton("bonjour".to_string(), "fr".to_string()));
+        assert!(parse_string_dkey_iri(&lang_iri).is_none());
+        let str_iri = str_dkey_iri(&StrSet::singleton("bonjour".to_string()));
+        assert!(parse_lang_dkey_iri(&str_iri).is_none());
     }
 
     #[test]

--- a/crates/owl-dl-core/src/data_axioms.rs
+++ b/crates/owl-dl-core/src/data_axioms.rs
@@ -1106,6 +1106,102 @@ impl StrSet {
     }
 }
 
+/// Issue #72 (2026-08-26): an `rdf:langString` value set. Like [`StrSet`] this
+/// is an EQUALITY-typed datatype, but a language-tagged literal's identity is
+/// the PAIR `(lexical form, language tag)`: under RDF semantics `"bonjour"@fr`
+/// and `"bonjour"@de` are DISTINCT literals, and `"bonjour"@fr` is distinct
+/// again from the plain `xsd:string` `"bonjour"`.
+///
+/// `Top` is the bare `rdf:langString` (every language-tagged literal); `Set`
+/// is a finite enumeration from `DataOneOf`.
+///
+/// SOUNDNESS, and why this is a bucket of its own rather than members bolted
+/// onto [`StrSet`]:
+///
+/// - **`rdf:langString` is DISJOINT from `xsd:string`** — see the
+///   `Family::LangString` arm below, which already says so. Sharing a bucket
+///   would let `"bonjour"` and `"bonjour"@fr` subsume one another, a false
+///   positive. Bucket separation is what makes that unconstructible rather
+///   than merely unlikely, exactly as the `f:`/`dbo:` split does for
+///   `xsd:float` vs `xsd:double`.
+/// - **Tags compare case-insensitively** (RDF 1.1 §3.3: language tags are
+///   compared per BCP47, which is case-insensitive), so the tag is LOWERCASED
+///   at parse. `"x"@FR` and `"x"@fr` are the same literal and must land on the
+///   same key; failing to normalise would be an incompleteness (a missed
+///   membership), not an FP.
+/// - The lexical form is NOT normalised — it is compared by exact identity,
+///   the same rule [`StrSet`] uses.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LangSet {
+    Top,
+    Set(BTreeSet<(String, String)>),
+}
+
+impl LangSet {
+    pub fn singleton(lex: String, lang: String) -> Self {
+        LangSet::Set([(lex, lang)].into_iter().collect())
+    }
+
+    /// `self ⊆ other`: anything ⊆ `Top`; `Top` is a subset only of `Top`;
+    /// two finite sets compare by ordinary set inclusion. Mirrors
+    /// [`StrSet::subset`].
+    pub fn subset(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, LangSet::Top) => true,
+            (LangSet::Top, LangSet::Set(_)) => false,
+            (LangSet::Set(a), LangSet::Set(b)) => a.is_subset(b),
+        }
+    }
+
+    /// `self ∩ other = ∅` — conservative, mirroring [`StrSet::disjoint`].
+    /// `Top` overlaps everything so is NEVER disjoint.
+    pub fn disjoint(&self, other: &Self) -> bool {
+        match (self, other) {
+            (LangSet::Top, _) | (_, LangSet::Top) => false,
+            (LangSet::Set(a), LangSet::Set(b)) => a.is_disjoint(b),
+        }
+    }
+}
+
+/// Extract an EXACT `rdf:langString` value from a literal as its
+/// `(lexical form, lowercased language tag)` pair. Every other literal form —
+/// including a plain or `xsd:string`-typed literal, which is a DIFFERENT
+/// datatype — returns `None`.
+///
+/// Lowercasing is `to_ascii_lowercase`: BCP47 tags are ASCII by grammar, so
+/// this cannot alter a well-formed tag's non-ASCII content (there is none),
+/// and a malformed non-ASCII tag is left alone rather than mangled by
+/// locale-dependent casing.
+pub(crate) fn exact_lang_literal<A: ForIRI>(l: &Literal<A>) -> Option<(String, String)> {
+    match l {
+        Literal::Language { literal, lang } => Some((literal.clone(), lang.to_ascii_lowercase())),
+        _ => None,
+    }
+}
+
+/// Parse a language-string `DataRange`: bare `rdf:langString` (→ `Top`) or a
+/// `DataOneOf` whose members are ALL language-tagged literals (→ `Set`). Any
+/// non-language member drops the WHOLE enumeration — never a partial set,
+/// which would be unsound in a sufficient-direction RHS. Mirrors
+/// [`parse_string_range`].
+pub(crate) fn parse_lang_range<A: ForIRI>(dr: &DataRange<A>) -> Option<LangSet> {
+    match dr {
+        DataRange::Datatype(dt) if dt.0.as_ref() == RDF_LANG_STRING => Some(LangSet::Top),
+        DataRange::DataOneOf(lits) if !lits.is_empty() => {
+            let mut set = BTreeSet::new();
+            for l in lits {
+                set.insert(exact_lang_literal(l)?);
+            }
+            Some(LangSet::Set(set))
+        }
+        _ => None,
+    }
+}
+
+/// `rdf:langString`. Its own constant here so the parsers above do not depend
+/// on the `Family` classifier's private one.
+pub(crate) const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+
 /// Extract an EXACT `xsd:string` value from a literal: `Simple` (untyped is
 /// `xsd:string` by OWL 2) or `Datatype` tagged exactly `xsd:string`. ALL
 /// other forms — language-tagged, or any non-string datatype — return
@@ -3725,6 +3821,66 @@ Ontology(<http://t/x>
         // Sharing a member → NOT disjoint.
         assert!(!set(&["a"]).disjoint(&set(&["a", "b"])));
         assert!(!set(&["a", "b"]).disjoint(&set(&["b", "c"])));
+    }
+
+    /// Issue #72. Mirrors `strset_disjoint`, but on the PAIR key: the
+    /// lexical form alone is not the identity.
+    #[test]
+    fn langset_subset_and_disjoint() {
+        let set = |xs: &[(&str, &str)]| {
+            LangSet::Set(
+                xs.iter()
+                    .map(|(l, t)| ((*l).to_string(), (*t).to_string()))
+                    .collect(),
+            )
+        };
+        // Top behaves as it does for StrSet.
+        assert!(set(&[("bonjour", "fr")]).subset(&LangSet::Top));
+        assert!(!LangSet::Top.subset(&set(&[("bonjour", "fr")])));
+        assert!(!LangSet::Top.disjoint(&set(&[("bonjour", "fr")])));
+
+        // SAME lexical form, DIFFERENT tag: distinct literals. This is the
+        // property the whole bucket exists for — if the key were the lexical
+        // form alone these two would be equal and either could subsume the
+        // other, which is the false positive.
+        let fr = set(&[("bonjour", "fr")]);
+        let de = set(&[("bonjour", "de")]);
+        assert!(!fr.subset(&de));
+        assert!(!de.subset(&fr));
+        assert!(fr.disjoint(&de));
+
+        // Ordinary set containment on matching pairs.
+        assert!(fr.subset(&set(&[("bonjour", "fr"), ("hallo", "de")])));
+        assert!(!fr.disjoint(&set(&[("bonjour", "fr"), ("hallo", "de")])));
+    }
+
+    /// The tag is lowercased at parse, so `@FR` and `@fr` land on one key.
+    /// A completeness property (failing to normalise would MISS a membership,
+    /// never invent one), but it is the documented RDF 1.1 semantics.
+    #[test]
+    fn lang_literal_tag_is_lowercased() {
+        use horned_owl::model::{Build, Literal};
+        let _b: Build<RcStr> = Build::new_rc();
+        let upper: Literal<RcStr> = Literal::Language {
+            literal: "bonjour".to_string(),
+            lang: "FR".to_string(),
+        };
+        let lower: Literal<RcStr> = Literal::Language {
+            literal: "bonjour".to_string(),
+            lang: "fr".to_string(),
+        };
+        assert_eq!(exact_lang_literal(&upper), exact_lang_literal(&lower));
+        assert_eq!(
+            exact_lang_literal(&upper),
+            Some(("bonjour".to_string(), "fr".to_string()))
+        );
+        // A plain / typed string is NOT a langString and must not leak in.
+        let plain: Literal<RcStr> = Literal::Simple {
+            literal: "bonjour".to_string(),
+        };
+        assert_eq!(exact_lang_literal(&plain), None);
+        // …and conversely a language-tagged literal is not an xsd:string.
+        assert_eq!(exact_string_literal(&upper), None);
     }
 
     // ── `literal_provably_outside_range` unit tests ────────────────────

--- a/crates/owl-dl-py/python/rustdl/__init__.pyi
+++ b/crates/owl-dl-py/python/rustdl/__init__.pyi
@@ -205,8 +205,14 @@ def object_property_values(path: str) -> list[tuple[str, str, str]]:
     if the budget was exhausted."""
     ...
 
-def data_property_values(path: str) -> list[tuple[str, str, str, str]]:
-    """Inferred data property values (subject, property, lexical, datatype)."""
+def data_property_values(path: str) -> list[tuple[str, str, str, str, str]]:
+    """Inferred data property values (subject, property, lexical, datatype, lang).
+
+    `lang` is the language tag for `rdf:langString` values and EMPTY otherwise.
+    It is part of the literal's IDENTITY, not decoration: `"bonjour"@fr` and
+    `"bonjour"@de` are distinct literals. Until issue #72 the tag was dropped
+    before dedup, which merged such rows and lost an assertion outright when
+    they shared a subject."""
     ...
 
 # ── complex class-expression queries ────────────────────────────────────────

--- a/crates/owl-dl-py/src/queries.rs
+++ b/crates/owl-dl-py/src/queries.rs
@@ -155,10 +155,12 @@ pub(crate) fn object_property_values(
 /// over named individuals.
 #[pyfunction]
 #[allow(clippy::type_complexity)]
-pub(crate) fn data_property_values(path: &str) -> PyResult<Vec<(String, String, String, String)>> {
+pub(crate) fn data_property_values(
+    path: &str,
+) -> PyResult<Vec<(String, String, String, String, String)>> {
     let o = load::load_path(path)?;
     owl_dl_reasoner::inferred_data_property_values(&o)
-        .map(|v| v.quads().to_vec())
+        .map(|v| v.quints().to_vec())
         .map_err(reason_error_to_py)
 }
 

--- a/crates/owl-dl-py/src/queries.rs
+++ b/crates/owl-dl-py/src/queries.rs
@@ -151,7 +151,7 @@ pub(crate) fn object_property_values(
         .map_err(reason_error_to_py)
 }
 
-/// Inferred data property values `(subject, property, lexical, datatype)`
+/// Inferred data property values `(subject, property, lexical, datatype, lang)`
 /// over named individuals.
 #[pyfunction]
 #[allow(clippy::type_complexity)]

--- a/crates/owl-dl-py/tests/python/test_queries.py
+++ b/crates/owl-dl-py/tests/python/test_queries.py
@@ -234,7 +234,32 @@ def test_data_property_values(tmp_path):
         "  Declaration(NamedIndividual(:a))\n"
         "  DataPropertyAssertion(:dp :a \"5\"^^xsd:integer))\n"
     )
-    quads = rustdl.data_property_values(str(p))
+    quints = rustdl.data_property_values(str(p))
+    # Assert the ARITY, not just a couple of indices: the previous version of
+    # this test read q[0]/q[1] only, so it passed at any tuple width and did
+    # not notice when the row grew a language-tag column (issue #72).
+    assert all(len(q) == 5 for q in quints), quints
     assert any(
-        q[0] == "http://ex/#a" and q[1] == "http://ex/#dp" for q in quads
+        q[0] == "http://ex/#a" and q[1] == "http://ex/#dp" and q[4] == ""
+        for q in quints
+    ), quints
+
+
+def test_data_property_values_keeps_language_tags(tmp_path):
+    """Issue #72: the tag is part of the literal's identity.
+
+    Two tagged assertions on ONE subject sharing a lexical form must stay TWO
+    rows. Dropping `lang` before dedup merged them, losing an assertion.
+    """
+    p = tmp_path / "lang.ofn"
+    p.write_text(
+        "Prefix(:=<http://ex/#>)\n"
+        "Ontology(<http://ex/>\n"
+        "  Declaration(DataProperty(:dp))\n"
+        "  Declaration(NamedIndividual(:a))\n"
+        '  DataPropertyAssertion(:dp :a "bonjour"@fr)\n'
+        '  DataPropertyAssertion(:dp :a "bonjour"@de))\n'
     )
+    quints = rustdl.data_property_values(str(p))
+    tags = sorted(q[4] for q in quints)
+    assert tags == ["de", "fr"], quints

--- a/crates/owl-dl-py/tests/python/test_stubs.py
+++ b/crates/owl-dl-py/tests/python/test_stubs.py
@@ -1,6 +1,7 @@
 """The hand-written __init__.pyi must stay in sync with the runtime __all__."""
 import ast
 import pathlib
+import re
 
 import rustdl
 
@@ -39,3 +40,46 @@ def test_every_public_name_is_stubbed():
 def test_stub_names_are_real():
     for name in _stub_declared_names() - {"examples"}:
         assert hasattr(rustdl, name), f"stub declares {name!r} but rustdl has no such attr"
+
+
+def _stub_return_arity(func_name: str) -> int | None:
+    """Declared tuple arity of `func_name`'s `list[tuple[...]]` return, if any.
+
+    The name-level check above cannot see SIGNATURE drift, which is a real gap
+    and not a theoretical one: issue #72 widened `data_property_values` from a
+    4-tuple to a 5-tuple, the stub kept saying 4, and CI stayed green — stubs
+    are not checked at runtime, and the query test indexed only `q[0]`/`q[1]`.
+    """
+    stub = pathlib.Path(rustdl.__file__).with_name("__init__.pyi")
+    for node in ast.parse(stub.read_text()).body:
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            ann = ast.unparse(node.returns) if node.returns else ""
+            m = re.fullmatch(r"list\[tuple\[(.*)\]\]", ann)
+            if m:
+                return len(m.group(1).split(","))
+    return None
+
+
+def test_tuple_returning_stubs_match_runtime_arity(tmp_path):
+    """The declared tuple width must equal what the function actually returns."""
+    p = tmp_path / "o.ofn"
+    p.write_text(
+        "Prefix(:=<http://ex/#>)\n"
+        "Ontology(<http://ex/>\n"
+        "  Declaration(ObjectProperty(:r))\n"
+        "  Declaration(DataProperty(:dp))\n"
+        "  Declaration(NamedIndividual(:a))\n"
+        "  Declaration(NamedIndividual(:b))\n"
+        "  ObjectPropertyAssertion(:r :a :b)\n"
+        '  DataPropertyAssertion(:dp :a "bonjour"@fr))\n'
+    )
+    for name in ("object_property_values", "data_property_values"):
+        declared = _stub_return_arity(name)
+        assert declared is not None, f"{name}: stub declares no list[tuple[...]]"
+        rows = getattr(rustdl, name)(str(p))
+        assert rows, f"{name}: fixture produced no rows, arity unchecked"
+        for row in rows:
+            assert len(row) == declared, (
+                f"{name}: stub declares a {declared}-tuple, runtime returned "
+                f"{len(row)}: {row}"
+            )

--- a/crates/owl-dl-reasoner/src/property_values.rs
+++ b/crates/owl-dl-reasoner/src/property_values.rs
@@ -65,21 +65,30 @@ impl ObjectPropertyValues {
     }
 }
 
-/// Entailed DATA property quads over named individuals, plus a completeness
+/// Entailed DATA property values over named individuals, plus a completeness
 /// flag.
 #[derive(Debug, Clone)]
 pub struct DataPropertyValues {
-    quads: Vec<(String, String, String, String)>,
+    quints: Vec<(String, String, String, String, String)>,
     incomplete: bool,
 }
 
 impl DataPropertyValues {
-    /// `(subject_iri, property_iri, lexical, datatype_iri)` 4-tuples, sorted
-    /// and deduplicated (the `lang` element of the underlying materialize
-    /// closure is dropped — see the module doc).
+    /// `(subject_iri, property_iri, lexical, datatype_iri, lang)` 5-tuples,
+    /// sorted and deduplicated.
+    ///
+    /// `lang` is the language tag when the datatype is `rdf:langString`, and
+    /// EMPTY otherwise — the same representation
+    /// [`crate::materialize_data_property_assertions`] uses, so this is a
+    /// passthrough with no lossy conversion in between.
+    /// It is part of the KEY, not decoration: under RDF semantics
+    /// `"bonjour"@fr` and `"bonjour"@de` are DISTINCT literals, so dropping
+    /// the tag before `dedup` (which is what this did until 2026-08-26, issue
+    /// #72) silently merged them into one row — losing an assertion outright
+    /// when they shared a subject, not merely losing the tag.
     #[must_use]
-    pub fn quads(&self) -> &[(String, String, String, String)] {
-        &self.quads
+    pub fn quints(&self) -> &[(String, String, String, String, String)] {
+        &self.quints
     }
 
     /// Always `false`: `inferred_data_property_values` is a pure structural
@@ -474,9 +483,15 @@ pub fn inferred_object_property_values<A: ForIRI>(
 }
 
 /// Inferred DATA property values over named individuals: a pure structural
-/// passthrough over `materialize_data_property_assertions`, dropping the
-/// `lang` element to a 4-tuple. See the module doc for the v1 scope boundary
-/// (no negative-data-assertion entailment extension).
+/// passthrough over `materialize_data_property_assertions`, preserving the
+/// full 5-tuple INCLUDING the language tag. See the module doc for the v1
+/// scope boundary (no negative-data-assertion entailment extension).
+///
+/// The tag must survive into the dedup key. It did not until 2026-08-26
+/// (issue #72), and because `dedup` ran on the truncated tuple, two
+/// language-tagged assertions on one subject sharing a lexical form —
+/// `"bonjour"@fr` and `"bonjour"@de` — collapsed to a single row. That is
+/// data loss, not a formatting choice, and it was silent.
 ///
 /// # Errors
 /// [`ReasonError::Inconsistent`] if the ontology is inconsistent;
@@ -484,15 +499,11 @@ pub fn inferred_object_property_values<A: ForIRI>(
 pub fn inferred_data_property_values<A: ForIRI>(
     onto: &SetOntology<A>,
 ) -> Result<DataPropertyValues, ReasonError> {
-    let quints = crate::materialize_data_property_assertions(onto)?;
-    let mut quads: Vec<(String, String, String, String)> = quints
-        .into_iter()
-        .map(|(s, p, lex, dt, _lang)| (s, p, lex, dt))
-        .collect();
-    quads.sort();
-    quads.dedup();
+    let mut quints = crate::materialize_data_property_assertions(onto)?;
+    quints.sort();
+    quints.dedup();
     Ok(DataPropertyValues {
-        quads,
+        quints,
         incomplete: false,
     })
 }

--- a/crates/owl-dl-reasoner/tests/datatype_value_membership.rs
+++ b/crates/owl-dl-reasoner/tests/datatype_value_membership.rs
@@ -735,6 +735,15 @@ fn language_tagged_oneof_member_drops_enumeration() {
     // A DataOneOf with a language-tagged member is NOT all-exact-string →
     // the whole enumeration drops → no subsumption even for the plain
     // member that would otherwise match.
+    //
+    // Still exactly true after issue #72 added the `lang:` bucket, and the
+    // reason is worth stating so this does not read as "langString is
+    // unsupported": a MIXED enumeration now fails BOTH parsers —
+    // `parse_string_range` rejects the tagged member, `parse_lang_range`
+    // rejects the untagged one — so it drops for the same all-or-nothing
+    // reason, not for want of a langString bucket. The pure-langString case
+    // is `lang_value_in_oneof_subsumes`; the mixed case's sibling canary is
+    // `lang_mixed_oneof_drops_whole_enumeration`.
     let c = classify(
         r#"    Declaration(Class(:C))
     Declaration(Class(:D))
@@ -1547,5 +1556,154 @@ fn int_oneof_wrong_property_not_subsumed() {
     assert!(
         !c.is_subclass(C, D),
         "∃g.{{1}} ⊄ ∃h.{{1,2}}: wrong property must NOT subsume"
+    );
+}
+
+// ── Issue #72 (2026-08-26): rdf:langString value membership ──────────────
+//
+// A language-tagged literal's identity is the PAIR (lexical form, tag), and
+// `rdf:langString` is a DIFFERENT datatype from `xsd:string`. Before this,
+// `exact_string_literal` rejected `Literal::Language` and nothing else picked
+// it up, so a langString `DataHasValue` failed conversion outright and was
+// DROPPED — no membership was derivable by any route.
+//
+// NEGATIVES-FIRST, as above: the new `lang:` bucket is new FP surface, and
+// the curated corpus is inert for it (see this file's header). These are the
+// entire safety net.
+
+/// POSITIVE: same lexical form AND same tag ⇒ member of the enumeration.
+#[test]
+fn lang_value_in_oneof_subsumes() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@fr))
+    EquivalentClasses(:D DataSomeValuesFrom(:g DataOneOf("bonjour"@fr "hallo"@de)))
+"#,
+    );
+    assert!(c.is_subclass(C, D), r#""bonjour"@fr ∈ {{@fr, @de}}"#);
+}
+
+/// NEGATIVE — DIFFERENT TAG, SAME LEXICAL FORM. The whole point of the pair
+/// key: `"bonjour"@de` is a different literal from `"bonjour"@fr`.
+#[test]
+fn lang_same_lexical_different_tag_not_subsumed() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@de))
+    EquivalentClasses(:D DataSomeValuesFrom(:g DataOneOf("bonjour"@fr)))
+"#,
+    );
+    assert!(
+        !c.is_subclass(C, D),
+        r#""bonjour"@de ∉ {{"bonjour"@fr}}: the TAG is part of the key"#
+    );
+}
+
+/// NEGATIVE — CROSS-DATATYPE, the FP this bucket exists to prevent. A plain
+/// `xsd:string` and a language-tagged literal with the same lexical form are
+/// different literals in different datatypes; a shared bucket would make them
+/// subsume each other.
+#[test]
+fn lang_vs_plain_string_not_subsumed_either_direction() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@fr))
+    EquivalentClasses(:D DataHasValue(:g "bonjour"^^xsd:string))
+"#,
+    );
+    assert!(!c.is_subclass(C, D), "langString ⊄ xsd:string");
+    assert!(!c.is_subclass(D, C), "xsd:string ⊄ langString");
+}
+
+/// POSITIVE: a tagged literal IS an `rdf:langString`, so the bare datatype
+/// acts as `Top` for this bucket.
+#[test]
+fn lang_value_subsumed_by_bare_langstring() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@fr))
+    EquivalentClasses(:D DataSomeValuesFrom(:g <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>))
+"#,
+    );
+    assert!(c.is_subclass(C, D), r#""bonjour"@fr ∈ rdf:langString"#);
+}
+
+/// NEGATIVE: bare `xsd:string` must NOT swallow a language-tagged value.
+#[test]
+fn lang_value_not_subsumed_by_bare_xsd_string() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@fr))
+    EquivalentClasses(:D DataSomeValuesFrom(:g xsd:string))
+"#,
+    );
+    assert!(
+        !c.is_subclass(C, D),
+        "a langString value is NOT an xsd:string"
+    );
+}
+
+/// POSITIVE: BCP47 tags compare case-insensitively (RDF 1.1 §3.3), so `@FR`
+/// and `@fr` are the same literal. Normalising is a COMPLETENESS matter — a
+/// missed membership, never an FP — but it is the documented semantics.
+#[test]
+fn lang_tag_comparison_is_case_insensitive() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@FR))
+    EquivalentClasses(:D DataSomeValuesFrom(:g DataOneOf("bonjour"@fr)))
+"#,
+    );
+    assert!(c.is_subclass(C, D), r#""bonjour"@FR ≡ "bonjour"@fr"#);
+}
+
+/// NEGATIVE — WRONG PROPERTY, mirroring the other buckets' control: the pair
+/// matches but the data property does not, so CR5 must not relay.
+#[test]
+fn lang_wrong_property_not_subsumed() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    Declaration(DataProperty(:h))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@fr))
+    EquivalentClasses(:D DataSomeValuesFrom(:h DataOneOf("bonjour"@fr)))
+"#,
+    );
+    assert!(
+        !c.is_subclass(C, D),
+        "∃g.{{@fr}} ⊄ ∃h.{{@fr}}: wrong property must NOT subsume"
+    );
+}
+
+/// NEGATIVE — MIXED ENUMERATION DROPS WHOLE. A `DataOneOf` mixing a tagged
+/// and an untagged literal is not a langString set; it must drop entirely
+/// rather than silently become the tagged subset (a partial set would be
+/// unsound in a sufficient-direction RHS).
+#[test]
+fn lang_mixed_oneof_drops_whole_enumeration() {
+    let c = classify(
+        r#"    Declaration(Class(:C))
+    Declaration(Class(:D))
+    Declaration(DataProperty(:g))
+    EquivalentClasses(:C DataHasValue(:g "bonjour"@fr))
+    EquivalentClasses(:D DataSomeValuesFrom(:g DataOneOf("bonjour"@fr "plain"^^xsd:string)))
+"#,
+    );
+    assert!(
+        !c.is_subclass(C, D),
+        "a mixed DataOneOf must drop whole, not become its tagged subset"
     );
 }

--- a/crates/owl-dl-reasoner/tests/langstring_values.rs
+++ b/crates/owl-dl-reasoner/tests/langstring_values.rs
@@ -1,0 +1,90 @@
+//! Issue #72 — `rdf:langString` end-to-end.
+//!
+//! Two defects, one fixture:
+//!
+//! 1. `inferred_data_property_values` dropped the `lang` element and THEN
+//!    deduped, so two language-tagged assertions on one subject sharing a
+//!    lexical form collapsed to a single row. That is data loss, not a
+//!    formatting choice, and it was silent.
+//! 2. No `rdf:langString` `DKey` bucket existed, so a language-tagged literal
+//!    failed conversion (`exact_string_literal` rejects `Literal::Language`
+//!    by design) and the axiom was DROPPED — nothing could confirm it.
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::{dropped_axioms, inferred_data_property_values};
+use std::io::Cursor;
+
+fn onto(src: &str) -> SetOntology<RcStr> {
+    read_ofn(
+        &mut Cursor::new(src.to_owned()),
+        ParserConfiguration::default(),
+    )
+    .unwrap()
+    .0
+}
+
+/// One subject, two tags, ONE lexical form — the row-loss case. Before the
+/// fix this returned 2 rows for 3 assertions.
+const SHARED_LEXICAL: &str = r#"Ontology(<http://example.org/o>
+    Declaration(DataProperty(<http://example.org/v>))
+    DataPropertyAssertion(<http://example.org/v> <http://example.org/a> "bonjour"@de)
+    DataPropertyAssertion(<http://example.org/v> <http://example.org/a> "bonjour"@fr)
+    DataPropertyAssertion(<http://example.org/v> <http://example.org/a> "hello"@en)
+)"#;
+
+#[test]
+fn tagged_values_sharing_a_lexical_form_do_not_collapse() {
+    let v = inferred_data_property_values(&onto(SHARED_LEXICAL)).unwrap();
+    let rows = v.quints();
+    assert_eq!(
+        rows.len(),
+        3,
+        "3 assertions must yield 3 rows; dropping `lang` before dedup merged \
+         the @de and @fr rows (issue #72). got: {rows:?}"
+    );
+    let tags: Vec<&str> = rows.iter().map(|(_, _, _, _, l)| l.as_str()).collect();
+    for t in ["de", "en", "fr"] {
+        assert!(tags.contains(&t), "tag {t} missing from {tags:?}");
+    }
+}
+
+/// A non-langString value reports an EMPTY tag — the column is always present
+/// so the row shape is uniform for consumers.
+#[test]
+fn typed_value_reports_an_empty_tag() {
+    let o = onto(
+        r#"Ontology(<http://example.org/o>
+    Declaration(DataProperty(<http://example.org/v>))
+    DataPropertyAssertion(<http://example.org/v> <http://example.org/m> "37.8"^^<http://www.w3.org/2001/XMLSchema#double>)
+)"#,
+    );
+    let v = inferred_data_property_values(&o).unwrap();
+    assert_eq!(v.quints().len(), 1);
+    let (_, _, lex, dt, lang) = &v.quints()[0];
+    assert_eq!(lex, "37.8");
+    assert_eq!(dt, "http://www.w3.org/2001/XMLSchema#double");
+    assert!(lang.is_empty(), "a typed literal has no language tag");
+}
+
+/// The second defect: a language-tagged assertion must now REACH the
+/// reasoner. Before the fix both assertions were dropped at conversion, which
+/// is why no query could confirm one.
+#[test]
+fn language_tagged_assertions_are_no_longer_dropped() {
+    let o = onto(
+        r#"Ontology(<http://example.org/o>
+    Declaration(DataProperty(<http://example.org/v>))
+    DataPropertyAssertion(<http://example.org/v> <http://example.org/de> "bonjour"@de)
+    DataPropertyAssertion(<http://example.org/v> <http://example.org/fr> "bonjour"@fr)
+)"#,
+    );
+    let dropped = dropped_axioms(&o).unwrap();
+    assert!(
+        dropped.is_empty(),
+        "language-tagged assertions must convert, not drop: {dropped:?}"
+    );
+}

--- a/crates/owl-dl-reasoner/tests/property_values_oracle.rs
+++ b/crates/owl-dl-reasoner/tests/property_values_oracle.rs
@@ -53,10 +53,12 @@ fn object_values_include_asserted_and_symmetric() {
     assert!(has("http://ex/#b", "http://ex/#r", "http://ex/#a"));
 }
 
-/// A plain `DataPropertyAssertion` must surface as its 4-tuple (subject,
-/// property, lexical, datatype) — `inferred_data_property_values` is a
-/// structural passthrough over `materialize_data_property_assertions` with the
-/// `lang` element dropped.
+/// A plain `DataPropertyAssertion` must surface as its 5-tuple (subject,
+/// property, lexical, datatype, lang) — `inferred_data_property_values` is a
+/// structural passthrough over `materialize_data_property_assertions`,
+/// preserving every element. It used to drop `lang` and then dedup, which
+/// merged rows differing only by tag (issue #72); `lang` is empty here because
+/// the value is typed, not language-tagged.
 #[test]
 fn data_values_include_asserted() {
     let o = onto(

--- a/crates/owl-dl-reasoner/tests/property_values_oracle.rs
+++ b/crates/owl-dl-reasoner/tests/property_values_oracle.rs
@@ -67,11 +67,12 @@ fn data_values_include_asserted() {
             DataPropertyAssertion(:dp :a "42"^^xsd:integer))"#,
     );
     let v = inferred_data_property_values(&o).unwrap();
-    assert!(v.quads().iter().any(|(s, p, lex, dt)| {
+    assert!(v.quints().iter().any(|(s, p, lex, dt, lang)| {
         s == "http://ex/#a"
             && p == "http://ex/#dp"
             && lex == "42"
             && dt == "http://www.w3.org/2001/XMLSchema#integer"
+            && lang.is_empty()
     }));
     assert!(!v.incomplete());
 }


### PR DESCRIPTION
Closes #72.

Two reported problems, and a third found while root-causing them.

## 1. `rdf:langString` had no `DKey` bucket, so the literal never reached the reasoner

`data_point_some` tries integer → float → decimal → date → dateTime → `exact_string_literal`. That last one refuses `Literal::Language` — deliberately, per Phase D9. So `data_point_some` returned `None`, the caller raised `ConversionError::UnsupportedDataRange`, and the axiom was **dropped**:

```json
"dropped": { "DataPropertyAssertion: unsupported data range": 2 }
```

The `DataHasValue` probe was not failing to match; there was nothing to match against. This also explains the asymmetry in the report — `property-values` is a **structural** pass that never converts, so it still saw assertions the reasoner never received.

Adds the 8th bucket, `lang:`. **The key is the PAIR `(lexical form, language tag)`**: `"bonjour"@fr` and `"bonjour"@de` are distinct literals, and both are distinct from the `xsd:string` `"bonjour"`. Tags are lowercased at parse (RDF 1.1 §3.3 compares per BCP47, case-insensitively) — a completeness matter, never an FP. Members encode as `hex(lex).hex(tag)` joined by `:`; both halves hex, so neither delimiter can occur inside one and the two-level decode is unambiguous for arbitrary content.

**Why a separate bucket rather than members in `str:`** — the datatypes are disjoint, so sharing would let `"bonjour"` and `"bonjour"@fr` subsume one another. That is the same defect shape as the `xsd:float`/`xsd:double` collision that shipped undetected for months; bucket separation makes it unconstructible rather than merely unlikely.

## 2. `property-values` did not merely erase the tag — it LOST ROWS

`inferred_data_property_values` dropped `lang` and *then* deduped. In the reported fixture the rows differ by subject so both survive; on one subject an assertion disappears:

```
DataPropertyAssertion(v a "bonjour"@de)
DataPropertyAssertion(v a "bonjour"@fr)
DataPropertyAssertion(v a "hello"@en)
```

Three assertions in, **two rows out**. Silent data loss, not lossy formatting.

`quads()` → `quints()`, and `property-values` gains a fifth column. It is emitted **always**, empty for non-langString values, so the row width does not vary by datatype — a variable width would break any consumer splitting on tab, which is the same class of silent lossiness this issue is about. `property_values_text_output` caught the format change, which is what it is for; its expectation is updated with the reasoning recorded in the doc comment.

## 3. New: the dropped-axiom warning reached 3 of 27 CLI commands

`instances-expr` on the fixture printed **nothing at all** — no answer, no warning — while `classify` on the same file reported the drop. `warn_if_dropped` now runs from every command that *answers an entailment question* (14). Pure diagnostics stay out: they report on conversion rather than querying, and `dropped_block` costs an extra `convert_ontology` per call. The warning goes to stderr, so it fires on `--json` paths too, where those commands' JSON carries no `dropped` block; stdout remains a single valid JSON object.

This is `CLAUDE.md`'s own rule — *"When adding a sound under-approximation, ask whether a caller can tell. If not, add the signal in the same change."*

## Evidence — and the corpus is deliberately not part of it

The FP=0 net is **11 fixtures VERIFIED, closures exact** (galen 28007, ore-10908 6001, ore-15672 142, sio 8904, wine 653, pizza 499, ro 158, bibtex 16, sulo 51, ore-10080 32356). But `datatype_value_membership.rs` states plainly that the curated corpus contains no clash of this kind, so a green net here demonstrates **non-regression only**. What actually carries this:

**Konclude ∪ HermiT adjudication, all three reasoners agreeing 4/4:**

| probe | rustdl | Konclude | HermiT |
| --- | --- | --- | --- |
| same lexical + tag, ∈ enumeration | `C ⊑ D` | `SubClassOf(C,D)` | `SubClassOf(C,D)` |
| same lexical, **different tag** | neither | none | none |
| langString vs `xsd:string` | neither | none | none |
| **control**: identical tagged literals | `C ≡ D` | `EquivalentClasses` | `EquivalentClasses` |

The control is load-bearing: both oracles *do* report a relation when one exists, so their silence on the two negative probes is genuine non-entailment rather than the under-reporting Konclude is documented for.

**Tests**: 8 negatives-first canaries in `datatype_value_membership.rs`, 3 unit tests, 3 end-to-end regressions in a new `langstring_values.rs`. Suite **1718 passed / 0 failed**; `fmt` and `clippy --all-targets --all-features -D warnings` clean.

**Sabotage: 4 run, 4 caught** — keying on the lexical form alone, routing langString into the `str:` bucket, restoring the lang-dropping dedup, and skipping tag lowercasing each fail exactly the intended canary.

## One finding worth carrying beyond this PR

`numeric_oneof_parser_matrix_exclusivity` hit `unreachable!()` on the new bucket until fixed — meaning **that half of the FP check was silently not running**. Both parser matrices draw from `sample_iris()` but have separate probes, so extending the fixture list without extending both leaves a decoder pair unchecked. Noted in `CLAUDE.md`.

Also verified rather than assumed: HermiT's output contains `EquivalentClasses(C, g)`-looking entries where `g` is a *data property*. Those are ROBOT echoing the **asserted** axioms, not inferences — my first extraction regex flattened nested axioms and conflated them. The genuine class-to-class inferences are the ones in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
