### PR TITLE
fix(clause): negated-disjunct naming clause was unanchored — wedge Sat on a subsumed pair (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1001,6 +1001,55 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   merge; and `search.rs:161` invokes the choose rule with an EMPTY `DepSet` where the
   disjunction path threads `or_deps`.
 
+  **Negated-disjunct naming clause was UNANCHORED (2026-08-29, #78) — a wedge
+  INCOMPLETENESS, one line, unflagged.** `clause.rs`'s `head_atom_for` names a `¬A`
+  appearing as a DISJUNCT with a fresh `Q` plus `Q ⊓ A → ⊥`. That clause states a
+  UNIVERSAL property of `Q` (`∀z. ¬(Q(z) ∧ A(z))`) but was emitted on the LOCAL
+  variable. Inside a `∀` body the local variable is the successor `y`, so the clause
+  had **no `X` atom and no `Role` atom** — nothing for the matcher to anchor it to,
+  no join to bind `y` through — and could never fire. A branch whose only route to
+  closure was that clash stayed open, and the wedge returned **`Sat` for a subsumed
+  pair**. Fixed by emitting it on `X`; the returned head atom stays on `var`.
+  **Why it needed BOTH a disjunction and a negated atomic** (the bisection that found
+  it): a single-literal `∀p.¬A` goes through `emit_head`'s `Not` arm, which appends to
+  the enclosing body already carrying `Class(C,X)` + `Role(p,X,y)` — always anchored.
+  Only the disjunct path is unanchored. `∀p.(V ⊔ Z)` (no negation) and `∀p.¬R` (no
+  disjunction) were both fine; `∀p.(V ⊔ ¬R)` was not.
+  **This is the engine cause of #66** — `classify` omitting subsumptions `subclass`
+  proves. Its fixture now classifies correctly and the wedge verdict on the pair goes
+  `Sat, restores=0` → `Unsat, branches=5, restores=5`. The `restores=0` was the tell:
+  a search reporting branches but never restoring had not explored alternatives.
+  **THE CURATED CORPUS IS INERT FOR THIS** — FP=0 net 11 fixtures, closures EXACT and
+  unchanged. A green net here is non-regression only; the evidence is 5 canaries
+  (2 bug + 3 controls + a negative control), Konclude confirming all four
+  subsumptions, and one real ORE gain.
+  **Full 1,920-ontology two-arm sweep: exactly ONE real difference, and it is a pure
+  gain.** 1,796 IDENTICAL / 120 BOTH_FAIL / wall **+0.32%** (order split +2.61% /
+  −1.11%), 0 rows >1 s more than 1.5× slower. `ore_ont_778` closure **575 → 627,
+  gained 52, lost 0, FP 0** — 47 pairs directly confirmed by Konclude, the rest
+  asserted equivalences; it also derives `OmnivoreAnimal` EQUIVALENT to the four
+  `AnimalBy*Partition` classes (a 5-member group where there were 4). **Cost: that
+  ontology goes 0.88 s → 26.8 s (30×)**, and at `--pair-timeout-ms 1000` the OLD arm
+  completes while the fixed one does not — the price of the wedge no longer giving up.
+  The other three flagged rows are all noise: `ore_ont_1508` (BEFORE varies 92967 /
+  92971 / 92967, AFTER stable), and `ore_ont_10568` / `ore_ont_16462` which at a 240 s
+  cap are 72 vs 73 s and 55 vs 56 s with IDENTICAL rows — **so the sweep's one
+  "REGRESSED" and one "RECOVERED" are both 60 s cap-boundary artifacts, not effects.**
+  **METHOD WARNING — a transitive-closure script that memoises `anc(x)` under a
+  cycle-detection stack is WRONG on cyclic graphs, and equivalence groups ARE cycles.**
+  Mine reported "3 lost" then "4 lost" entailments on `ore_ont_778`; a correct
+  per-node BFS gives **lost = 0**. That is the exact shape of finding that should block
+  a merge, so verify the instrument before believing it. Use `scratchpad/closure.py`'s
+  BFS form, not a memoised recursion.
+  Canaries `crates/owl-dl-reasoner/tests/wedge_neg_disjunct_anchor.rs`; sabotage
+  (reverting `X` to `var`) fails exactly the 2 bug tests and no control.
+  **Known sibling, NOT fixed and NOT demonstrated:** the same function emits
+  `Q ∧ R(var,var) → ⊥` for `¬∃R.Self` on the local variable. It carries a `Role` atom
+  so it may be matchable, but I did not test it. Separately, `fresh_class_id`
+  (`owl-dl-reasoner/src/lib.rs`) scans `Atom::Class` and `Atom::Exists` but NOT
+  `Atom::AtMost(_, Some(c), _, _)`, so an ontology whose largest class id occurs only
+  in an `AtMost` qualifier would seed the H3b encoder too low and alias real classes.
+
 - **`crates/owl-dl-datatypes`** — concrete-domain reasoners (`card_sat`,
   interval/finite-set value ranges). **Wired into reasoning** (via the DKey
   side-map + the tableau `concrete_domain_clash`), and as of 2026-06-18 data

--- a/crates/owl-dl-core/src/clause.rs
+++ b/crates/owl-dl-core/src/clause.rs
@@ -737,10 +737,32 @@ impl Clausifier {
                 // ¬A as a disjunct: name it with a fresh class Q
                 // and the auxiliary clause Q ⊓ A → ⊥, i.e. Q means
                 // "¬A". (H1 treats Q as the negative literal.)
+                //
+                // The auxiliary clause is emitted on `X`, NOT on `var`
+                // (issue #78). It states a UNIVERSAL property of the fresh
+                // `Q` — `∀z. ¬(Q(z) ∧ A(z))` — so `X` is both correct and
+                // the only matchable choice. On `var` it was a soundness-
+                // preserving but INERT clause whenever `var != X`: with the
+                // disjunct inside a `∀` body, `var` is the successor `y`, so
+                // the clause had NO `X` atom and NO `Role` atom, leaving the
+                // matcher nothing to anchor it to and no join to bind `y`
+                // through. It could therefore never fire, and a branch whose
+                // only route to closure was this clash stayed open — the
+                // wedge reported `Sat` for a subsumed pair.
+                //
+                // Only reachable for `var != X` via a DISJUNCTIVE `∀` body:
+                // a single-literal `∀p.¬A` goes through `emit_head`'s `Not`
+                // arm instead, which appends to the enclosing body (already
+                // carrying `Class(C,X)` and `Role(p,X,y)`) and so was always
+                // anchored. That is exactly why the defect needed BOTH a
+                // disjunction and a negated atomic to appear.
+                //
+                // The returned head atom stays on `var` — that one really is
+                // about this node.
                 if let Some(a) = self.class_id_of(inner) {
                     let q = self.fresh_class();
                     self.clauses.push(DlClause {
-                        body: vec![Atom::Class(q, var), Atom::Class(a, var)],
+                        body: vec![Atom::Class(q, X), Atom::Class(a, X)],
                         head: Vec::new(),
                     });
                     Some(Atom::Class(q, var))

--- a/crates/owl-dl-reasoner/tests/wedge_neg_disjunct_anchor.rs
+++ b/crates/owl-dl-reasoner/tests/wedge_neg_disjunct_anchor.rs
@@ -1,0 +1,118 @@
+//! Issue #78 — the wedge reported `Sat` for a subsumed pair.
+//!
+//! The clausifier names a `¬A` occurring as a DISJUNCT with a fresh class `Q`
+//! plus the auxiliary clause `Q ⊓ A → ⊥`. That clause states a UNIVERSAL
+//! property of `Q`, but it was emitted on the LOCAL variable. Inside a `∀`
+//! body the local variable is the successor `y`, so the clause had no `X` atom
+//! and no `Role` atom — nothing for the matcher to anchor it to and no join to
+//! bind `y` through. It could never fire, so a branch whose only route to
+//! closure was that clash stayed open and the pair came back `Sat`.
+//!
+//! THE BISECTION IS THE POINT, and each case below is load-bearing:
+//!   * disjunction WITHOUT negation  -> no `¬A` naming at all          -> was OK
+//!   * negation WITHOUT disjunction  -> `emit_head`'s `Not` arm appends to the
+//!     enclosing body (already carrying `Class(C,X)` + `Role(p,X,y)`) -> was OK
+//!   * BOTH                          -> the only route to closure is the
+//!     unanchored clause                                              -> BROKE
+//!
+//! All four subsumptions below are confirmed by Konclude.
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+const T: &str = "http://ex#T";
+const S: &str = "http://ex#S";
+
+fn onto(body: &str) -> SetOntology<RcStr> {
+    let src = format!(
+        "Prefix(:=<http://ex#>)\nOntology(\n\
+         Declaration(Class(:A)) Declaration(Class(:V)) Declaration(Class(:R))\n\
+         Declaration(Class(:Z)) Declaration(Class(:W))\n\
+         Declaration(Class(:S)) Declaration(Class(:T))\n\
+         Declaration(ObjectProperty(:p))\n{body}\n)"
+    );
+    read_ofn(&mut Cursor::new(src), ParserConfiguration::default())
+        .unwrap()
+        .0
+}
+
+/// `classify` must contain `T ⊑ S`. This is the assertion that failed: the
+/// per-pair `subclass` path always answered correctly, so only the classify
+/// hierarchy exposes the wedge's wrong `Sat`.
+fn classify_has_t_sub_s(body: &str) -> bool {
+    let o = onto(body);
+    let c = owl_dl_reasoner::classify(&o).unwrap();
+    assert!(
+        owl_dl_reasoner::is_subclass_of(&o, T, S).unwrap(),
+        "fixture is wrong: the per-pair oracle must agree the subsumption holds"
+    );
+    c.is_subclass(T, S)
+}
+
+/// THE BUG. `T`'s only axiom IS `S`'s definition, so `T ⊑ S` is immediate —
+/// and the wedge answered `Sat`. `¬S` expands to `∃p.(R ⊓ Z)`, and the branch
+/// from `T`'s own `∀` can only close through the unanchored clash clause.
+#[test]
+fn disjunctive_forall_with_negated_atomics_is_classified() {
+    assert!(classify_has_t_sub_s(
+        "EquivalentClasses(:S ObjectAllValuesFrom(:p ObjectUnionOf(ObjectComplementOf(:R) ObjectComplementOf(:Z))))\n\
+         SubClassOf(:T ObjectAllValuesFrom(:p ObjectUnionOf(ObjectComplementOf(:R) ObjectComplementOf(:Z))))"
+    ));
+}
+
+/// The original issue-#66 shape: one negated atomic, and the entailment needs
+/// `A ⊑ V` to relate the positive disjuncts.
+#[test]
+fn disjunctive_forall_mixed_polarity_is_classified() {
+    assert!(classify_has_t_sub_s(
+        "SubClassOf(:A :V)\n\
+         EquivalentClasses(:S ObjectAllValuesFrom(:p ObjectUnionOf(:V ObjectComplementOf(:R))))\n\
+         SubClassOf(:T ObjectAllValuesFrom(:p ObjectUnionOf(:A ObjectComplementOf(:R))))"
+    ));
+}
+
+/// CONTROL — disjunction, no negation. Worked before the fix; must still work.
+/// Guards against a "fix" that merely disabled the naming path.
+#[test]
+fn disjunctive_forall_without_negation_still_classified() {
+    assert!(classify_has_t_sub_s(
+        "SubClassOf(:A :V)\n\
+         EquivalentClasses(:S ObjectAllValuesFrom(:p ObjectUnionOf(:V :Z)))\n\
+         SubClassOf(:T ObjectAllValuesFrom(:p ObjectUnionOf(:A :Z)))"
+    ));
+}
+
+/// CONTROL — negation, no disjunction. Takes `emit_head`'s `Not` arm, which
+/// was always anchored. Worked before; must still work.
+#[test]
+fn single_negated_forall_still_classified() {
+    assert!(classify_has_t_sub_s(
+        "EquivalentClasses(:S ObjectAllValuesFrom(:p ObjectComplementOf(:R)))\n\
+         SubClassOf(:T ObjectAllValuesFrom(:p ObjectComplementOf(:R)))"
+    ));
+}
+
+/// NEGATIVE CONTROL — a non-entailment must stay non-entailed. The fix makes
+/// the wedge derive MORE, so its risk direction is a false POSITIVE; without
+/// this, every test above would pass on an engine that simply asserted
+/// everything.
+#[test]
+fn unrelated_forall_bodies_are_not_subsumed() {
+    let o = onto(
+        "EquivalentClasses(:S ObjectAllValuesFrom(:p ObjectUnionOf(ObjectComplementOf(:R) ObjectComplementOf(:Z))))\n\
+         SubClassOf(:T ObjectAllValuesFrom(:p ObjectUnionOf(:V :W)))",
+    );
+    assert!(
+        !owl_dl_reasoner::is_subclass_of(&o, T, S).unwrap(),
+        "unrelated ∀ bodies must NOT subsume"
+    );
+    let c = owl_dl_reasoner::classify(&o).unwrap();
+    assert!(
+        !c.is_subclass(T, S),
+        "classify must not invent the subsumption"
+    );
+}


### PR DESCRIPTION
Closes #78. **Also the engine cause of #66** — that issue's fixture now classifies correctly.

## The bug, in one line

`head_atom_for` names a `¬A` appearing as a **disjunct** with a fresh class `Q` plus `Q ⊓ A → ⊥`. That auxiliary clause states a **universal** property of `Q` — `∀z. ¬(Q(z) ∧ A(z))` — but it was emitted on the **local** variable:

```rust
- body: vec![Atom::Class(q, var), Atom::Class(a, var)],
+ body: vec![Atom::Class(q, X),   Atom::Class(a, X)],
```

Inside a `∀` body the local variable is the successor `y`, so the clause had **no `X` atom and no `Role` atom** — nothing for the matcher to anchor it to, and no join to bind `y` through. It could never fire. A branch whose only route to closure was that clash stayed open, and the wedge returned **`Sat` for a subsumed pair**.

The returned head atom stays on `var`; that one really is about this node.

## Why it needed *both* a disjunction and a negated atomic

This is what located it. A single-literal `∀p.¬A` goes through `emit_head`'s `Not` arm, which appends to the enclosing body — already carrying `Class(C,X)` and `Role(p,X,y)` — so it was always anchored. Only the disjunct path was unanchored.

| `∀` body | before |
| --- | --- |
| `∀p.V` | ok |
| `∀p.(V ⊔ Z)` — disjunction, no negation | ok |
| `∀p.¬R` — negation, no disjunction | ok |
| **`∀p.(V ⊔ ¬R)` — both** | **`Sat` on a subsumed pair** |

The wedge verdict on #66's pair goes `Sat, restores=0` → **`Unsat, branches=5, restores=5`**. That `restores=0` was the tell: a search reporting branches but never restoring had not actually explored its alternatives.

## Evidence — and the corpus is not most of it

**The curated corpus is inert for this fix**: FP=0 net, 11 fixtures, closures exact and *unchanged*. That green is non-regression only, and I'd rather say so than present it as validation. What carries it:

- **5 canaries** — 2 for the bug, 2 controls that were already passing and must stay passing (guarding against a "fix" that just asserts more), 1 negative control for the inverted FP risk. **Sabotage**: reverting `X` to `var` fails exactly the 2 bug tests and no control.
- **Konclude confirms** all four subsumptions used in the canaries.
- **Full 1,920-ontology two-arm sweep**, pinned binaries, arm order alternated: **1,796 IDENTICAL / 120 BOTH_FAIL**, wall **+0.32%** (order split +2.61% / −1.11%), **0 rows >1 s more than 1.5× slower**.

**Exactly one real difference across the corpus, and it is a pure gain.** `ore_ont_778`: closure **575 → 627, gained 52, lost 0, FP 0** — 47 pairs directly confirmed by Konclude, the remainder asserted equivalences. It also newly derives `OmnivoreAnimal` **equivalent** to the four `AnimalBy*Partition` classes (a 5-member group where there were 4).

## Cost, stated plainly

`ore_ont_778` goes **0.88 s → 26.8 s (30×)**, and at `--pair-timeout-ms 1000` the *old* arm completes while the fixed one does not. That is the price of the wedge no longer giving up early, and it buys the 52 entailments above. It is isolated rather than systemic — corpus wall is +0.32% and nothing else moved.

## Two flagged rows that turned out to be nothing

The sweep's one `REGRESSED` and one `RECOVERED` are both **60 s cap-boundary artifacts**. At a 240 s cap, `ore_ont_10568` is 72 s vs 73 s and `ore_ont_16462` is 55 s vs 56 s — both with **identical rows**. `ore_ont_1508`'s diff is its documented nondeterminism (BEFORE varies 92967 / 92971 / 92967; AFTER stable).

## Method warning now in `CLAUDE.md`

A transitive-closure script that memoises `anc(x)` under a cycle-detection stack is **wrong on cyclic graphs** — and equivalence groups *are* cycles. Mine reported "3 lost" and then "4 lost" entailments on `ore_ont_778`; a correct per-node BFS gives **lost = 0**. "A strictly more complete engine lost entailments" is exactly the finding that should block a merge, so the instrument has to be verified before the result is believed.

## Not fixed, not demonstrated, recorded

- The `¬∃R.Self` sibling in the same function emits `Q ∧ R(var,var) → ⊥` on the local variable. It carries a `Role` atom so it may well be matchable — I did not test it either way.
- `fresh_class_id` scans `Atom::Class` and `Atom::Exists` but **not** `Atom::AtMost(_, Some(c), _, _)`, so an ontology whose largest class id occurs only in an `AtMost` qualifier would seed the H3b encoder too low and alias real classes.

Suite **1738 / 0**; `fmt` and `clippy --all-targets --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
