### PR TITLE
test(gate): gate the per-pair FP surface — the net's blindness, made reproducible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -983,6 +983,22 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   MASKING this: it was found only by running the FP=0 net with the #66 prototype
   (`RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1`) forcing classify to tableau-adjudicate, where
   pizza went 499 → **501, FP=2**.
+  **THAT GAP IS NOW GATED (2026-08-30) — `crates/owl-dl-reasoner/tests/per_pair_fp_gate.rs`.**
+  The instrument that found #76 was never in `main`; it lived only on the superseded
+  `fix/classify-verify-refutations-66` branch, so once #66 was fixed at root by #78/#83 the
+  per-pair surface went back to being ungated. `RUSTDL_CLASSIFY_VERIFY_REFUTATIONS` is now
+  in-tree (still **default OFF** — its completeness benefit measured ZERO corpus-wide against
+  +21.6% wall, so it is an instrument, not a policy), and one `#[ignore]`d test runs the
+  oracle diff under it over pizza/ro/sulo — the out-of-EL fixtures, since the flag is gated on
+  `OutOfFragment` and is INERT on `PureEl`/`Horn` (bibtex is Horn and is deliberately excluded:
+  a fixture where the flag cannot engage would pad the gate without testing it).
+  **The control is what licenses the gate, not the pass.** Same sabotage
+  (`RUSTDL_MAX_TRIAL_MERGE=0`, reverting #76), two nets: the classify-only net reports
+  `pizza 499=499 FP=0 MISSED=0 VERIFIED` — **blind, passing on a live FP** — while the new gate
+  reports **501 vs 499, FP=2**, naming `Margherita`/`QuattroFormaggi ⊑ InterestingPizza` and
+  failing. So the months-long invisibility of #76 is now reproducible on demand rather than
+  argued. Re-run that sabotage after touching either flag; a gate that cannot be made to fail
+  is not a gate.
   **Evidence:** full 1,920-ontology two-arm sweep (`=0` vs default, one pinned binary, env
   var the only difference, arm order alternated): **1,774 IDENTICAL / 24 DIFFER / 121
   BOTH_FAIL / 0 REGRESSED / 1 RECOVERED** (`ore_ont_1938` DNF → 40.9 s). All 24 DIFFERs

--- a/crates/owl-dl-cli/src/json_out.rs
+++ b/crates/owl-dl-cli/src/json_out.rs
@@ -41,11 +41,58 @@ pub(crate) fn dropped_block(onto: &SetOntology<RcStr>) -> BTreeMap<String, u64> 
         .unwrap_or_default()
 }
 
+/// Pairs whose "not subsumed" came from the wedge's `Sat` verdict on an
+/// ontology outside the fragment where that verdict is complete by
+/// construction (issue #66).
+///
+/// **This is an EXPOSURE count, not a defect count, and the difference is
+/// measured.** It reads 58 on `ro`, 163 on `sio` and 102 on `pizza` — all
+/// three of which are MISSED=0 against the Konclude oracle in the FP=0 net.
+/// So a non-zero value says these pairs were decided WITHOUT the tableau, not
+/// that any of them is wrong. It is emitted as a diagnostic for exactly that
+/// reason; an earlier revision raised a stderr WARNING here and was withdrawn
+/// once those three numbers were measured, because a warning that fires on
+/// three verifiably-correct flagship fixtures trains users to ignore the
+/// channel.
+///
+/// What it IS good for: a consumer that needs exactness (the issue-#66
+/// reporter was diffing two `classify` hierarchies) can see that the
+/// hierarchy contains un-tableau-verified refutations and re-run with
+/// `RUSTDL_HYPERTABLEAU_TRUST_SAT=0`, or ask `subclass` per pair.
+///
+/// `PureEl` and `Horn` return 0: `trust_sat` is complete by construction there
+/// (the saturator carries `PureEl`, the Horn fixpoint carries `Horn`), so
+/// there is no exposure to report.
+pub(crate) fn trusted_sat_risk(stats: &owl_dl_reasoner::ClassificationStats) -> usize {
+    if matches!(
+        stats.fragment,
+        owl_dl_reasoner::FragmentClassification::OutOfFragment
+    ) {
+        stats.hyper_refuted_pairs
+    } else {
+        0
+    }
+}
+
 #[derive(Serialize)]
 pub(crate) struct ClassifyJson {
     pub(crate) schema_version: u32,
     pub(crate) consistent: bool,
+    /// A class pair hit a DEADLINE and was recorded as not-subsumed. Reports
+    /// only that; it does NOT cover the `trust_sat` risk below.
     pub(crate) incomplete: bool,
+    /// Issue #66: pairs concluded NOT SUBSUMED from the wedge's own `Sat`
+    /// verdict, on an ontology OUTSIDE the fragment where that verdict is
+    /// complete by construction — so this hierarchy CAN disagree with
+    /// `rustdl subclass` on the same binary and the same pair while
+    /// `incomplete` stays `false`. An EXPOSURE count, not a defect count:
+    /// see [`trusted_sat_risk`] for the measured false-alarm rate.
+    ///
+    /// Deliberately a SEPARATE field rather than folded into `incomplete`:
+    /// that flag means "a deadline fired", and overloading it would destroy a
+    /// distinction callers already depend on. Same reasoning as
+    /// `Realization::witness_prune_active`.
+    pub(crate) trusted_sat_refutations: usize,
     pub(crate) unsatisfiable: Vec<String>,
     pub(crate) equivalent_groups: Vec<Vec<String>>,
     pub(crate) direct_subsumptions: Vec<[String; 2]>,
@@ -233,6 +280,7 @@ pub(crate) fn build_classify_json(
         schema_version: SCHEMA_VERSION,
         consistent: !stats.inconsistent,
         incomplete: stats.timed_out_pairs > 0,
+        trusted_sat_refutations: trusted_sat_risk(&stats),
         unsatisfiable,
         equivalent_groups: groups,
         direct_subsumptions,

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -1136,6 +1136,14 @@ fn write_classification<W: Write>(out: &mut W, h: &Classification) -> std::io::R
             stats.timed_out_pairs
         )?;
     }
