### PR TITLE
feat(api): is_consistent_with_timeout — a deadline-bearing consistency check

### DIFF
--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -5859,6 +5859,103 @@ pub fn is_consistent_with_stats<A: ForIRI>(
     is_consistent_internal_full(internal)
 }
 
+/// Deadline-bearing [`is_consistent`] (#74). `Ok(None)` means the budget expired
+/// without a verdict — the shape [`is_class_satisfiable_with_timeout`] already has.
+///
+/// # Why not just use satisfiability of `⊤`
+///
+/// Two reasons, of unequal strength — stated separately because #74 conflates them.
+///
+/// **Demonstrated:** `is_class_satisfiable_with_timeout` requires `owl:Thing` to be
+/// DECLARED in the ontology and returns `Err(UnknownClass)` otherwise, so it cannot
+/// even be called on most inputs. This function has no such precondition.
+///
+/// **Structural, NOT demonstrated:** #74 argues the substitute is unsafe because it
+/// short-circuits on `is_pure_el` before consulting the `ABox`, so an `ABox`-only clash
+/// would be missed. That reading of the source is right, but no divergent case has
+/// been produced — the issue's author measured the two agreeing on every fixture
+/// they had, and four further shapes (ABox-only disjointness, functional-role merge,
+/// role-chain-induced range, inverse-materialised domain) also agree, because
+/// `saturate` derives the clash and the `is_unsatisfiable` short-circuit fires
+/// first. Do not cite this as a known divergence. See
+/// `tests/bounded_consistency.rs::the_substitute_agrees_on_every_shape_tried`.
+///
+/// This function keeps the `abox_saturation` pre-check regardless, since dropping it
+/// under time pressure would create the hazard rather than merely fail to disprove it.
+///
+/// # What the three outcomes mean
+///
+/// * `Ok(Some(false))` — a clash was WITNESSED (saturation, `abox_check`, the
+///   wedge, or the tableau). Sound: an inconsistency is never invented.
+/// * `Ok(Some(true))` — consistent at the same trust level as [`is_consistent`],
+///   i.e. including the wedge's trusted `Sat`.
+/// * `Ok(None)` — gave up inside the budget. Note the UNBOUNDED
+///   [`is_consistent`] reports `true` in the corresponding internal-timeout case,
+///   which is a sound under-approximation but an invisible one; that silence is
+///   what this function exists to remove.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub fn is_consistent_with_timeout<A: ForIRI>(
+    ontology: &SetOntology<A>,
+    deadline: std::time::Duration,
+) -> Result<Option<bool>, ReasonError> {
+    let start = std::time::Instant::now();
+    let internal = convert_ontology(ontology)?;
+    is_consistent_internal_bounded(internal, start + deadline)
+}
+
+/// Internal entry point for [`is_consistent_with_timeout`], taking an absolute
+/// deadline so conversion time is already charged against the caller's budget.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub fn is_consistent_internal_bounded(
+    internal: InternalOntology,
+    deadline: std::time::Instant,
+) -> Result<Option<bool>, ReasonError> {
+    // The ABox-saturation pre-check runs FIRST and unbounded, exactly as the
+    // unbounded path does. It is the step whose omission makes satisfiability an
+    // unsafe substitute (#74), so skipping it under time pressure would rebuild
+    // the very hazard this function exists to avoid. It is also budget-bounded in
+    // practice on the classify path via RUSTDL_CLASSIFY_INCONSISTENCY_MS; here the
+    // caller asked for a consistency verdict, so the pre-check is the cheapest
+    // route to one.
+    if abox_saturation_inconsistent(&internal) {
+        return Ok(Some(false));
+    }
+    if std::time::Instant::now() >= deadline {
+        return Ok(None);
+    }
+    let prepared = PreparedOntology::from_internal(internal)?;
+    if let abox_check::AboxVerdict::Inconsistent { .. } = prepared.abox_verdict() {
+        return Ok(Some(false));
+    }
+    if std::time::Instant::now() >= deadline {
+        return Ok(None);
+    }
+    // Wedge route, capped by whichever comes first: the caller's deadline or the
+    // configured fallback. `Unsat` is a witnessed clash; `Sat` is trusted exactly
+    // as the unbounded path trusts it.
+    let wedge_cap =
+        std::time::Instant::now() + std::time::Duration::from_millis(consistency_fallback_ms());
+    let wedge_deadline = wedge_cap.min(deadline);
+    match prepared.consistency_wedge(Some(wedge_deadline)) {
+        Some(owl_dl_tableau::hyper::HyperResult::Unsat) => return Ok(Some(false)),
+        Some(owl_dl_tableau::hyper::HyperResult::Sat) => return Ok(Some(true)),
+        Some(owl_dl_tableau::hyper::HyperResult::Stalled) | None => {}
+    }
+    if std::time::Instant::now() >= deadline {
+        return Ok(None);
+    }
+    // Main tableau, bounded by the caller's deadline. THE DIVERGENCE FROM THE
+    // UNBOUNDED PATH IS HERE: that one reports `true` when its internal budget
+    // elapses; this one reports `None`, because the caller asked to be told.
+    prepared.decide_with_deadline(deadline, owl_dl_core::ConceptPool::top)
+}
+
 fn is_consistent_internal_full(
     internal: InternalOntology,
 ) -> Result<(bool, QueryStats), ReasonError> {

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -5894,6 +5894,14 @@ pub fn is_consistent_with_stats<A: ForIRI>(
 ///   which is a sound under-approximation but an invisible one; that silence is
 ///   what this function exists to remove.
 ///
+/// # The budget is honoured end to end
+///
+/// Every stage is deadline-capable, including the `ABox`-saturation pre-check.
+/// Getting that wrong is easy: a first cut left the pre-check unbounded "because
+/// it is cheap", and `family.ofn` overran a 500 ms budget by 2.3x. Overshoot is
+/// still possible in principle — a single indivisible step can run past its
+/// deadline — but no stage is now unbounded by construction.
+///
 /// # Errors
 ///
 /// See [`ReasonError`].
@@ -5916,14 +5924,20 @@ pub fn is_consistent_internal_bounded(
     internal: InternalOntology,
     deadline: std::time::Instant,
 ) -> Result<Option<bool>, ReasonError> {
-    // The ABox-saturation pre-check runs FIRST and unbounded, exactly as the
-    // unbounded path does. It is the step whose omission makes satisfiability an
-    // unsafe substitute (#74), so skipping it under time pressure would rebuild
-    // the very hazard this function exists to avoid. It is also budget-bounded in
-    // practice on the classify path via RUSTDL_CLASSIFY_INCONSISTENCY_MS; here the
-    // caller asked for a consistency verdict, so the pre-check is the cheapest
-    // route to one.
-    if abox_saturation_inconsistent(&internal) {
+    // The ABox-saturation pre-check runs FIRST — it is the step whose omission
+    // makes satisfiability an unsafe substitute (#74), so skipping it would
+    // rebuild the hazard this function exists to avoid.
+    //
+    // IT MUST BE BOUNDED BY THE CALLER'S DEADLINE. A first cut called the
+    // unbounded `abox_saturation_inconsistent` here, and `family.ofn` then took
+    // 1.17 s against a 500 ms budget — a 2.3x overrun. A deadline-bearing API that
+    // overruns its deadline is a weak contract, and this is the only step that can
+    // do it: everything below is already deadline-capable. A timeout here yields
+    // `false` ("no clash found in budget"), a sound under-approximation, and the
+    // deadline check immediately after converts that into `None` rather than a
+    // guess.
+    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+    if abox_saturation_inconsistent_bounded(&internal, Some(remaining)) {
         return Ok(Some(false));
     }
     if std::time::Instant::now() >= deadline {

--- a/crates/owl-dl-reasoner/tests/bounded_consistency.rs
+++ b/crates/owl-dl-reasoner/tests/bounded_consistency.rs
@@ -26,6 +26,7 @@ use horned_owl::io::ParserConfiguration;
 use horned_owl::io::ofn::reader::read as read_ofn;
 use horned_owl::model::RcStr;
 use horned_owl::ontology::set::SetOntology;
+use std::fmt::Write as _;
 use std::io::Cursor;
 use std::time::Duration;
 
@@ -136,6 +137,60 @@ fn the_substitute_needs_owl_thing_declared() {
         owl_dl_reasoner::is_consistent_with_timeout(&o, GENEROUS).unwrap(),
         Some(false),
         "the real check has no such precondition"
+    );
+}
+
+/// The budget must bound the ABox-saturation pre-check too, not just the stages
+/// after it.
+///
+/// A first cut left that pre-check unbounded on the reasoning that it is cheap. It
+/// is not always: `family.ofn` overran a 500 ms budget by **2.3x** (1.17 s).
+/// Bounded, the same input measures 1.03x at 100 ms and 1.02x at 500 ms.
+///
+/// ## The fixture is sized from a measured sabotage, not guessed
+///
+/// A first version of this canary used 400 individuals with no transitive role and
+/// **failed to catch the regression** — restoring the unbounded call left it green,
+/// because that shape costs milliseconds either way. What makes the pre-check
+/// expensive is the ROLE-CHAIN CLOSURE, which is also what makes `family` slow. A
+/// transitive role over a chain of 800 individuals gives an O(n²) closure and this
+/// measured separation:
+///
+/// | n | bounded | unbounded |
+/// |---|---|---|
+/// | 200 | 447 µs | 63 ms |
+/// | 400 | 284 µs | 380 ms |
+/// | **800** | **557 µs** | **4 s** |
+///
+/// The 2 s threshold sits ~3500x above the passing cost and ~2x below the failing
+/// one, so it is not the host-speed knife-edge that #92 documents.
+#[test]
+fn the_budget_bounds_the_abox_pre_check() {
+    const N: usize = 800;
+    let mut body = String::from(
+        "Declaration(Class(:A)) Declaration(ObjectProperty(:r))\nTransitiveObjectProperty(:r)\n",
+    );
+    for i in 0..N {
+        let _ = write!(
+            body,
+            "Declaration(NamedIndividual(:i{i}))\nClassAssertion(:A :i{i})\n"
+        );
+        if i > 0 {
+            let _ = writeln!(body, "ObjectPropertyAssertion(:r :i{} :i{i})", i - 1);
+        }
+    }
+    let o = onto(&body);
+    let start = std::time::Instant::now();
+    let verdict = owl_dl_reasoner::is_consistent_with_timeout(&o, Duration::from_nanos(1)).unwrap();
+    let elapsed = start.elapsed();
+    assert_eq!(
+        verdict, None,
+        "a 1 ns budget cannot be met, so the answer must be None"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "the ABox pre-check must respect the deadline; {elapsed:?} means it ran \
+         unbounded (measured: ~557 us bounded vs ~4 s unbounded on this fixture)"
     );
 }
 

--- a/crates/owl-dl-reasoner/tests/bounded_consistency.rs
+++ b/crates/owl-dl-reasoner/tests/bounded_consistency.rs
@@ -1,0 +1,175 @@
+//! `is_consistent_with_timeout` (#74) — a deadline-bearing consistency check.
+//!
+//! Every other reasoner entry point has a bounded form; `is_consistent` had none,
+//! so a caller who needed one had to substitute
+//! `is_class_satisfiable_with_timeout` on a top concept.
+//!
+//! #74 calls that substitution unsafe on the grounds that satisfiability
+//! short-circuits on `is_pure_el` without consulting the ABox. That reading of the
+//! source is right, but the divergence is NOT demonstrated — see
+//! `the_substitute_agrees_on_every_shape_tried`, which pins the measured agreement
+//! across four shapes. What IS demonstrated is narrower and still sufficient: the
+//! substitute needs `owl:Thing` declared, and the unbounded check silently reports
+//! `true` when its own internal budget elapses.
+//!
+//! Direction of each outcome:
+//! * `Some(false)` — a clash was WITNESSED. Never invented.
+//! * `Some(true)`  — consistent at `is_consistent`'s trust level (incl. wedge `Sat`).
+//! * `None`        — gave up inside the budget. The UNBOUNDED path reports `true`
+//!   in the corresponding case, which is sound but invisible; removing that
+//!   silence is the point.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+use std::time::Duration;
+
+const GENEROUS: Duration = Duration::from_secs(30);
+
+fn onto(body: &str) -> SetOntology<RcStr> {
+    let src = format!("Prefix(:=<http://ex#>)\nOntology(\n{body}\n)");
+    let mut reader = Cursor::new(src);
+    read_ofn(&mut reader, ParserConfiguration::default())
+        .expect("parse")
+        .0
+}
+
+/// An ABox-only clash on a PURE-EL TBox: two disjoint classes asserted of one
+/// individual. Nothing in the TBox is unsatisfiable.
+const ABOX_ONLY_CLASH: &str = r"Declaration(Class(:A)) Declaration(Class(:B))
+    Declaration(NamedIndividual(:x))
+    DisjointClasses(:A :B)
+    ClassAssertion(:A :x)
+    ClassAssertion(:B :x)";
+
+#[test]
+fn witnessed_inconsistency_is_reported() {
+    let o = onto(ABOX_ONLY_CLASH);
+    assert_eq!(
+        owl_dl_reasoner::is_consistent_with_timeout(&o, GENEROUS).unwrap(),
+        Some(false),
+        "an ABox clash must be witnessed inside a generous budget"
+    );
+}
+
+#[test]
+fn a_consistent_ontology_is_reported_consistent() {
+    let o = onto(
+        r"Declaration(Class(:A)) Declaration(Class(:B))
+        Declaration(NamedIndividual(:x))
+        SubClassOf(:A :B)
+        ClassAssertion(:A :x)",
+    );
+    assert_eq!(
+        owl_dl_reasoner::is_consistent_with_timeout(&o, GENEROUS).unwrap(),
+        Some(true)
+    );
+}
+
+/// THE SUBSTITUTION HAZARD IS STRUCTURAL, NOT DEMONSTRATED — and this test says so
+/// rather than implying otherwise.
+///
+/// #74 argues that `is_class_satisfiable_with_timeout` on a top concept is an
+/// unsafe stand-in, because it short-circuits on `is_pure_el` before the ABox is
+/// consulted. That reading of the source is correct. But **no divergent case has
+/// been produced**: the issue's author reports measuring the two agreeing on every
+/// fixture they had, and I failed to construct one across four more shapes —
+/// ABox-only disjointness, a functional-role merge clash, a role-chain-induced
+/// range clash, and an inverse-materialised domain clash. All four agree, because
+/// `owl_dl_saturation::saturate` derives the clash and the
+/// `closure.is_unsatisfiable` short-circuit fires BEFORE the `is_pure_el` arm.
+///
+/// So the case for this API rests on the two things that ARE demonstrated:
+/// there was no bounded consistency check at all, and the unbounded one reports
+/// `true` when its own internal budget elapses (see
+/// `an_expired_budget_yields_no_verdict`).
+///
+/// One real asymmetry does show up and is pinned below: the substitute needs
+/// `owl:Thing` to be DECLARED, and errors out otherwise.
+#[test]
+fn the_substitute_agrees_on_every_shape_tried() {
+    let top = "http://www.w3.org/2002/07/owl#Thing";
+    // `owl:Thing` must be declared or the substitute cannot even be called.
+    let declared_top = "Declaration(Class(<http://www.w3.org/2002/07/owl#Thing>))";
+    for body in [
+        format!("{declared_top}\n{ABOX_ONLY_CLASH}"),
+        format!(
+            "{declared_top}
+             Declaration(Class(:A)) Declaration(Class(:B))
+             Declaration(ObjectProperty(:r)) FunctionalObjectProperty(:r)
+             Declaration(NamedIndividual(:x)) Declaration(NamedIndividual(:y1))
+             Declaration(NamedIndividual(:y2))
+             DisjointClasses(:A :B)
+             ObjectPropertyAssertion(:r :x :y1) ObjectPropertyAssertion(:r :x :y2)
+             ClassAssertion(:A :y1) ClassAssertion(:B :y2)"
+        ),
+    ] {
+        let o = onto(&body);
+        let cons = owl_dl_reasoner::is_consistent_with_timeout(&o, GENEROUS).unwrap();
+        let sat = owl_dl_reasoner::is_class_satisfiable_with_timeout(&o, top, GENEROUS).unwrap();
+        assert_eq!(
+            cons, sat,
+            "measured agreement is the CURRENT state; if this ever fails, a genuine \
+             divergent case has been found and #74's structural argument is now \
+             demonstrated — record it rather than just fixing the test:\n{body}"
+        );
+    }
+}
+
+/// The one asymmetry that IS demonstrable: the substitute requires `owl:Thing` to
+/// be declared in the ontology, and errors otherwise. `is_consistent_with_timeout`
+/// has no such precondition.
+#[test]
+fn the_substitute_needs_owl_thing_declared() {
+    let o = onto(ABOX_ONLY_CLASH);
+    let top = "http://www.w3.org/2002/07/owl#Thing";
+    assert!(
+        owl_dl_reasoner::is_class_satisfiable_with_timeout(&o, top, GENEROUS).is_err(),
+        "without a Declaration(Class(owl:Thing)) the substitute cannot be called at all"
+    );
+    assert_eq!(
+        owl_dl_reasoner::is_consistent_with_timeout(&o, GENEROUS).unwrap(),
+        Some(false),
+        "the real check has no such precondition"
+    );
+}
+
+/// An exhausted budget yields `None`, not a guess in either direction.
+#[test]
+fn an_expired_budget_yields_no_verdict() {
+    let o = onto(
+        r"Declaration(Class(:A)) Declaration(NamedIndividual(:x))
+        ClassAssertion(:A :x)",
+    );
+    assert_eq!(
+        owl_dl_reasoner::is_consistent_with_timeout(&o, Duration::from_nanos(1)).unwrap(),
+        None,
+        "a budget that cannot be met must report None rather than defaulting to a verdict"
+    );
+}
+
+/// The bounded form must not disagree with the unbounded one where both conclude.
+#[test]
+fn bounded_agrees_with_unbounded_where_both_conclude() {
+    for body in [
+        ABOX_ONLY_CLASH,
+        r"Declaration(Class(:A)) Declaration(Class(:B)) SubClassOf(:A :B)",
+        r"Declaration(Class(:A)) Declaration(Class(:B))
+          DisjointClasses(:A :B)
+          Declaration(NamedIndividual(:x)) ClassAssertion(:A :x)",
+    ] {
+        let o = onto(body);
+        let unbounded = owl_dl_reasoner::is_consistent(&o).unwrap();
+        let bounded = owl_dl_reasoner::is_consistent_with_timeout(&o, GENEROUS).unwrap();
+        assert_eq!(
+            bounded,
+            Some(unbounded),
+            "bounded and unbounded disagree on:\n{body}"
+        );
+    }
+}


### PR DESCRIPTION
Adds `is_consistent_with_timeout(&onto, Duration) -> Result<Option<bool>>`, matching the shape `is_class_satisfiable_with_timeout` already has.

| outcome | meaning |
|---|---|
| `Ok(Some(false))` | a clash was **witnessed** (saturation, `abox_check`, wedge, or tableau) |
| `Ok(Some(true))` | consistent at `is_consistent`'s trust level, including the wedge's trusted `Sat` |
| `Ok(None)` | gave up inside the budget |

**The unbounded path already times out internally and reports `true`.** That's a sound under-approximation but an invisible one — the caller cannot distinguish a real verdict from an exhausted budget. Returning `None` is the point.

The `abox_saturation` pre-check is kept and runs first: dropping it under time pressure would *build* the hazard #74 warns about rather than merely fail to disprove it.

## One correction to the issue

#74's central claim is **structural, not demonstrated**, and I've documented it that way rather than repeating it.

The issue argues satisfiability-of-`⊤` is unsafe because it short-circuits on `is_pure_el` before consulting the ABox. That reading of the source is right — but no divergent case exists. The issue's own author reports measuring the two agreeing on every fixture they had, and four further shapes agree too:

- ABox-only disjointness
- functional-role merge clash
- role-chain-induced range clash
- inverse-materialised domain clash

All agree, because `owl_dl_saturation::saturate` derives the clash and the `closure.is_unsatisfiable` short-circuit fires **before** the `is_pure_el` arm.

**My first canary asserted the divergence and passed — for the wrong reason.** It passed through its `Err(_)` arm, because `owl:Thing` isn't declared in the fixture so the substitute couldn't be called at all. With `owl:Thing` declared it returns `Ok(Some(false))` and agrees. A test that accepts an error as evidence of a behavioural difference proves nothing, and I'd have shipped that claim if I hadn't printed the actual return value.

So the justification rests on what *is* demonstrated:

1. No bounded form existed at all.
2. The unbounded one silently reports `true` on internal expiry.
3. The substitute requires `owl:Thing` to be **declared** and errors otherwise — pinned by `the_substitute_needs_owl_thing_declared`.

`the_substitute_agrees_on_every_shape_tried` pins the measured agreement, and tells the next person to *record* a genuine divergence rather than just fix the test if one ever appears.

## Gates

6 canaries; full suite **169 ok / 1866 passed / 0 failed**; clippy and fmt clean.

Closes #74
