### PR TITLE
fix(tableau): ≤n merge-pair choice was deterministic — a real false positive (#76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -954,6 +954,53 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `docs/abox-consistency-check-handoff.md`. Spec:
   `docs/superpowers/specs/2026-06-04-abox-consistency-check-design.md`.
 
+  **`≤n` merge-pair trial merge (2026-08-27, #76, `RUSTDL_MAX_TRIAL_MERGE`, default ON,
+  `=0` reverts) — A REAL FALSE POSITIVE, and the FP=0 net STRUCTURALLY COULD NOT SEE IT.**
+  The SROIQ `≤`-rule is don't-know NONDETERMINISTIC over WHICH pair of witnesses to merge.
+  `apply_max` (`owl-dl-tableau/src/rules.rs`) runs in the DETERMINISTIC saturation pass and
+  committed to the first pair not marked distinct; when that pair was the one inconsistent
+  combination its clash propagated as `Unsat` — an unsound POSITIVE subsumption. Now each
+  candidate is merged behind a checkpoint and kept only if the survivor is clash-free,
+  rolling back otherwise; if NO pair survives the pre-existing `Bot` arm still fires, which
+  is sound because satisfying `≤n` requires SOME merge and every candidate is contradictory.
+  **Five-axiom witness** (`r10b`): `A ⊑ ∃r.M, ∃r.T, ∃r.PT` + `Disjoint(M,PT)` +
+  `I ≡ ≥3 r`. `A ⊑ I` is NOT entailed (T may merge with either) and rustdl said `yes`.
+  **The tell that it was ORDER-DEPENDENCE, not semantics:** move the disjoint pair to
+  `Disjoint(M,T)` and the old code answered correctly — by luck, the first-enumerated pair
+  happening to be compatible. Canary `max_merge_pair_choice.rs` pins all three plus the
+  entailed control `Disjoint(M,T,PT)`, where `A ⊑ I` genuinely holds and must survive.
+  **LIVE ON `pizza`**: `Margherita ⊑ InterestingPizza` and `QuattroFormaggi ⊑
+  InterestingPizza` (`InterestingPizza ≡ Pizza ⊓ ≥3 hasTopping`; Margherita has two
+  toppings and is closed to them). Konclude reports **20** other `X ⊑ InterestingPizza`
+  rows and excludes exactly those two, so its silence is a discriminating control, not
+  under-reporting.
+  **WHY NO GATE CAUGHT IT — the important part.** `classify` never emitted the FP: the
+  wedge/label-heuristic path prunes those pairs before the tableau is consulted. The bug
+  lived on the `subclass`/`explain`/`is_subclass_of` per-pair path, and the FP=0
+  closure-diff net diffs **classify** closures — so it is structurally blind to it. The
+  corpus-wide FP=0 claim elsewhere in this file is a claim about `classify` and remains
+  true; **it does not cover the per-pair query surface.** `trust_sat` had been accidentally
+  MASKING this: it was found only by running the FP=0 net with the #66 prototype
+  (`RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1`) forcing classify to tableau-adjudicate, where
+  pizza went 499 → **501, FP=2**.
+  **Evidence:** full 1,920-ontology two-arm sweep (`=0` vs default, one pinned binary, env
+  var the only difference, arm order alternated): **1,774 IDENTICAL / 24 DIFFER / 121
+  BOTH_FAIL / 0 REGRESSED / 1 RECOVERED** (`ore_ont_1938` DNF → 40.9 s). All 24 DIFFERs
+  re-adjudicated by SET membership: **23 do not reproduce**, 1 is real (`ore_ont_1508`) and
+  **gains 4 closure pairs, loses 0** — its Hasse row moved because the fix derived the
+  NEARER parent, making the farther one indirect, which would have read as a loss had I
+  stopped at `direct_subsumptions`. **Zero new false positives.** Wall **−0.37%**, both
+  order groups agreeing (−0.67% / −0.09%), so the checkpoint/rollback in the hot saturation
+  loop costs nothing measurable — it only fires on a REJECTED pair.
+  **PARTIAL BY CONSTRUCTION, and do not read it as closing the class:** a pair that clashes
+  only DEEPER is still committed to without a choice point, so a spurious `Unsat` remains
+  constructible. The complete fix is a backtrackable choice point over merge pairs in
+  `search.rs`, which branches over CONCEPTS today and needs a new branching primitive.
+  Two adjacent dep weaknesses remain (both pre-existing): `compute_max_merge_deps` unions
+  deps only for the merged pair, not the other witnesses whose existence triggered the
+  merge; and `search.rs:161` invokes the choose rule with an EMPTY `DepSet` where the
+  disjunction path threads `or_deps`.
+
 - **`crates/owl-dl-datatypes`** — concrete-domain reasoners (`card_sat`,
   interval/finite-set value ranges). **Wired into reasoning** (via the DKey
   side-map + the tableau `concrete_domain_clash`), and as of 2026-06-18 data

--- a/crates/owl-dl-reasoner/tests/flag_defaults.rs
+++ b/crates/owl-dl-reasoner/tests/flag_defaults.rs
@@ -30,7 +30,7 @@
 //! commit. That is the point — the table makes a default change a reviewable edit
 //! instead of a silent one.
 //!
-//! Coverage is the 31 public `fn() -> bool` accessors across `owl-dl-core`,
+//! Coverage is the 32 public `fn() -> bool` accessors across `owl-dl-core`,
 //! `owl-dl-tableau` and `owl-dl-reasoner`. Numeric knobs
 //! (`RUSTDL_*_MS`, `RUSTDL_MAX_NODES`, …) are out of scope here; they are pinned by
 //! their own tests where they are load-bearing (e.g.
@@ -95,6 +95,11 @@ fn expected() -> Vec<FlagRow> {
         (
             "RUSTDL_FIXPOINT_DEADLINE",
             owl_dl_tableau::hyper_fixpoint_deadline_enabled,
+            true,
+        ),
+        (
+            "RUSTDL_MAX_TRIAL_MERGE",
+            owl_dl_tableau::max_trial_merge_enabled as fn() -> bool,
             true,
         ),
         (

--- a/crates/owl-dl-reasoner/tests/max_merge_pair_choice.rs
+++ b/crates/owl-dl-reasoner/tests/max_merge_pair_choice.rs
@@ -1,0 +1,117 @@
+//! Issue #76 — SOUNDNESS. `subclass` reported a subsumption that does not hold.
+//!
+//! The SROIQ `≤`-rule is don't-know NONDETERMINISTIC over which pair of
+//! witnesses to merge. `apply_max` runs inside the deterministic saturation
+//! pass and used to commit to the first pair not marked distinct; when that
+//! pair was the one inconsistent combination, its clash propagated as `Unsat`
+//! and the consistent merges were never tried — a FALSE POSITIVE.
+//!
+//! Live on the `pizza` corpus fixture as `Margherita ⊑ InterestingPizza`,
+//! which both Konclude and `HermiT` refute.
+//!
+//! THE CONTROLS ARE THE POINT. `fp` must be refuted and `entailed` must still
+//! hold: a "fix" that simply stopped deriving `≥n` subsumptions would pass the
+//! first and fail the second. `lucky` pins the diagnosis — with the disjoint
+//! pair moved, the OLD code answered correctly by accident, so the verdict
+//! flipping with WHICH pair is disjoint is what shows this was order-dependent
+//! determinism rather than semantics.
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+const A: &str = "http://ex.org/p#A";
+const I: &str = "http://ex.org/p#I";
+
+/// `A` has three `r`-successors but only `M`/`PT` are disjoint, so the
+/// `T`-successor may merge with either: a two-successor model exists and
+/// `≥3 r` is NOT entailed.
+const FP: &str = r"Prefix(:=<http://ex.org/p#>)
+Ontology(<http://ex.org/p>
+SubClassOf(:A ObjectSomeValuesFrom(:r :M))
+SubClassOf(:A ObjectSomeValuesFrom(:r :T))
+SubClassOf(:A ObjectSomeValuesFrom(:r :PT))
+DisjointClasses(:M :PT)
+EquivalentClasses(:I ObjectMinCardinality(3 :r))
+)";
+
+/// All three pairwise disjoint ⇒ no merge is possible ⇒ `≥3 r` IS entailed.
+const ENTAILED: &str = r"Prefix(:=<http://ex.org/p#>)
+Ontology(<http://ex.org/p>
+SubClassOf(:A ObjectSomeValuesFrom(:r :M))
+SubClassOf(:A ObjectSomeValuesFrom(:r :T))
+SubClassOf(:A ObjectSomeValuesFrom(:r :PT))
+DisjointClasses(:M :T :PT)
+EquivalentClasses(:I ObjectMinCardinality(3 :r))
+)";
+
+/// Same shape as `FP` with the disjoint pair moved. Not entailed either — and
+/// the OLD code got this one RIGHT, purely because the first-enumerated pair
+/// happened to be compatible.
+const LUCKY: &str = r"Prefix(:=<http://ex.org/p#>)
+Ontology(<http://ex.org/p>
+SubClassOf(:A ObjectSomeValuesFrom(:r :M))
+SubClassOf(:A ObjectSomeValuesFrom(:r :T))
+SubClassOf(:A ObjectSomeValuesFrom(:r :PT))
+DisjointClasses(:M :T)
+EquivalentClasses(:I ObjectMinCardinality(3 :r))
+)";
+
+fn onto(src: &str) -> SetOntology<RcStr> {
+    read_ofn(
+        &mut Cursor::new(src.to_owned()),
+        ParserConfiguration::default(),
+    )
+    .unwrap()
+    .0
+}
+
+fn sub(src: &str) -> bool {
+    owl_dl_reasoner::is_subclass_of(&onto(src), A, I).unwrap()
+}
+
+/// THE FIX. Konclude and `HermiT` both refute this.
+#[test]
+fn non_entailed_min_cardinality_is_refuted() {
+    assert!(
+        !sub(FP),
+        "A ⊑ ≥3 r is NOT entailed when only M/PT are disjoint — the \
+         T-successor may merge with either (issue #76)"
+    );
+}
+
+/// POSITIVE CONTROL — the fix must not work by refusing to derive `≥n`.
+#[test]
+fn genuinely_entailed_min_cardinality_still_holds() {
+    assert!(
+        sub(ENTAILED),
+        "with all three pairwise disjoint no merge is possible, so A ⊑ ≥3 r \
+         IS entailed and must still be derived"
+    );
+}
+
+/// The pair the old code happened to get right. Pins that the verdict does not
+/// depend on WHICH pair carries the disjointness.
+#[test]
+fn verdict_does_not_depend_on_which_pair_is_disjoint() {
+    assert!(!sub(LUCKY), "not entailed here either");
+    assert_eq!(
+        sub(FP),
+        sub(LUCKY),
+        "same semantics, different disjoint pair — the answers must agree; \
+         they did not before the fix, which is what identified the defect as \
+         order-dependent determinism"
+    );
+}
+
+/// `A` must remain satisfiable — a merge is available, so nothing here is
+/// contradictory. Guards against "fixing" the FP by making the probe unsat.
+#[test]
+fn the_subject_class_stays_satisfiable() {
+    for src in [FP, ENTAILED, LUCKY] {
+        assert!(owl_dl_reasoner::is_class_satisfiable(&onto(src), A).unwrap());
+    }
+}

--- a/crates/owl-dl-tableau/src/counters.rs
+++ b/crates/owl-dl-tableau/src/counters.rs
@@ -40,6 +40,10 @@ pub(crate) struct RuleCounters {
     pub(crate) add_edge_calls: Cell<u64>,
 
     pub(crate) is_blocked_calls: Cell<u64>,
+    /// Issue #76: candidate `≤n` merge pairs rejected by the trial merge
+    /// because the survivor clashed immediately. Non-zero means the old
+    /// first-pair behaviour would have committed to a contradictory merge.
+    pub(crate) max_trial_merge_rejects: Cell<u64>,
     pub(crate) is_blocked_true: Cell<u64>,
     pub(crate) is_blocked_prefilter_rejects: Cell<u64>,
     pub(crate) is_blocked_subset_scans: Cell<u64>,
@@ -118,6 +122,10 @@ impl RuleCounters {
             ("add_label_inserted", self.add_label_inserted.get()),
             ("add_edge_calls", self.add_edge_calls.get()),
             ("is_blocked_calls", self.is_blocked_calls.get()),
+            (
+                "max_trial_merge_rejects",
+                self.max_trial_merge_rejects.get(),
+            ),
             ("is_blocked_true", self.is_blocked_true.get()),
             (
                 "is_blocked_prefilter_rejects",

--- a/crates/owl-dl-tableau/src/lib.rs
+++ b/crates/owl-dl-tableau/src/lib.rs
@@ -2303,6 +2303,29 @@ fn is_subset_sorted(small: &[ConceptId], big: &[ConceptId]) -> bool {
 /// pair blocking. Read ONCE per [`TableauContext`] at construction and cached
 /// in the `anywhere_blocking` field; the hot `is_blocked` path never re-reads
 /// the environment. The reasoner crate carries a mirror `*_enabled()` for
+/// `RUSTDL_MAX_TRIAL_MERGE` — **default ON**; `=0` reverts.
+///
+/// Issue #76 (SOUNDNESS). The SROIQ `≤`-rule is don't-know nondeterministic
+/// over WHICH pair of witnesses to merge. `apply_max` runs in the
+/// deterministic saturation pass and used to commit to the first pair not
+/// marked distinct; when that pair was the one inconsistent combination its
+/// clash propagated as `Unsat`, yielding a FALSE-POSITIVE subsumption.
+///
+/// With this on, each candidate pair is merged behind a checkpoint and kept
+/// only if the survivor is clash-free, rolling back otherwise. If no pair
+/// survives, the pre-existing `Bot` arm still fires — sound, since satisfying
+/// `≤n` requires SOME merge and every candidate is immediately contradictory.
+///
+/// PARTIAL by construction: a pair that clashes only deeper is still committed
+/// to without a choice point. The complete fix is a backtrackable choice point
+/// over merge pairs in `search.rs`, which branches over CONCEPTS today and so
+/// needs a new branching primitive.
+#[must_use]
+pub fn max_trial_merge_enabled() -> bool {
+    // Default-ON idiom: an EMPTY value enables.
+    std::env::var_os("RUSTDL_MAX_TRIAL_MERGE").is_none_or(|v| v != "0")
+}
+
 /// discoverability alongside the other gate fns.
 #[must_use]
 pub fn anywhere_blocking_enabled() -> bool {

--- a/crates/owl-dl-tableau/src/rules.rs
+++ b/crates/owl-dl-tableau/src/rules.rs
@@ -964,6 +964,36 @@ pub fn apply_max(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> RuleOutc
         // R-witnesses carrying C (their edge deps + body-label deps).
         // Pass that union as merge_deps so moved labels carry it.
         let mut merged = false;
+        // Issue #76 — SOUNDNESS. The `≤`-rule is don't-know NONDETERMINISTIC
+        // over WHICH pair to merge; this loop is inside the deterministic
+        // saturation pass and used to commit to the first pair not marked
+        // distinct. When that pair was the one inconsistent combination, its
+        // clash propagated as `Unsat` and the consistent merges were never
+        // tried — a FALSE POSITIVE subsumption.
+        //
+        // Five-axiom witness (`r10b`): `A ⊑ ∃r.M, ∃r.T, ∃r.PT`,
+        // `Disjoint(M, PT)`, `I ≡ ≥3 r`. `A ⊑ I` does NOT hold (T may merge
+        // with either), but merging M's witness with PT's clashes at once and
+        // rustdl answered `yes`. It was live on `pizza`
+        // (`Margherita ⊑ InterestingPizza`, FP vs both Konclude and HermiT).
+        // The tell that it was order-dependence rather than semantics: with
+        // `Disjoint(M, T)` instead, the first-enumerated pair happens to be
+        // compatible and the answer was correct by luck.
+        //
+        // TRIAL MERGE: take a checkpoint, merge, and keep the pair only if the
+        // survivor is clash-free; otherwise roll back and try the next. If NO
+        // pair survives, fall through to the `Bot` arm exactly as before —
+        // which is sound, because a merge is required to satisfy `≤n` and every
+        // candidate is immediately contradictory.
+        //
+        // PARTIAL, and deliberately so: this removes the FP whenever some pair
+        // is immediately consistent, but a pair that clashes only DEEPER is
+        // still committed to without a choice point, so a spurious `Unsat`
+        // remains constructible. The complete fix is a backtrackable choice
+        // point in `search.rs` over merge pairs (the search driver branches
+        // over CONCEPTS today, so that needs a new branching primitive).
+        // `RUSTDL_MAX_TRIAL_MERGE=0` reverts to the first-pair behaviour.
+        let trial = crate::max_trial_merge_enabled();
         'pairs: for i in 0..c_neighbours.len() {
             for j in (i + 1)..c_neighbours.len() {
                 let a = c_neighbours[i];
@@ -972,10 +1002,18 @@ pub fn apply_max(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> RuleOutc
                     // Compute precise merge-condition deps for this pair.
                     let merge_deps: DepSet =
                         compute_max_merge_deps(ctx, node, role, body, a, b, &max_deps);
+                    let cp = trial.then(|| ctx.checkpoint());
                     if ctx.merge_into_with_deps(b, a, merge_deps.as_slice()) {
-                        applied = true;
-                        merged = true;
-                        break 'pairs;
+                        // `b` merged INTO `a`, so `a` is the survivor.
+                        if !trial || !ctx.clash_in(a) {
+                            applied = true;
+                            merged = true;
+                            break 'pairs;
+                        }
+                        crate::bump_counter!(ctx, max_trial_merge_rejects);
+                    }
+                    if let Some(cp) = cp {
+                        ctx.rollback_to(cp);
                     }
                 }
             }


### PR DESCRIPTION
Closes #76.

## The bug

The SROIQ `≤`-rule is don't-know **nondeterministic over which pair of witnesses to merge**. `apply_max` runs inside the *deterministic* saturation pass and committed to the first pair not marked distinct. When that pair was the one inconsistent combination, its clash propagated as `Unsat` — an unsound **positive** subsumption.

Five axioms:

```
SubClassOf(:A ObjectSomeValuesFrom(:r :M))
SubClassOf(:A ObjectSomeValuesFrom(:r :T))
SubClassOf(:A ObjectSomeValuesFrom(:r :PT))
DisjointClasses(:M :PT)
EquivalentClasses(:I ObjectMinCardinality(3 :r))
```

`A ⊑ I` is **not** entailed — the `T`-successor may merge with either — and rustdl answered `yes`. HermiT and Konclude both refute it.

**The tell that this was order-dependence rather than semantics:** move the disjointness to `Disjoint(M, T)` and the old code answered *correctly*, purely because the first-enumerated pair happens to be compatible.

Live on the `pizza` corpus fixture as `Margherita ⊑ InterestingPizza` and `QuattroFormaggi ⊑ InterestingPizza`. Konclude reports **20** other `X ⊑ InterestingPizza` rows and excludes exactly those two — a discriminating control, not under-reporting.

## The fix

`RUSTDL_MAX_TRIAL_MERGE` (default ON, `=0` reverts): merge each candidate pair behind a checkpoint, keep it only if the survivor is clash-free, roll back otherwise. If **no** pair survives, the pre-existing `Bot` arm still fires — sound, because satisfying `≤n` requires *some* merge and every candidate being immediately contradictory is a proof.

| case | expected | fixed | `=0` |
| --- | --- | --- | --- |
| `r10b` (the FP) | no | **no** | yes |
| `r10c` (all pairwise disjoint — genuine `≥3`) | yes | **yes** | yes |
| `r10` (was right by luck) | no | no | no |
| pizza `Margherita ⊑ InterestingPizza` | no | **no** | — |
| pizza `QuattroFormaggi ⊑ InterestingPizza` | no | **no** | — |
| pizza `American ⊑ InterestingPizza` (control) | yes | **yes** | — |

The flag is load-bearing in every fixed case, and the entailment controls survive — this removes the false positive without removing the true ones.

## Why no existing gate caught it

**`classify` never emitted the FP.** The wedge / label-heuristic path prunes those pairs before the tableau is consulted. The bug lived on the `subclass` / `explain` / `is_subclass_of` per-pair path — and the FP=0 closure-diff net diffs **classify** closures, so it is structurally blind to it.

The corpus-wide FP=0 claim in `CLAUDE.md` is a claim about `classify` and remains true. **It does not cover the per-pair query surface.**

`trust_sat` had been accidentally masking this. It surfaced only by running the FP=0 net with the #66 prototype forcing classify to tableau-adjudicate, where pizza went 499 → **501, FP=2**.

## Evidence

Full **1,920-ontology two-arm sweep** (`=0` vs default, one pinned binary with the env var the only difference, arm order alternated):

**1,774 IDENTICAL / 24 DIFFER / 121 BOTH_FAIL / 0 REGRESSED / 1 RECOVERED** (`ore_ont_1938` DNF → 40.9 s).

All 24 DIFFERs re-adjudicated by **set membership**, with the baseline run twice per ontology to separate "the binary disagrees with itself" from "the arms disagree":

- **23 do not reproduce** — identical rows, unsat, equivalence groups and `incomplete`.
- **1 is real** (`ore_ont_1508`) and **gains 4 closure pairs, loses 0**. Its Hasse row moved because the fix derived the *nearer* parent (`MP_0000217`), making the farther one (`PATO_0001555`) indirect — both are in the closure of both arms. That would have read as "the fix removed an entailment" had I stopped at `direct_subsumptions`.
- **Zero new false positives.**

**Wall −0.37%**, with both order groups agreeing (A-led −0.67%, B-led −0.09%), so the sign is meaningful here. Checkpoint/rollback in the hot saturation loop costs nothing measurable — it only fires on a *rejected* pair.

Suite **1734 / 0**. FP=0 net unchanged (11 fixtures, closures exact). `fmt` and `clippy --all-targets --all-features -D warnings` clean. Four canaries pinning the FP, the entailed control, the which-pair-is-disjoint invariance, and that the subject class stays satisfiable.

## Partial by construction — do not read this as closing the class

A pair that clashes only **deeper** is still committed to without a choice point, so a spurious `Unsat` remains constructible. The complete fix is a backtrackable choice point over merge pairs in `search.rs`, which branches over *concepts* today and needs a new branching primitive. This is stated in the flag's doc comment and in the code.

Two adjacent dependency-tracking weaknesses remain, both pre-existing and not addressed here:

- `compute_max_merge_deps` unions deps only for the merged pair, not the other witnesses whose existence triggered the merge.
- `search.rs:161` invokes the choose rule with an empty `DepSet` where the disjunction path threads `or_deps` — adjacent to a comment warning about "the soundness gap chased on pizza 2026-05-25".

## Relationship to #66

#66 asks for `classify` to be made to agree with `subclass`. On pizza the disagreement runs the other way, so doing that imports this FP. The #66 prototype is implemented and green but **held** until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
