### PR TITLE
fix(convert): seed DKey disjointness ACROSS datatype buckets (#86)

### DIFF
--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -3929,8 +3929,22 @@ fn dkey_components(out: &InternalOntology) -> DkeyComponents {
 /// provably never share a label, so skipping them drops zero consumable clash and
 /// keeps the volume in the same class as the within-bucket seeding.
 ///
-/// The caller is responsible for passing only genuinely disjoint bucket pairs —
-/// `xsd:integer`/`xsd:decimal` must NOT be passed here.
+/// The caller is responsible for passing only genuinely disjoint bucket pairs.
+/// Two pairs that look like gaps and are NOT:
+///
+/// * **`xsd:integer` / `xsd:decimal`** — `integer ⊆ decimal`, so they overlap.
+///   `DataPropertyRange(p, xsd:integer)` + `"1.5"^^xsd:decimal` IS inconsistent,
+///   but by VALUE MEMBERSHIP (`1.5 ∉ integer`), not by datatype disjointness;
+///   rustdl misses it and no rule here can close it. Seeding this pair to catch
+///   the `1.5` case would make `"1"^^xsd:integer` in a decimal range a false
+///   UNSAT.
+/// * **`date:` / `dt:`** — rustdl has both buckets, which makes them inviting.
+///   Measured: Konclude reports `date` × `dateTime` CONSISTENT in both
+///   directions, and `HermiT` refuses the input entirely with
+///   `UnsupportedDatatypeException` because `xsd:date` is not in the OWL 2
+///   datatype map (it accepts `dateTime` × `dateTime`, which is what isolates
+///   the cause). No peer supports the entailment, so seeding it would
+///   manufacture a false positive.
 fn seed_cross_bucket_disjoint(
     out: &mut InternalOntology,
     a_keys: &[ClassId],

--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -3109,6 +3109,36 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
     seed_disjoint_bucket(out, &dt_dkeys, OrdRange::disjoint, comp);
     seed_disjoint_bucket(out, &str_dkeys, StrSet::disjoint, comp);
     seed_disjoint_bucket(out, &lang_dkeys, LangSet::disjoint, comp);
+
+    // #86 — CROSS-BUCKET disjointness. Within-bucket disjointness (above) has
+    // always been seeded; cross-bucket never was, so a value of one numeric
+    // datatype asserted against a range of another never clashed:
+    // `DataPropertyRange(p, xsd:double)` + `DataPropertyAssertion(p, a,
+    // "1.0"^^xsd:float)` is INCONSISTENT per Konclude AND HermiT, and rustdl
+    // reported it consistent. That is the dual of the v0.4.6-v0.4.9 FP: folding
+    // float and double into one bucket made them EQUIVALENT, and splitting the
+    // buckets removed the false equivalence without adding the disjointness the
+    // split implies.
+    //
+    // ONLY GENUINELY DISJOINT PAIRS BELONG HERE. `xsd:integer` is a SUBSET of
+    // `xsd:decimal` (Konclude reports both directions CONSISTENT), so that pair
+    // is deliberately absent — seeding it would emit a false `DisjointClasses`
+    // and turn this MISS into a false UNSAT, in the one subsystem that has
+    // already shipped an FP for months. Guarded by
+    // `integer_value_in_decimal_range_is_consistent`.
+    if dkey_cross_bucket_disjoint_enabled() {
+        let ints: Vec<ClassId> = int_dkeys.iter().map(|(c, _)| *c).collect();
+        let floats: Vec<ClassId> = float_dkeys.iter().map(|(c, _)| *c).collect();
+        let doubles: Vec<ClassId> = double_dkeys.iter().map(|(c, _)| *c).collect();
+        let decs: Vec<ClassId> = dec_dkeys.iter().map(|(c, _)| *c).collect();
+        // IEEE floats are disjoint from each other and from the exact numerics.
+        seed_cross_bucket_disjoint(out, &floats, &doubles, comp);
+        seed_cross_bucket_disjoint(out, &floats, &decs, comp);
+        seed_cross_bucket_disjoint(out, &floats, &ints, comp);
+        seed_cross_bucket_disjoint(out, &doubles, &decs, comp);
+        seed_cross_bucket_disjoint(out, &doubles, &ints, comp);
+        // NOT (ints, decs) — xsd:integer ⊂ xsd:decimal.
+    }
     // Numeric-oneof disjointness. FP-CRITICAL DIRECTION: emitting a
     // `DisjointClasses` ADDS clashes, so a wrong "disjoint" is a false UNSAT,
     // not a miss. `BTreeSet::is_disjoint` is exact here because every bucket's
@@ -3309,6 +3339,28 @@ fn dkey_merging_gate_enabled() -> bool {
 /// See `docs/2026-08-03-dkey-volume-scan.md`.
 fn dkey_emit_order_enabled() -> bool {
     std::env::var_os("RUSTDL_DKEY_EMIT_ORDER").is_none_or(|v| v != "0")
+}
+
+/// `RUSTDL_DKEY_CROSS_BUCKET_DISJOINT` — **default ON**, `=0` reverts (#86).
+///
+/// Seeds `DisjointClasses(DKey_a, DKey_b)` across datatype buckets whose VALUE
+/// SPACES are disjoint. Within-bucket disjointness (D11b) has always been seeded;
+/// cross-bucket never was, so `DataPropertyRange(p, xsd:double)` +
+/// `DataPropertyAssertion(p, a, "1.0"^^xsd:float)` — inconsistent per Konclude AND
+/// `HermiT` — was reported CONSISTENT.
+///
+/// This is the dual of the v0.4.6–v0.4.9 fix. That FP came from folding
+/// `xsd:float` and `xsd:double` into ONE f64 bucket, making them EQUIVALENT; the
+/// fix split the buckets, which removed the false equivalence but never added the
+/// disjointness the split implies.
+///
+/// **FP-CRITICAL, and the guard is a NEGATIVE:** `xsd:integer` is a SUBSET of
+/// `xsd:decimal`, so that pair is deliberately NOT seeded. Declaring "different
+/// numeric bucket ⇒ disjoint" would turn a MISS into a false UNSAT. See
+/// `integer_value_in_decimal_range_is_consistent` in
+/// `crates/owl-dl-reasoner/tests/dkey_cross_bucket_disjointness.rs`.
+fn dkey_cross_bucket_disjoint_enabled() -> bool {
+    std::env::var_os("RUSTDL_DKEY_CROSS_BUCKET_DISJOINT").is_none_or(|v| v != "0")
 }
 
 /// See a role restriction that only exists **after NNF** when classifying roles for
@@ -3867,6 +3919,75 @@ fn dkey_components(out: &InternalOntology) -> DkeyComponents {
 /// O(k²) walk still stalls), so cost is `O(Σ_component` values²). The
 /// per-pair `disjoint` range check is kept in both paths (FP-safety: the
 /// bounded set is a subset of the sound all-pairs set by construction).
+/// Cross-bucket sibling of [`seed_disjoint_bucket`] (#86). Every `a × b` pair is
+/// disjoint UNCONDITIONALLY — the two buckets' datatypes have disjoint value
+/// spaces, so no per-pair range test applies and none is taken.
+///
+/// Uses the same merge-aware component gating: a `DisjointClasses` is only ever
+/// CONSUMED when both `DKey`s can land in one node label, which needs their data
+/// roles connected through a merge-inducing super-role. Cross-component pairs
+/// provably never share a label, so skipping them drops zero consumable clash and
+/// keeps the volume in the same class as the within-bucket seeding.
+///
+/// The caller is responsible for passing only genuinely disjoint bucket pairs —
+/// `xsd:integer`/`xsd:decimal` must NOT be passed here.
+fn seed_cross_bucket_disjoint(
+    out: &mut InternalOntology,
+    a_keys: &[ClassId],
+    b_keys: &[ClassId],
+    components: Option<&DkeyComponents>,
+) {
+    let emit = |out: &mut InternalOntology, a: ClassId, b: ClassId| {
+        let ca = out.concepts.atomic(a);
+        let cb = out.concepts.atomic(b);
+        out.axioms.push(Axiom::DisjointClasses(vec![ca, cb]));
+    };
+    let Some(comp) = components else {
+        for a in a_keys {
+            for b in b_keys {
+                emit(out, *a, *b);
+            }
+        }
+        return;
+    };
+    // `reach(k)` = the components k participates in, or None when k is
+    // unanchored (pairs with everything). A key that is neither anchored nor
+    // unanchored appears under no role restriction, can never reach a node
+    // label, and is skipped — same rule as `seed_disjoint_bucket`.
+    let reach = |k: &ClassId| -> Option<Option<&Vec<usize>>> {
+        if comp.unanchored.contains(k) {
+            return Some(None);
+        }
+        comp.components.get(k).map(Some)
+    };
+    let mut emitted: std::collections::HashSet<(ClassId, ClassId)> =
+        std::collections::HashSet::new();
+    for a in a_keys {
+        let Some(ra) = reach(a) else { continue };
+        for b in b_keys {
+            let Some(rb) = reach(b) else { continue };
+            let shares = match (ra, rb) {
+                // an unanchored key pairs with every key in the other bucket
+                (None, _) | (_, None) => true,
+                // component lists are short (a key sits in few components), so a
+                // nested scan beats building a set per pair
+                (Some(sa), Some(sb)) => sa.iter().any(|c| sb.contains(c)),
+            };
+            if !shares {
+                continue;
+            }
+            let pair = if a.index() <= b.index() {
+                (*a, *b)
+            } else {
+                (*b, *a)
+            };
+            if emitted.insert(pair) {
+                emit(out, *a, *b);
+            }
+        }
+    }
+}
+
 fn seed_disjoint_bucket<R>(
     out: &mut InternalOntology,
     keys: &[(ClassId, R)],

--- a/crates/owl-dl-reasoner/tests/datatype_inconsistency.rs
+++ b/crates/owl-dl-reasoner/tests/datatype_inconsistency.rs
@@ -866,16 +866,27 @@ fn float_distinct_f32_values_functional_inconsistent() {
     ));
 }
 
-/// NEGATIVE: cross-datatype no-clash — xsd:float and xsd:double are in
-/// SEPARATE DKey buckets; a float value vs a double range MUST NOT cross-
-/// subsume. Asserted float value does NOT violate the double-typed range
-/// (the float assertion simply drops into the float bucket, which has no
-/// range constraint, so no inconsistency fires).
+/// INVERTED 2026-08-30 (#86) — this asserted `consistent` and was WRONG.
+///
+/// The half of its rationale that stands: `xsd:float` and `xsd:double` are in
+/// SEPARATE DKey buckets and must never cross-SUBSUME. That is untouched — #86
+/// adds cross-bucket DISJOINTNESS, not subsumption.
+///
+/// The half that was wrong: it concluded that a float value therefore "does NOT
+/// violate the double-typed range", reasoning from the implementation ("the float
+/// assertion simply drops into the float bucket, which has no range constraint")
+/// rather than from OWL 2. Disjoint value spaces mean the asserted value cannot
+/// lie in the declared range, so the KB IS inconsistent.
+///
+/// Adjudicated on THIS EXACT FIXTURE, not on a similar one:
+///   Konclude `consistency` → `false`
+///   HermiT  `--consistency` → `owl:Thing is not satisfiable`
+/// Both agree the ontology is inconsistent; rustdl now does too.
 #[test]
-fn float_value_vs_double_range_no_cross_bucket_clash() {
-    // Float value "2.0" and double range [0.0, 1.0] are in disjoint buckets
-    // → the float assertion does not violate the double range → CONSISTENT.
-    assert!(consistent(
+fn float_value_vs_double_range_clashes_across_buckets() {
+    // Float value "2.0" against a double range: the value spaces of xsd:float and
+    // xsd:double are disjoint, so this violates the range regardless of the facet.
+    assert!(!consistent(
         r#"    Declaration(DataProperty(:p)) Declaration(NamedIndividual(:a))
     DataPropertyRange(:p DatatypeRestriction(xsd:double xsd:minInclusive "0.0"^^xsd:double xsd:maxInclusive "1.0"^^xsd:double))
     DataPropertyAssertion(:p :a "2.0"^^xsd:float)"#

--- a/crates/owl-dl-reasoner/tests/datatype_value_membership.rs
+++ b/crates/owl-dl-reasoner/tests/datatype_value_membership.rs
@@ -902,16 +902,25 @@ fn forall_string_value_inside_enum_satisfiable() {
     );
 }
 
+/// INVERTED 2026-08-30 (#86). This asserted "no clash" and described itself as a
+/// "sound under-approx" — which it was, and #86 is the fix for exactly that MISS.
+/// Cross-bucket DISJOINTNESS is now seeded for provably-disjoint datatype pairs
+/// (cross-bucket SUBSUMPTION still is not, and must not be).
+///
+/// Adjudicated on this exact shape:
+///   Konclude → `C is UNSATISFIABLE`
+///   `HermiT` → lists `<http://ex#C>` alongside `owl:Nothing`
 #[test]
-fn forall_cross_datatype_no_clash() {
-    // ∃h.{5-int} ⊓ ∀h.[0.0,3.0]-double — different buckets never seed
-    // disjointness, so NO clash (sound under-approx, not a wrong ⊥).
+fn forall_cross_datatype_clashes() {
+    // ∃h.{5^^integer} ⊓ ∀h.[0.0,3.0]^^double: the successor would have to be the
+    // integer 5 AND a double in [0,3]. Those value spaces are disjoint, so no
+    // value satisfies both and C is unsatisfiable.
     assert!(
-        !forall_clash_unsat(
+        forall_clash_unsat(
             r#""5"^^xsd:integer"#,
             r#"DatatypeRestriction(xsd:double xsd:minInclusive "0.0"^^xsd:double xsd:maxInclusive "3.0"^^xsd:double)"#
         ),
-        "int value vs double range: cross-datatype, no clash"
+        "int value vs double range: disjoint value spaces ⇒ C unsatisfiable (#86)"
     );
 }
 

--- a/crates/owl-dl-reasoner/tests/dkey_cross_bucket_disjointness.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_cross_bucket_disjointness.rs
@@ -63,9 +63,27 @@ fn integer_value_in_decimal_range_is_consistent() {
     );
 }
 
-/// The other direction. A decimal value need not be an integer, so this is a
-/// range VIOLATION in general — but it is not a datatype-disjointness one, and
-/// both oracles report consistent.
+/// The other direction, with an INTEGRAL decimal value. Both oracles report
+/// consistent.
+///
+/// ## Do not "complete the matrix" from the `1.5` case
+///
+/// `DataPropertyRange(p, xsd:integer)` + `"1.5"^^xsd:decimal` IS inconsistent
+/// (Konclude and HermiT agree), and rustdl misses it. That is tempting to read as
+/// "so integer and decimal are disjoint after all" — they are not. The direction
+/// is VALUE-dependent, not datatype-dependent:
+///
+/// | range | value | oracles |
+/// |---|---|---|
+/// | `xsd:decimal` | `"1"^^xsd:integer` | consistent |
+/// | `xsd:integer` | `"1"^^xsd:decimal` | consistent |
+/// | `xsd:integer` | `"1.5"^^xsd:decimal` | **inconsistent** |
+///
+/// `xsd:integer ⊆ xsd:decimal`, so no bucket-disjointness rule can close the
+/// `1.5` row — it needs VALUE MEMBERSHIP (`1.5 ∉ integer`), which is different
+/// machinery. Adding `int × dec` to `seed_cross_bucket_disjoint` would fail THIS
+/// test and `integer_value_in_decimal_range_is_consistent`, which is the point of
+/// both.
 #[test]
 fn decimal_value_in_integer_range_is_consistent() {
     assert!(

--- a/crates/owl-dl-reasoner/tests/dkey_cross_bucket_disjointness.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_cross_bucket_disjointness.rs
@@ -1,0 +1,131 @@
+//! Canaries for CROSS-BUCKET DKey disjointness (#86).
+//!
+//! `DataPropertyRange(p, D1)` plus `DataPropertyAssertion(p, a, "v"^^D2)` is
+//! INCONSISTENT when `D1` and `D2` have disjoint value spaces. rustdl missed
+//! every numeric instance of this: `seed_dkey_subsumptions` buckets DKeys by
+//! datatype and seeds subsumption only WITHIN a bucket (correct — that is what
+//! fixed the v0.4.6–v0.4.9 FP where float and double were folded together and
+//! reported EQUIVALENT), and D11b seeded `DisjointClasses` only within a bucket
+//! too. So cross-bucket DKeys were neither comparable nor disjoint.
+//!
+//! ## NEGATIVES-FIRST, because the risk direction is INVERTED here
+//!
+//! Emitting disjointness ADDS clashes, so a wrong "disjoint" is a false UNSAT —
+//! a false POSITIVE — not a miss. This is the subsystem that already shipped an
+//! FP for months (the float/double fold). The FP guards below are therefore the
+//! load-bearing half of this file, not the bug tests:
+//!
+//! **`xsd:integer` is a SUBSET of `xsd:decimal`, NOT disjoint from it.** Konclude
+//! confirms both directions consistent. A fix that says "different numeric bucket
+//! ⇒ disjoint" turns the MISS into an FP, and `integer_value_in_decimal_range_*`
+//! is what catches that.
+//!
+//! Every verdict here is adjudicated against Konclude AND HermiT; see
+//! `docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md`.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+/// `DataPropertyRange(p, range)` + `DataPropertyAssertion(p, a, "lit"^^lit_ty)`.
+fn range_and_value(range: &str, lit: &str, lit_ty: &str) -> bool {
+    let src = format!(
+        "Prefix(:=<http://ex#>)\n\
+         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n\
+         Ontology(\n\
+         Declaration(DataProperty(:p))\n\
+         Declaration(NamedIndividual(:a))\n\
+         DataPropertyRange(:p xsd:{range})\n\
+         DataPropertyAssertion(:p :a \"{lit}\"^^xsd:{lit_ty})\n\
+         )"
+    );
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).unwrap();
+    owl_dl_reasoner::is_consistent(&onto).unwrap()
+}
+
+// ── FP GUARDS (the load-bearing half) ───────────────────────────────────────
+
+/// `xsd:integer ⊂ xsd:decimal`. Konclude and HermiT both say CONSISTENT.
+/// A "different numeric bucket ⇒ disjoint" fix fails here.
+#[test]
+fn integer_value_in_decimal_range_is_consistent() {
+    assert!(
+        range_and_value("decimal", "1", "integer"),
+        "xsd:integer is a SUBSET of xsd:decimal — declaring these buckets \
+         disjoint is a FALSE POSITIVE, not a fix"
+    );
+}
+
+/// The other direction. A decimal value need not be an integer, so this is a
+/// range VIOLATION in general — but it is not a datatype-disjointness one, and
+/// both oracles report consistent.
+#[test]
+fn decimal_value_in_integer_range_is_consistent() {
+    assert!(
+        range_and_value("integer", "1", "decimal"),
+        "xsd:decimal and xsd:integer overlap — not a disjointness clash"
+    );
+}
+
+/// Same datatype on both sides must never clash, in every bucket.
+#[test]
+fn same_datatype_never_clashes() {
+    for (ty, lit) in [
+        ("double", "1.0"),
+        ("float", "1.0"),
+        ("decimal", "1.0"),
+        ("integer", "1"),
+        ("string", "x"),
+    ] {
+        assert!(
+            range_and_value(ty, lit, ty),
+            "xsd:{ty} against itself must stay consistent"
+        );
+    }
+}
+
+// ── THE BUG: disjoint value spaces must clash ───────────────────────────────
+
+/// #86's own two-axiom reproducer. HermiT: `owl:Thing is not satisfiable`;
+/// Konclude: `false`.
+#[test]
+fn float_value_in_double_range_is_inconsistent() {
+    assert!(
+        !range_and_value("double", "1.0", "float"),
+        "xsd:float and xsd:double have disjoint value spaces (#86)"
+    );
+}
+
+#[test]
+fn double_value_in_float_range_is_inconsistent() {
+    assert!(!range_and_value("float", "1.0", "double"));
+}
+
+#[test]
+fn float_value_in_decimal_range_is_inconsistent() {
+    assert!(!range_and_value("decimal", "1.0", "float"));
+}
+
+#[test]
+fn float_value_in_integer_range_is_inconsistent() {
+    assert!(!range_and_value("integer", "1", "float"));
+}
+
+#[test]
+fn double_value_in_integer_range_is_inconsistent() {
+    assert!(!range_and_value("integer", "1", "double"));
+}
+
+/// Cross-FAMILY already worked before #86; pinned so a bucket refactor cannot
+/// silently lose it.
+#[test]
+fn integer_value_in_string_range_is_inconsistent() {
+    assert!(!range_and_value("string", "1", "integer"));
+}

--- a/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
+++ b/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
@@ -1,7 +1,25 @@
 # The numeric DKey buckets are non-comparable but not DISJOINT — rustdl misses the clash
 
-**Status: live on v0.4.24. Sound (a MISS, never an FP). Root-caused to a 2-axiom
-reproducer, adjudicated by Konclude AND HermiT with a discriminating control.**
+**Status: FIXED on the `is_consistent` surface (`RUSTDL_DKEY_CROSS_BUCKET_DISJOINT`,
+default ON, `=0` reverts). `classify` STILL MISSES IT — see the residual below.**
+
+Was: live on v0.4.24, sound (a MISS, never an FP), root-caused to a 2-axiom reproducer
+adjudicated by Konclude AND HermiT with a discriminating control.
+
+## Residual: `classify` and `consistent` still disagree here
+
+`rustdl consistent ore_ont_16321` now correctly reports **inconsistent**; `classify --json`
+on the same file still reports `consistent: true, unsatisfiable: []`.
+
+The clash is ABox-level — an individual's data value violating a declared range — so no
+*named class* becomes unsatisfiable, and classify's inconsistency pre-check
+(`saturator globally_inconsistent`/`top_is_unsat` plus `abox_saturation`) cannot see it:
+`abox_saturation` propagates over NAMED individuals with no witness generation, and the
+clash lives at the data successor. Closing it needs either DKey-aware ABox saturation or a
+consistency probe on the classify path — different machinery, not this change.
+
+This is the documented classify-vs-`consistent` under-approximation, now with a concrete
+instance.
 
 ## The 2-axiom reproducer
 

--- a/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
+++ b/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
@@ -69,6 +69,49 @@ Cross-*family* disjointness already works; only the numeric split is missing.
 | `decimal` | `integer` | **consistent** | consistent | agree |
 | `string` | `integer` | inconsistent | **inconsistent** | agree |
 
+## Two adjacent cases that are NOT gaps (verified 2026-08-31)
+
+Both look like the fix is incomplete. Neither is.
+
+### `xsd:integer` / `xsd:decimal` — a residual no bucket rule can reach
+
+| range | value | Konclude | HermiT | rustdl |
+|---|---|---|---|---|
+| `xsd:decimal` | `"1"^^xsd:integer` | consistent | consistent | consistent ✓ |
+| `xsd:integer` | `"1"^^xsd:decimal` | consistent | consistent | consistent ✓ |
+| `xsd:integer` | `"1.5"^^xsd:decimal` | **inconsistent** | **inconsistent** | **consistent** ✗ |
+
+The `1.5` row is a genuine rustdl MISS, and it is **value-dependent, not
+datatype-dependent**. `xsd:integer ⊆ xsd:decimal`, so the buckets genuinely overlap and
+no disjointness rule can close it — it needs VALUE MEMBERSHIP (`1.5 ∉ integer`), which is
+different machinery.
+
+**Do not "complete the matrix" from it.** Seeding `int × dec` to catch `1.5` makes
+`"1"^^xsd:integer` in a decimal range a false UNSAT. The canaries
+`integer_value_in_decimal_range_is_consistent` and
+`decimal_value_in_integer_range_is_consistent` both fail if anyone tries, and the second
+one's docstring explains why.
+
+This is also distinct from the classify-surface residual above — that one is about which
+*surface* reports the clash; this one is about a clash rustdl cannot derive at all.
+
+### `date` / `dateTime` — no peer supports the entailment
+
+rustdl has a `date:` and a `dt:` bucket, which makes them an inviting-looking pair for
+anyone extending `seed_cross_bucket_disjoint`. Measured:
+
+| range | value | Konclude | HermiT |
+|---|---|---|---|
+| `date` | `dateTime` | consistent | `UnsupportedDatatypeException` |
+| `dateTime` | `date` | consistent | `UnsupportedDatatypeException` |
+| `date` | `date` | consistent | `UnsupportedDatatypeException` |
+| **`dateTime`** | **`dateTime`** | consistent | **is satisfiable** |
+
+The last row is the discriminator: HermiT handles `dateTime` fine, so the exception is
+specifically that **`xsd:date` is not in the OWL 2 datatype map** — not an artefact of the
+test shape. Konclude reports consistent in both directions. Seeding `date ⊥ dateTime`
+would manufacture a false positive no peer supports.
+
 ## THE TRAP ANY FIX MUST AVOID
 
 **`xsd:integer ⊂ xsd:decimal` — they are NOT disjoint**, and Konclude confirms it in both

--- a/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
+++ b/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
@@ -113,3 +113,45 @@ consistent for both reasoners once the unsupported `anyURI` range is dropped).
 Sound — rustdl under-reports, never over-reports. But **silent**: a consumer reading
 `consistent: true` gets no signal, and every downstream entailment rests on a KB with no
 model.
+
+
+---
+
+## Gates run on the fix (2026-08-30)
+
+| gate | result |
+|---|---|
+| canaries (`dkey_cross_bucket_disjointness.rs`) | 9/9, incl. 3 FP guards |
+| suite | 1856 passed / 0 failed |
+| clippy / fmt | clean |
+| FP=0 net | 20 VERIFIED, every closure exact and **unchanged** |
+| two-arm classify sweep, 637 data-property-bearing ORE | 603 both-ok, **603 identical, 0 DIFFER, 0 `ok→dnf`** |
+| two-arm **consistency** sweep, 268 ORE with ≥2 numeric datatypes | **3 changed, all correct; 0 wrong-direction** |
+| conversion volume, 3 worst DKey ontologies | **identical both arms** (`ore_ont_5368` 18,620,251 rules / 18,608,050 disjoint pairs) |
+
+The classify sweep shows **non-regression, not benefit** — classify's output is unchanged
+precisely because the fix lands on the `consistent` surface (see the residual above). The
+consistency sweep is where the benefit shows: the only three verdict changes across 268
+ontologies are `ore_ont_16321`, `ore_ont_4198` and `ore_ont_5014`, all going
+consistent → inconsistent, and all three confirmed inconsistent by Konclude (the first two
+by KM as well).
+
+**The FP=0 net's green is non-regression only** — `datatype_value_membership.rs` states the
+curated corpus is inert for DKey work. The positive evidence is the canaries plus the
+Konclude ∪ HermiT adjudication, done on each fixture individually including the two
+inverted tests.
+
+### Two pre-existing tests asserted the wrong answer
+
+Both were adjudicated on their **exact** fixtures before being touched, because a failing
+test is usually the codebase reporting a defect in the change, not the reverse:
+
+* `float_value_vs_double_range_no_cross_bucket_clash` reasoned from the implementation
+  ("the float assertion simply drops into the float bucket, which has no range constraint")
+  to a semantic conclusion. Konclude `false`; HermiT `owl:Thing is not satisfiable`.
+* `forall_cross_datatype_no_clash` described itself as a "sound under-approx" — which it
+  was, and this is the fix for that MISS. Konclude `C is UNSATISFIABLE`; HermiT lists `C`
+  alongside `owl:Nothing`.
+
+The half of the first test's rationale that stands — cross-bucket **subsumption** must never
+be seeded — is untouched by this change and is preserved in the inverted test's docstring.

--- a/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
+++ b/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
@@ -69,6 +69,41 @@ Cross-*family* disjointness already works; only the numeric split is missing.
 | `decimal` | `integer` | **consistent** | consistent | agree |
 | `string` | `integer` | inconsistent | **inconsistent** | agree |
 
+## Why pairwise seeding, not marker classes — measured
+
+A reviewer built a duplicate fix using per-family MARKER classes (`DKey ⊑ marker`, markers
+pairwise disjoint) to get O(#DKeys) instead of pairwise seeding, and hit an
+**8.7×–78× slowdown on ontologies with ZERO numeric datatypes** (`ore_ont_1016`). Their
+diagnosis was that interning markers shifted class ids corpus-wide. **That is not the
+mechanism** — measured on `ore_ont_1016` (3,087 classes, no numeric datatypes at all):
+
+| variant | wall | mode |
+|---|---|---|
+| baseline | 0.12 s | `pure EL (saturation-only)` |
+| +3 classes, prepended (shifts every id) | 0.11 s | `pure EL` |
+| +3 classes, appended | 0.11 s | `pure EL` |
+| **+3 classes AND 3 `DisjointClasses`** | **1.04 s** | **`hybrid`** |
+
+The id shift costs nothing. **The `DisjointClasses` axioms are what bite**, and the route
+is `saturator_complete_fragment`'s `disjoint_ok` gate: disjointness is admitted only when
+no functional or inverse-functional role is present, because the disjoint×functional-merge
+interaction is unproven. `ore_ont_1016` is galen-derived — 150 `FunctionalObjectProperty`,
+0 `DisjointClasses` — i.e. exactly the "functional, no disjoint" profile that gate's own
+comment names as staying on the fast path. Injecting any disjointness flips
+`has_cardinality_role`-bearing ontologies off saturation-only into the hybrid path.
+
+**The design constraint, for anyone adding disjointness anywhere:** an *unconditional*
+`DisjointClasses` injection knocks EVERY functional-role-bearing pure-EL ontology off the
+fast path. That population is large (the galen family is well represented in ORE), and the
+cost is invisible to canaries — it is a wall change on ontologies the feature does not
+touch at all, so only a two-arm sweep sees it.
+
+`seed_cross_bucket_disjoint` is immune **by construction**, not by luck: it emits only
+between actual DKeys inside merge-inducing role components, so an ontology with no numeric
+DKeys receives nothing and its mode is unchanged. Verified — `ore_ont_1016` still reports
+`# mode: pure EL` with this PR applied, and the 637-ontology two-arm classify sweep found
+0 differences.
+
 ## Two adjacent cases that are NOT gaps (verified 2026-08-31)
 
 Both look like the fix is incomplete. Neither is.

--- a/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
+++ b/docs/known-limitations/dkey-numeric-buckets-are-not-disjoint.md
@@ -1,0 +1,97 @@
+# The numeric DKey buckets are non-comparable but not DISJOINT — rustdl misses the clash
+
+**Status: live on v0.4.24. Sound (a MISS, never an FP). Root-caused to a 2-axiom
+reproducer, adjudicated by Konclude AND HermiT with a discriminating control.**
+
+## The 2-axiom reproducer
+
+```
+DataPropertyRange(:p xsd:double)
+DataPropertyAssertion(:p :a "1.0"^^xsd:float)
+```
+
+`xsd:float` and `xsd:double` have disjoint value spaces in OWL 2, so the asserted value
+cannot lie in the declared range and the KB is **inconsistent**.
+
+| | float/double | float/float (control) |
+|---|---|---|
+| HermiT | `owl:Thing is not satisfiable` | satisfiable |
+| Konclude | `false` | `true` |
+| **rustdl** | **`consistent`** ✗ | `consistent` ✓ |
+
+The control is what makes this a finding rather than a disagreement: all three agree on
+float/float, so rustdl is wrong specifically on the cross-datatype case. Nothing is
+dropped (`dropped: {}`), so this is not the graceful-degradation path.
+
+## Root cause
+
+`seed_dkey_subsumptions` buckets DKeys by datatype and seeds subsumption edges **only
+within a bucket**. That is correct and deliberate — it is precisely what fixed the
+v0.4.6–v0.4.9 false positive where `xsd:float` and `xsd:double` were folded into one
+f64-keyed bucket and reported EQUIVALENT.
+
+D11b then seeds `DisjointClasses(DKey(ra), DKey(rb))` for provably-disjoint pairs, also
+**only within a bucket**. So two DKeys in different buckets are neither subsumption-related
+nor disjoint, and `∃p.DKey(f:1.0)` never clashes with an `xsd:double` range.
+
+**The v0.4.9 fix removed the false equivalence and never added the disjointness.** This
+defect is its dual, and has been latent since.
+
+## The exact scope, measured
+
+Cross-*family* disjointness already works; only the numeric split is missing.
+
+| range | asserted | Konclude | rustdl | |
+|---|---|---|---|---|
+| `double` | `float` | inconsistent | consistent | **MISS** |
+| `decimal` | `float` | inconsistent | consistent | **MISS** |
+| `integer` | `float` | inconsistent | consistent | **MISS** |
+| `float` | `double` | inconsistent | consistent | **MISS** |
+| `integer` | `decimal` | **consistent** | consistent | agree |
+| `decimal` | `integer` | **consistent** | consistent | agree |
+| `string` | `integer` | inconsistent | **inconsistent** | agree |
+
+## THE TRAP ANY FIX MUST AVOID
+
+**`xsd:integer ⊂ xsd:decimal` — they are NOT disjoint**, and Konclude confirms it in both
+directions above. A fix that simply declares "different numeric bucket ⇒ disjoint" would
+emit a false `DisjointClasses` and turn a MISS into a **false positive** — in the one
+subsystem this repo documents as having already shipped an FP for months.
+
+The correct table is:
+
+* `float` ⊥ `double`, `decimal`, `integer`
+* `double` ⊥ `decimal`, `integer`
+* `integer` / `decimal` — **NOT disjoint** (subset)
+
+**Direction of risk is inverted here.** Emitting more disjointness risks FPs, so a fix
+needs canaries first, a Konclude ∪ HermiT adjudication, and a corpus sweep — the curated
+corpus is inert for DKey work by `datatype_value_membership.rs`'s own admission, so a green
+FP=0 net would show non-regression only.
+
+## Corpus reach — measured, and it explains most of the unsat misses
+
+A census over all 1,920 ORE ontologies for `DataPropertyRange(p, D1)` +
+`DataPropertyAssertion(p, _, "v"^^D2)` with `D1`, `D2` in different disjoint families finds
+**7 ontologies**. All 7 are inconsistent per Konclude. rustdl misses **3**
+(`ore_ont_16321`, `ore_ont_4198`, `ore_ont_5014`), detects 2 by other routes, and 2 time out
+in conversion (`ore_ont_4141`, `ore_ont_8445` — the known DKey conversion-bound pair).
+
+`ore_ont_16321` and `ore_ont_4198` are the two ontologies where rustdl reports
+`consistent: true` against **both** Konclude and KM
+(`missed-inconsistency-ore-16321-4198.md`). Between them they account for **82 of the 89**
+corpus-wide missed-unsat classes in the 391-ontology MISSED-net sample — as ONE defect each,
+not 41 apiece, since all 41 follow from the KB being inconsistent.
+
+**So this single 2-axiom defect is the largest identified contributor to rustdl's measured
+unsat-completeness gap.**
+
+Note the census over-attributes: `ore_ont_6446` carries the shape but its inconsistency comes
+from elsewhere (rustdl already detects it, and the isolated `anyURI`/`string` probe is
+consistent for both reasoners once the unsupported `anyURI` range is dropped).
+
+## Severity
+
+Sound — rustdl under-reports, never over-reports. But **silent**: a consumer reading
+`consistent: true` gets no signal, and every downstream entailment rests on a KB with no
+model.


### PR DESCRIPTION
Closes the missed inconsistency root-caused in #86.

## The defect, in two axioms

```
DataPropertyRange(:p xsd:double)
DataPropertyAssertion(:p :a "1.0"^^xsd:float)
```

`xsd:float` and `xsd:double` have disjoint value spaces, so this is **inconsistent**. rustdl reported `consistent`, with nothing dropped.

| | float/double | float/float (control) |
|---|---|---|
| HermiT | `owl:Thing is not satisfiable` | satisfiable |
| Konclude | `false` | `true` |
| rustdl before | **`consistent`** ✗ | `consistent` ✓ |
| rustdl after | `inconsistent` ✓ | `consistent` ✓ |

## Root cause — the dual of a fix already in this codebase

`seed_dkey_subsumptions` buckets DKeys by datatype and seeds subsumption **only within a bucket**. That is correct, and is exactly what fixed the v0.4.6–v0.4.9 FP where float and double were folded into one f64 bucket and reported *equivalent*. D11b seeded `DisjointClasses` only within a bucket too — so cross-bucket DKeys ended up neither comparable **nor disjoint**.

Splitting the buckets removed the false equivalence and never added the disjointness the split implies. `seed_cross_bucket_disjoint` adds it, reusing the same merge-aware component gating so volume stays in the class of the existing seeding.

## Only genuinely disjoint pairs are seeded

**`xsd:integer` is a SUBSET of `xsd:decimal`** — Konclude reports both directions consistent — so that pair is deliberately absent. Seeding it would emit a false `DisjointClasses` and turn this MISS into a false UNSAT, in the subsystem that has already shipped an FP for months. The FP guards are the load-bearing half of the new canary file, not the bug tests.

## Gates

| gate | result |
|---|---|
| canaries | 9/9, incl. 3 FP guards |
| suite | 1856 / 0 |
| clippy, fmt | clean |
| FP=0 net | 20 VERIFIED, every closure exact and unchanged |
| two-arm classify sweep, 637 data-property-bearing ORE | 603 both-ok, **603 identical, 0 DIFFER, 0 `ok→dnf`** |
| two-arm **consistency** sweep, 268 ORE with ≥2 numeric datatypes | **3 changed, all correct; 0 wrong-direction** |
| conversion volume, 3 worst DKey ontologies | identical both arms (`ore_ont_5368` 18,620,251 rules) |

The classify sweep is **non-regression, not benefit** — classify's output is unchanged because the fix lands on the `consistent` surface. The benefit shows in the consistency sweep: the only three verdict changes are `ore_ont_16321`, `ore_ont_4198`, `ore_ont_5014`, all consistent → inconsistent, all Konclude-confirmed.

The FP=0 net's green is **non-regression only** — the curated corpus is inert for DKey work by `datatype_value_membership.rs`'s own admission. The positive evidence is the canaries plus the Konclude ∪ HermiT adjudication.

## Two pre-existing tests asserted the wrong answer

Both adjudicated on their **exact** fixtures before being touched, since a failing test is usually the codebase reporting a defect in the change:

- `float_value_vs_double_range_no_cross_bucket_clash` reasoned from the implementation ("the float assertion simply drops into the float bucket, which has no range constraint") to a semantic conclusion. The half that stands — no cross-**subsumption** — is untouched and preserved in the inverted test's docstring.
- `forall_cross_datatype_no_clash` described itself as a "sound under-approx", which it was; this is the fix for that MISS.

## Known residual, recorded not hidden

This closes the `consistent` / `is_consistent` surface. **`classify` still reports `consistent: true` on `ore_ont_16321`**: the clash is ABox-level, so no *named class* becomes unsatisfiable, and `abox_saturation` has no witness generation to reach the data successor. Closing that needs DKey-aware ABox saturation or a consistency probe on the classify path — different machinery.

`RUSTDL_DKEY_CROSS_BUCKET_DISJOINT`, default ON, `=0` reverts.

Refs #86