+    let tsr = json_out::trusted_sat_risk(&stats);
+    if tsr > 0 {
+        writeln!(
+            out,
+            "# trusted-Sat refutations: {tsr} (decided without the tableau; \
+             see issue #66 — NOT an error signal, this is 0 MISSED on ro/sio/pizza)"
+        )?;
+    }
     if stats.hyper_proven_pairs > 0 {
         writeln!(
             out,

--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -4771,6 +4771,25 @@ fn subsumes_via_tableau(
     counting_relevant: &std::collections::HashSet<owl_dl_core::ClassId>,
     stats: &mut ClassificationStats,
 ) -> Result<Option<bool>, ReasonError> {
+    // Issue #66 (`RUSTDL_CLASSIFY_VERIFY_REFUTATIONS`, default OFF). Out of the
+    // fragment where the wedge's `Sat` verdict is complete BY CONSTRUCTION,
+    // trusting it can silently drop a real subsumption — `classify` omitted
+    // `Cap ⊑ VE` while `rustdl subclass` on the SAME binary proved it. When the
+    // flag is on, withdraw the trust exactly there and let the pair fall
+    // through to the tableau.
+    //
+    // Gated on the FRAGMENT, not applied blanket, so `PureEl`/`Horn` inputs keep
+    // the fast path: the saturator carries `PureEl` and the Horn fixpoint
+    // carries `Horn`, so a trusted `Sat` on those cannot be wrong and verifying
+    // it would be pure cost. That is what makes this cheaper than
+    // `RUSTDL_HYPERTABLEAU_TRUST_SAT=0` for the same completeness.
+    //
+    // `stats.fragment` is stamped before the pair loop, so reading it here is
+    // one gate covering every call site rather than four threaded parameters.
+    let trust_sat = trust_sat
+        && !(crate::classify_verify_refutations_enabled()
+            && matches!(stats.fragment, FragmentClassification::OutOfFragment));
+
     // Phase 1b snapshot-replay shortcut. When RUSTDL_SNAPSHOT_CAPTURE
     // is ON AND the ontology is BackPropRisk::Safe, consult the per-class
     // snapshot cache before the wedge. A snapshot for `sub` is built on

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -1964,6 +1964,51 @@ pub fn hyper_sat_seed_enabled() -> bool {
 /// (`process_fact` range propagation, fixed in f71a012), not a
 /// wedge bug. Disable with `RUSTDL_HYPERTABLEAU_TRUST_SAT=0`. Off ⇒
 /// `Sat` verdicts are treated as `Unknown` (older H4 behaviour, falls
+/// `RUSTDL_CLASSIFY_VERIFY_REFUTATIONS` — **default OFF**, `=1` opts in.
+///
+/// When ON, `classify` stops trusting the wedge's `Sat` verdict on ontologies
+/// OUTSIDE the fragment where that verdict is complete by construction, and
+/// falls through to the tableau instead. This closes issue #66, where
+/// `classify` omitted `Cap ⊑ VE` while `rustdl subclass` on the SAME binary
+/// proved it — the wedge is incomplete on that ALC pattern (`∀p.(A ⊔ ¬R)`
+/// with `A ⊑ V`, `V ⊑ R`, `Disjoint(Pizza, R)`) and `trust_sat` believed it.
+/// `incomplete` stayed `false` throughout, so a consumer could not tell; a
+/// migration tool diffing two hierarchies read the absences as real and
+/// reported ~46% spurious "lost" subsumptions.
+///
+/// **Not cheaper than `RUSTDL_HYPERTABLEAU_TRUST_SAT=0` in practice — measured,
+/// after an earlier draft of this comment claimed it was.** The gate is keyed on
+/// the exact condition that makes the trust unsound-for-completeness, so in
+/// principle it spares `PureEl`/`Horn` inputs a pointless verification. In
+/// practice those take the saturation fast path and never reach the pair loop,
+/// so essentially everything reaching this gate is ALREADY out-of-fragment.
+/// Head to head on the two most expensive cases from the sweep: `ore_ont_7011`
+/// 1.49 s default / 23.68 s `TRUST_SAT=0` / **23.59 s** here, and `ore_ont_5964`
+/// 26.75 s / **26.75 s** — identical, and all five worst slowdown cases are
+/// out-of-EL. What it offers is PRECISION OF MEANING, not speed: "verify where
+/// verification is needed" rather than "switch off an optimisation", and it
+/// cannot regress an in-fragment input if the fast path ever stops covering one.
+///
+/// **OFF by default because the measured benefit on real ontologies is zero.**
+/// A two-arm sweep of all 1,920 ORE ontologies (default vs `TRUST_SAT=0`, one
+/// pinned binary, env var the only difference) found **1,700 IDENTICAL, 91
+/// DIFFER of which 89 are the `incomplete` flag alone**; both count-differing
+/// cases cleared on adjudication (`ore_ont_16420` budget noise, re-run identical
+/// with closure 183363 both; `ore_ont_6485`'s extra pair found by BOTH arms at
+/// `--pair-timeout-ms 1000`). So **zero entailments recovered corpus-wide**,
+/// against **+21.6% wall** (1611 s → 1959 s over the 1,700 completing in both),
+/// 20 ontologies >2× slower, and 5 that stop completing at all.
+///
+/// #66 is real and reproducible on its 6-axiom fixture but does not occur in
+/// 1,920 real ontologies, so exactness is offered rather than imposed. The
+/// sweep's censoring runs one way — 123 `BOTH_FAIL` + 5 `REGRESSED` are ontologies
+/// where the verifying arm never finished and so COULD NOT report a gain; zero
+/// is a lower bound.
+#[must_use]
+pub fn classify_verify_refutations_enabled() -> bool {
+    std::env::var_os("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS").is_some_and(|v| v == "1")
+}
+
 /// through to the tableau).
 #[must_use]
 pub fn hyper_trust_sat_enabled() -> bool {

--- a/crates/owl-dl-reasoner/tests/classify_verify_refutations.rs
+++ b/crates/owl-dl-reasoner/tests/classify_verify_refutations.rs
@@ -15,6 +15,27 @@
 //! It is OFF by default: a two-arm sweep of all 1,920 ORE ontologies found
 //! **zero** entailments recovered corpus-wide against +21.6% wall, so the
 //! pattern is real but does not occur in real ontologies.
+//!
+//! ## #66 IS CLOSED, AND NOT BY THIS FLAG (2026-08-30)
+//!
+//! #78/#83 fixed the underlying wedge incompleteness at ROOT: `head_atom_for`
+//! emitted the fresh-`Q` naming clause on the successor variable when the clause
+//! states a UNIVERSAL property, leaving it with no `X` atom and no `Role` atom —
+//! unmatchable, never fired, so the wedge returned `Sat` on genuinely subsumed
+//! pairs. `Cap ⊑ VE` is therefore now found **at the default**, flag or no flag.
+//!
+//! Two tests in this file asserted the OPPOSITE and failed the moment the branch
+//! was rebased onto that fix — `flag_off_reproduces_the_defect` and the
+//! behavioural half of `default_is_off`. They were correct when written and are
+//! kept here, inverted, because the flip is the evidence that #66 is closed by a
+//! mechanism rather than by assertion. Both now pin the fixed behaviour.
+//!
+//! **What the flag is still FOR.** Not completeness — that is settled. It is the
+//! only in-tree way to route `classify` through the per-pair tableau, which is
+//! what makes per-pair false positives visible to an oracle diff. It is the
+//! instrument that found #76, and
+//! `crates/owl-dl-reasoner/tests/per_pair_fp_gate.rs` is the standing gate built
+//! on it. Keep the flag even though its original rationale has evaporated.
 #![allow(clippy::unwrap_used)]
 
 use horned_owl::io::ParserConfiguration;
@@ -103,26 +124,36 @@ fn flag_on_classify_agrees_with_subclass() {
     );
 }
 
-/// NEGATIVE CONTROL — the flag is LOAD-BEARING. Off (the default), the
-/// subsumption is still missing. Without this, the test above could pass for
-/// some unrelated reason and the flag would be doing nothing.
+/// WAS a negative control asserting the flag was load-bearing for #66; it
+/// asserted `!is_subclass(CAP, VE)` with the flag OFF and **failed on rebase**,
+/// exactly as its own message instructed ("if this now passes, the defect was
+/// closed elsewhere"). It was: #78/#83 fixed the wedge at root. Inverted, it now
+/// pins that the fix is real and independent of this flag — which is also what
+/// makes the flag safe to keep purely as an FP instrument.
 #[test]
-fn flag_off_reproduces_the_defect() {
+fn sixty_six_is_closed_at_the_default_without_this_flag() {
     let _l = ENV
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _g = set_flag(Some("0"));
     let c = owl_dl_reasoner::classify(&onto(MIN66)).unwrap();
     assert!(
-        !c.is_subclass(CAP, VE),
-        "flag OFF must reproduce issue #66 — if this now passes, the defect \
-         was closed elsewhere and this flag's rationale needs re-checking"
+        c.is_subclass(CAP, VE),
+        "issue #66 must stay closed at the DEFAULT — #78/#83 fixed the wedge \
+         clause anchoring at root, so `Cap ⊑ VE` must be found with \
+         RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=0. A failure here means that root \
+         fix regressed, NOT that this flag is needed again."
     );
 }
 
-/// The default is OFF, so the shipped behaviour is unchanged. Pinned here as
-/// well as in `flag_defaults.rs` because the DEFAULT is the whole reason this
-/// is safe to merge without a corpus flip.
+/// The default is OFF. Pinned here as well as in `flag_defaults.rs` because the
+/// default is the whole reason the flag is safe to carry: enabling it costs
+/// +21.6% wall corpus-wide and recovers nothing.
+///
+/// The second assertion USED to read `!c.is_subclass(CAP, VE)` ("default must be
+/// unchanged") and failed on rebase. That was not a regression: #78/#83 closed
+/// #66 at root, so the unflagged default now finds the subsumption. Asserting
+/// the live behaviour keeps this a real check rather than a stale one.
 #[test]
 fn default_is_off() {
     let _l = ENV
@@ -131,7 +162,10 @@ fn default_is_off() {
     let _g = set_flag(None);
     assert!(!owl_dl_reasoner::classify_verify_refutations_enabled());
     let c = owl_dl_reasoner::classify(&onto(MIN66)).unwrap();
-    assert!(!c.is_subclass(CAP, VE), "default must be unchanged");
+    assert!(
+        c.is_subclass(CAP, VE),
+        "unset must behave as `0`, and at `0` #66 is closed by #78/#83"
+    );
 }
 
 /// The flag must NOT invent subsumptions. It makes classify do MORE tableau

--- a/crates/owl-dl-reasoner/tests/classify_verify_refutations.rs
+++ b/crates/owl-dl-reasoner/tests/classify_verify_refutations.rs
@@ -1,0 +1,170 @@
+//! Issue #66 — `classify` omitted a subsumption that `subclass` on the SAME
+//! binary proves.
+//!
+//! Out of the fragment where the wedge's `Sat` verdict is complete BY
+//! CONSTRUCTION, `trust_sat` concludes "not subsumed" without consulting the
+//! tableau. On this 6-axiom ALC fixture the wedge is incomplete
+//! (`∀p.(A ⊔ ¬R)` against `A ⊑ V`, `V ⊑ R`, `Disjoint(Pizza, R)`), so
+//! `Cap ⊑ VE` was silently absent from the hierarchy while `subclass`,
+//! `prove` and `HermiT` all confirm it — and `incomplete` stayed `false`, so a
+//! consumer could not tell. A migration tool diffing two `classify`
+//! hierarchies read those absences as real and reported ~46% spurious "lost"
+//! subsumptions.
+//!
+//! `RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1` withdraws the trust exactly there.
+//! It is OFF by default: a two-arm sweep of all 1,920 ORE ontologies found
+//! **zero** entailments recovered corpus-wide against +21.6% wall, so the
+//! pattern is real but does not occur in real ontologies.
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+use std::sync::Mutex;
+
+/// Serialises env mutation within this binary — these tests set a process-wide
+/// variable, so they must not run concurrently with each other.
+static ENV: Mutex<()> = Mutex::new(());
+
+struct Guard(Option<std::ffi::OsString>);
+impl Drop for Guard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        // SAFETY: single-threaded within the ENV mutex.
+        unsafe {
+            match self.0.take() {
+                Some(v) => std::env::set_var("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS", v),
+                None => std::env::remove_var("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS"),
+            }
+        }
+    }
+}
+#[allow(unsafe_code)]
+fn set_flag(v: Option<&str>) -> Guard {
+    let g = Guard(std::env::var_os("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS"));
+    // SAFETY: single-threaded within the ENV mutex.
+    unsafe {
+        match v {
+            Some(x) => std::env::set_var("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS", x),
+            None => std::env::remove_var("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS"),
+        }
+    }
+    g
+}
+
+/// The issue's own fixture, verbatim.
+const MIN66: &str = r"Prefix(:=<http://ex#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(
+Declaration(Class(:A)) Declaration(Class(:V)) Declaration(Class(:R)) Declaration(Class(:Pizza)) Declaration(Class(:Cap)) Declaration(Class(:VE))
+Declaration(ObjectProperty(:p))
+SubClassOf(:A :V)
+SubClassOf(:Cap :Pizza)
+SubClassOf(:V :R)
+DisjointClasses(:Pizza :R)
+EquivalentClasses(:VE ObjectIntersectionOf(:Pizza ObjectAllValuesFrom(:p ObjectUnionOf(:V ObjectComplementOf(:R)))))
+SubClassOf(:Cap ObjectAllValuesFrom(:p ObjectUnionOf(:A ObjectComplementOf(:R))))
+)";
+
+const CAP: &str = "http://ex#Cap";
+const VE: &str = "http://ex#VE";
+
+fn onto(src: &str) -> SetOntology<RcStr> {
+    read_ofn(
+        &mut Cursor::new(src.to_owned()),
+        ParserConfiguration::default(),
+    )
+    .unwrap()
+    .0
+}
+
+/// `subclass` proves it. This is the ground truth the hierarchy must match,
+/// and it is independent of the flag.
+#[test]
+fn subclass_proves_the_subsumption() {
+    let o = onto(MIN66);
+    assert!(owl_dl_reasoner::is_subclass_of(&o, CAP, VE).unwrap());
+}
+
+/// THE FIX: with the flag on, `classify` agrees with `subclass`.
+#[test]
+fn flag_on_classify_agrees_with_subclass() {
+    let _l = ENV
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _g = set_flag(Some("1"));
+    let c = owl_dl_reasoner::classify(&onto(MIN66)).unwrap();
+    assert!(
+        c.is_subclass(CAP, VE),
+        "with RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1, classify must not omit \
+         a subsumption `subclass` proves (issue #66)"
+    );
+}
+
+/// NEGATIVE CONTROL — the flag is LOAD-BEARING. Off (the default), the
+/// subsumption is still missing. Without this, the test above could pass for
+/// some unrelated reason and the flag would be doing nothing.
+#[test]
+fn flag_off_reproduces_the_defect() {
+    let _l = ENV
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _g = set_flag(Some("0"));
+    let c = owl_dl_reasoner::classify(&onto(MIN66)).unwrap();
+    assert!(
+        !c.is_subclass(CAP, VE),
+        "flag OFF must reproduce issue #66 — if this now passes, the defect \
+         was closed elsewhere and this flag's rationale needs re-checking"
+    );
+}
+
+/// The default is OFF, so the shipped behaviour is unchanged. Pinned here as
+/// well as in `flag_defaults.rs` because the DEFAULT is the whole reason this
+/// is safe to merge without a corpus flip.
+#[test]
+fn default_is_off() {
+    let _l = ENV
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _g = set_flag(None);
+    assert!(!owl_dl_reasoner::classify_verify_refutations_enabled());
+    let c = owl_dl_reasoner::classify(&onto(MIN66)).unwrap();
+    assert!(!c.is_subclass(CAP, VE), "default must be unchanged");
+}
+
+/// The flag must NOT invent subsumptions. It makes classify do MORE tableau
+/// work, so its risk direction is a false POSITIVE — the opposite of the
+/// default path's. Every pair the flag-on hierarchy reports must also be
+/// reported by `is_subclass_of`, which is the complete per-pair oracle.
+#[test]
+fn flag_on_introduces_no_subsumption_the_oracle_rejects() {
+    let _l = ENV
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _g = set_flag(Some("1"));
+    let o = onto(MIN66);
+    let c = owl_dl_reasoner::classify(&o).unwrap();
+    let names = [
+        "http://ex#A",
+        "http://ex#V",
+        "http://ex#R",
+        "http://ex#Pizza",
+        CAP,
+        VE,
+    ];
+    for sub in names {
+        for sup in names {
+            if sub == sup {
+                continue;
+            }
+            if c.is_subclass(sub, sup) {
+                assert!(
+                    owl_dl_reasoner::is_subclass_of(&o, sub, sup).unwrap(),
+                    "classify reported {sub} ⊑ {sup} but the per-pair oracle refutes it"
+                );
+            }
+        }
+    }
+}

--- a/crates/owl-dl-reasoner/tests/flag_defaults.rs
+++ b/crates/owl-dl-reasoner/tests/flag_defaults.rs
@@ -87,6 +87,11 @@ fn expected() -> Vec<FlagRow> {
             true,
         ),
         (
+            "RUSTDL_CLASSIFY_VERIFY_REFUTATIONS",
+            owl_dl_reasoner::classify_verify_refutations_enabled as fn() -> bool,
+            false,
+        ),
+        (
             "RUSTDL_INVERSE_PAIR_FUNC",
             owl_dl_core::convert::inverse_pair_functionality_enabled,
             false,

--- a/crates/owl-dl-reasoner/tests/per_pair_fp_gate.rs
+++ b/crates/owl-dl-reasoner/tests/per_pair_fp_gate.rs
@@ -1,0 +1,165 @@
+//! The PER-PAIR false-positive gate.
+//!
+//! ## Why this file exists
+//!
+//! `konclude_closure_diff.rs` — the FP=0 net — diffs **`classify`** closures.
+//! Issue #76 was a REAL false positive (the SROIQ `≤n` rule committed to the
+//! first merge pair and never reconsidered, so a clash on that arbitrary choice
+//! reported a satisfiable concept unsatisfiable). It lived on the
+//! `subclass` / `explain` / `is_subclass_of` **per-pair** path, which `classify`
+//! never consults while `trust_sat` is on. The net was therefore *structurally
+//! blind* to it and it shipped for months, on `pizza` — a flagship fixture the
+//! net checks on every run and reported FP=0 for throughout.
+//!
+//! So "FP=0 corpus-wide" was, and still is, a claim about `classify` alone.
+//! This file gates the other surface.
+//!
+//! ## How it gates it
+//!
+//! `RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1` withdraws the wedge `Sat`-trust on
+//! out-of-fragment ontologies, so every refuted pair falls through to the same
+//! tableau the per-pair surface uses. Running the oracle diff under that flag
+//! therefore audits the per-pair path with the existing net's machinery, rather
+//! than reimplementing closure diffing (which `oracle_diff` owns).
+//!
+//! The flag is gated on `OutOfFragment`, so it is INERT on `PureEl`/`Horn`
+//! inputs — `bibtex` is Horn and is deliberately not a case here, because a
+//! fixture where the flag cannot engage would pad the gate without testing it.
+//!
+//! ## Sabotage-validated — re-run this after touching either flag
+//!
+//! With `RUSTDL_MAX_TRIAL_MERGE=0` (which reverts the #76 fix) this test FAILS:
+//! pizza closure **501 vs oracle 499, FP=2**, naming
+//! `Margherita ⊑ InterestingPizza` and `QuattroFormaggi ⊑ InterestingPizza` —
+//! exactly the two pairs the #76 investigation identified, and exactly the
+//! numbers the held #66 branch recorded before #76 landed. A gate that cannot
+//! be made to fail is not a gate.
+//!
+//! Fixtures live under the gitignored `ontologies/`, so this is `#[ignore]`d and
+//! **panics** when they are absent rather than passing vacuously — the failure
+//! mode `family-stripped` demonstrates elsewhere in the suite.
+
+#![allow(clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use owl_dl_reasoner::oracle_diff::{aligned_closures, read_owx_verdict};
+use std::collections::BTreeSet;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// `set_var` guard: restores the prior value on drop. Mirrors the pattern in
+/// `adaptive_inconsistency_budget.rs`.
+struct SetEnvGuard {
+    key: &'static str,
+    prior: Option<std::ffi::OsString>,
+}
+
+impl SetEnvGuard {
+    #[allow(unsafe_code)]
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var_os(key);
+        // SAFETY: `set_var` is unsafe under edition 2024 because it races with
+        // concurrent readers. This test binary contains exactly ONE test, so no
+        // other thread is reading the environment; the value is restored on drop.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prior }
+    }
+}
+
+impl Drop for SetEnvGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        // SAFETY: see `set`.
+        unsafe {
+            match self.prior.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn load(path: &Path) -> SetOntology<RcStr> {
+    let src =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) = read_ofn(&mut reader, ParserConfiguration::default())
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    onto
+}
+
+/// `(label, ontology, oracle)`. Every case is REQUIRED: a missing fixture fails
+/// the test with the path, because a skipped case is indistinguishable from a
+/// passing one in the log.
+fn cases() -> Vec<(&'static str, PathBuf, PathBuf)> {
+    let base = Path::new("../../ontologies/real");
+    ["pizza", "ro", "sulo"]
+        .iter()
+        .map(|n| {
+            (
+                *n,
+                base.join(format!("{n}.ofn")),
+                base.join(format!("konclude-input/{n}-classified.owx")),
+            )
+        })
+        .collect()
+}
+
+#[test]
+#[ignore = "needs the gitignored ontologies/real/{pizza,ro,sulo}.ofn + konclude-input/*-classified.owx; \
+            runs classify with the wedge Sat-trust withdrawn, so it is slower than the plain net"]
+fn per_pair_path_has_no_false_positives() {
+    // Withdraw the wedge `Sat`-trust so refuted pairs reach the tableau — the
+    // code path `subclass`/`is_subclass_of` use, and the one #76 was wrong on.
+    let _guard = SetEnvGuard::set("RUSTDL_CLASSIFY_VERIFY_REFUTATIONS", "1");
+
+    let mut offenders: Vec<String> = Vec::new();
+    let mut checked: Vec<&str> = Vec::new();
+
+    for (label, input, truth) in cases() {
+        assert!(
+            input.exists() && truth.exists(),
+            "[pp-fp] REQUIRED fixture `{label}` is missing ({} or {}). \
+             Fetch with ./scripts/fetch-real-ontologies.sh and generate the oracle with \
+             scripts/konclude-oracle.sh — do NOT silently skip: a vacuous pass here reads \
+             identically to a real one.",
+            input.display(),
+            truth.display(),
+        );
+
+        let onto = load(&input);
+        let c = classify_top_down_with_timeout(&onto, Duration::from_millis(200))
+            .unwrap_or_else(|e| panic!("classify {label}: {e:?}"));
+        let verdict = read_owx_verdict(&truth).expect("read oracle verdict");
+        let (rustdl, oracle) = aligned_closures(&c, &verdict);
+        let fp: BTreeSet<_> = rustdl.difference(&oracle).cloned().collect();
+
+        eprintln!(
+            "[pp-fp] {label}: rustdl={} oracle={} FP={}",
+            rustdl.len(),
+            oracle.len(),
+            fp.len()
+        );
+        for (s, t) in fp.iter().take(5) {
+            eprintln!("[pp-fp]   FP: {s} ⊑ {t}");
+        }
+        if !fp.is_empty() {
+            offenders.push(format!("{label} (FP={})", fp.len()));
+        }
+        checked.push(label);
+    }
+
+    eprintln!("[pp-fp] checked: {}", checked.join(", "));
+    assert!(
+        offenders.is_empty(),
+        "[pp-fp] the PER-PAIR path reports subsumptions the oracle rejects: {}. \
+         This is a soundness regression on `subclass`/`is_subclass_of`, which the \
+         classify-only FP=0 net cannot see (that is why #76 shipped for months).",
+        offenders.join(", "),
+    );
+}

--- a/docs/releases/RELEASE-PROCESS.md
+++ b/docs/releases/RELEASE-PROCESS.md
@@ -19,9 +19,27 @@ Cross-references name the incident.
 | **corpus report + verdict gate** | `owl-reasoner-harness/scripts/release-corpus-report.sh <version> <binary> <prev-baseline.json>` | **answer changes**, wall/RSS drift | ~20 min |
 | **two-arm full sweep** | harness `run` over all 1,920, previous release vs candidate | `ok → dnf` regressions | ~4 h/arm |
 | **MISSED net** (when trading completeness) | `missed-net.sh sweep/net` | ΔMISSED vs Konclude ∪ HermiT | ~10 min/arm |
+| **per-pair FP gate** | `cargo test -p owl-dl-reasoner --test per_pair_fp_gate -- --ignored` | false positives on `subclass`/`is_subclass_of`, which the FP=0 net **cannot see** | seconds |
 
 `owl-dl-py` is excluded from tests only because pyo3 cannot link libpython in this
 environment — a pre-existing environment issue, not a skip.
+
+### The FP=0 net does not cover the per-pair query surface
+
+`konclude_closure_diff.rs` diffs **`classify`** closures. #76 — a real false
+positive — lived on the `subclass`/`explain`/`is_subclass_of` path, which
+`classify` never consults while `trust_sat` is on, so the net was *structurally
+blind* to it and it shipped for months on `pizza`, a fixture the net checks every
+run and reported `FP=0 MISSED=0 VERIFIED` for throughout.
+
+`per_pair_fp_gate.rs` closes that. It runs the same oracle diff under
+`RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1`, which withdraws the wedge `Sat`-trust so
+refuted pairs reach the tableau the per-pair surface uses.
+
+**Demonstrated, not argued.** Under the same sabotage (`RUSTDL_MAX_TRIAL_MERGE=0`,
+reverting #76): the classify-only net reports `pizza 499=499 FP=0 VERIFIED`, while
+the per-pair gate reports `501 vs 499, FP=2` and fails. Re-run that sabotage after
+touching either flag — a gate that cannot be made to fail is not a gate.
 
 ## 2. The three gates are not substitutes for each other
 


### PR DESCRIPTION
## What was ungated

`konclude_closure_diff.rs` — the FP=0 net — diffs **`classify`** closures. #76 was a *real* false positive (the SROIQ `≤n` rule committed to the first merge pair and never reconsidered, so a clash on that arbitrary choice reported a satisfiable concept unsatisfiable). It lived on the `subclass` / `explain` / `is_subclass_of` **per-pair** path, which `classify` never consults while `trust_sat` is on.

The net was therefore *structurally blind* to it, and it shipped for months **on `pizza`** — a flagship fixture the net checks on every run and reported `FP=0 MISSED=0 VERIFIED` for throughout.

So "FP=0 corpus-wide" was, and still is, a claim about `classify` alone. This PR gates the other surface.

## The control is what licenses this, not the pass

Same sabotage (`RUSTDL_MAX_TRIAL_MERGE=0`, which reverts the #76 fix), two nets:

| | verdict |
|---|---|
| classify-only net | `pizza 499=499 FP=0 MISSED=0 VERIFIED` — **blind, passes** |
| new per-pair gate | `501 vs 499, **FP=2**` — **fails** |

naming `Margherita ⊑ InterestingPizza` and `QuattroFormaggi ⊑ InterestingPizza` — exactly the pairs the #76 investigation identified, and exactly the numbers the held #66 branch recorded before #76 landed. **The months-long invisibility of #76 is now reproducible on demand rather than argued.**

## Contents

- **`RUSTDL_CLASSIFY_VERIFY_REFUTATIONS`** (cherry-picked from the superseded `fix/classify-verify-refutations-66` branch, still **default OFF**). It withdraws the wedge `Sat`-trust on out-of-fragment ontologies so refuted pairs reach the tableau. Default OFF because its *completeness* benefit measured **zero** corpus-wide against **+21.6% wall** — it is an instrument, not a policy. Pinned in `flag_defaults.rs`.
- **`tests/per_pair_fp_gate.rs`** — runs the oracle diff under that flag over pizza/ro/sulo. Those are the out-of-EL fixtures; the flag is gated on `OutOfFragment`, so **bibtex (Horn) is deliberately excluded** — a fixture where the flag cannot engage would pad the gate without testing it.

## Two cherry-picked tests failed on rebase, and were right to

`flag_off_reproduces_the_defect` asserted `Cap ⊑ VE` is still *missing* with the flag off, and instructed its own reader: *"if this now passes, the defect was closed elsewhere and this flag's rationale needs re-checking."* It was — **#78/#83 fixed the wedge clause anchoring at root**. Both it and the behavioural half of `default_is_off` are inverted to pin the *fixed* behaviour, with the flip recorded, because that flip is the evidence #66 is closed by a mechanism rather than by assertion.

The flag's original rationale has evaporated. Its FP-instrument value is why it is kept.

## Gates

- suite **1852 passed / 0 failed** / 82 ignored, on this branch rebased onto current `main` (i.e. including #81)
- gate passes at the default: pizza 499=499, ro 158=158, sulo 51=51, all FP=0
- sabotage fails it; control confirms the classify-only net stays blind

Re-run that sabotage after touching either flag — a gate that cannot be made to fail is not a gate.

Refs #66, #76, #78