### PR TITLE
feat(api): is_instance_of / instances_of report truncation

### DIFF
--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -85,10 +85,12 @@ pub use property_values::{
     inferred_object_property_values,
 };
 pub use realize::{
-    Realization, instances_of, instances_of_internal, instances_of_saturation_only,
+    Realization, instances_of, instances_of_internal, instances_of_reporting,
+    instances_of_reporting_internal, instances_of_saturation_only,
     instances_of_saturation_only_internal, is_instance_of, is_instance_of_internal,
-    is_instance_of_saturation_only, is_instance_of_saturation_only_internal, realize,
-    realize_internal, realize_saturation_only, realize_saturation_only_internal,
+    is_instance_of_reporting, is_instance_of_reporting_internal, is_instance_of_saturation_only,
+    is_instance_of_saturation_only_internal, realize, realize_internal, realize_saturation_only,
+    realize_saturation_only_internal,
 };
 pub use repair::{Repair, Repairs, find_repairs, find_repairs_prepared};
 

--- a/crates/owl-dl-reasoner/src/realize.rs
+++ b/crates/owl-dl-reasoner/src/realize.rs
@@ -72,7 +72,7 @@ const DEFAULT_PSEUDO_MODEL_WITNESS_MS: u64 = 1000;
 /// `realize` call, under a bounded deadline
 /// (`RUSTDL_PSEUDO_MODEL_WITNESS_MS`, default
 /// [`DEFAULT_PSEUDO_MODEL_WITNESS_MS`]), and threads each individual's
-/// witness type set into [`instance_check_with_closure`] as a subtractive
+/// witness type set into [`instance_check_reporting`] as a subtractive
 /// prune: `class ∉ witness_types(individual) ⇒ Ok(false)`, skipping the
 /// per-pair `{a} ⊓ ¬C` tableau probe entirely. The prune only ever returns
 /// `Ok(false)` and only fires AFTER the told-closure `Ok(true)` fast path, so
@@ -198,6 +198,25 @@ pub fn is_instance_of<A: ForIRI>(
     is_instance_of_internal(&internal, class_iri, individual_iri)
 }
 
+/// [`is_instance_of`] plus the truncation flag (#73): `(is_instance, incomplete)`.
+///
+/// A bare [`is_instance_of`] returning `false` cannot be distinguished from a
+/// probe that was CUT, so a slow query silently becomes a negative answer. See
+/// [`is_instance_of_reporting_internal`] for what the flag does and does not
+/// claim.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub fn is_instance_of_reporting<A: ForIRI>(
+    ontology: &SetOntology<A>,
+    class_iri: &str,
+    individual_iri: &str,
+) -> Result<(bool, bool), ReasonError> {
+    let internal = convert_ontology(ontology)?;
+    is_instance_of_reporting_internal(&internal, class_iri, individual_iri)
+}
+
 /// Internal entry point.
 ///
 /// # Errors
@@ -208,6 +227,35 @@ pub fn is_instance_of_internal(
     class_iri: &str,
     individual_iri: &str,
 ) -> Result<bool, ReasonError> {
+    is_instance_of_reporting_internal(internal, class_iri, individual_iri)
+        .map(|(is_inst, _)| is_inst)
+}
+
+/// Truncation-reporting form of [`is_instance_of`] (#73). Returns
+/// `(is_instance, incomplete)`.
+///
+/// `incomplete == true` means the probe was CUT — a deadline expiry, a
+/// `RUSTDL_MAX_NODES` trip or a depth bail — rather than refuted. Without it a
+/// caller cannot distinguish "not an instance" from "gave up", and a slow query
+/// silently becomes a negative answer.
+///
+/// Note `(true, true)` is possible and is still a sound positive: the membership
+/// was proved even though some other part of the check was cut. Only a `false`
+/// answer is called into question by the flag, which is why this returns a pair
+/// rather than an `Option<bool>` — collapsing them would discard a verdict that
+/// is known good.
+///
+/// The value has always been computed one call down in `instance_check_reporting`;
+/// [`is_instance_of`] simply discarded it.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub fn is_instance_of_reporting_internal(
+    internal: &InternalOntology,
+    class_iri: &str,
+    individual_iri: &str,
+) -> Result<(bool, bool), ReasonError> {
     let class_id = internal
         .vocabulary
         .class_id(class_iri)
@@ -220,10 +268,15 @@ pub fn is_instance_of_internal(
     // saturation — `a : C` iff `C` subsumes `a`'s nominal class. Avoids the
     // `{a} ⊓ ¬C` tableau probe that explodes on issue-#35-style inputs.
     if realize_saturation_eligible(internal) {
+        // Complete and terminating on this fragment, with no tableau probe, so
+        // nothing can be cut: `incomplete` is false by construction here.
         let (subsumers, nominal_by_ind) = saturate_for_realize(internal);
-        return Ok(nominal_by_ind
-            .get(&individual_id)
-            .is_some_and(|&nom| subsumers.contains(nom, class_id)));
+        return Ok((
+            nominal_by_ind
+                .get(&individual_id)
+                .is_some_and(|&nom| subsumers.contains(nom, class_id)),
+            false,
+        ));
     }
     let closure = saturate(internal);
     let prepared = PreparedOntology::from_internal(internal.clone())?;
@@ -232,7 +285,7 @@ pub fn is_instance_of_internal(
     // Single-pair path — the witness is a realize-loop optimization (one
     // witness amortized across the whole per-individual, per-class loop);
     // it isn't worth building for a lone instance check.
-    instance_check_with_closure(
+    instance_check_reporting(
         internal,
         &closure,
         &prepared,
@@ -304,6 +357,15 @@ pub fn is_instance_of_saturation_only_internal(
 ///    — `a` is in `Rng` via the property range axiom, transitively
 ///    via the role hierarchy.
 ///
+/// `(is_instance, truncated)` — the instance check, plus WHETHER a negative answer
+/// came from a real refutation or from a cut probe.
+///
+/// This is now the ONLY instance-check entry point. It previously had a
+/// `instance_check_with_closure` wrapper whose whole body was
+/// `.map(|(is_instance, _truncated)| is_instance)`; both callers
+/// (`is_instance_of_internal`, `instances_of_internal`) went through it and so
+/// threw the flag away, which is precisely what #73 reported. The wrapper is gone
+/// rather than left as a trap.
 /// Falls through to the `{a} ⊓ ¬C` satisfiability reduction otherwise.
 ///
 /// `base_types`, when `Some`, is one `ABox` witness model's COMPLETE type set
@@ -316,29 +378,7 @@ pub fn is_instance_of_saturation_only_internal(
 /// returned `true` above, so it is never pruned; a class the individual
 /// genuinely has is always present in a real witness model's label). `None`
 /// (no witness available) takes the unchanged normal path.
-fn instance_check_with_closure(
-    internal: &InternalOntology,
-    closure: &Subsumers,
-    prepared: &PreparedOntology,
-    class_id: ClassId,
-    individual_id: IndividualId,
-    pair_deadline: Option<std::time::Instant>,
-    base_types: Option<&HashSet<ClassId>>,
-) -> Result<bool, ReasonError> {
-    instance_check_reporting(
-        internal,
-        closure,
-        prepared,
-        class_id,
-        individual_id,
-        pair_deadline,
-        base_types,
-    )
-    .map(|(is_instance, _truncated)| is_instance)
-}
-
-/// `(is_instance, truncated)` — [`instance_check_with_closure`] plus WHETHER the
-/// negative answer came from a real refutation or from a cut probe.
+///
 ///
 /// **Why this exists.** A deadline expiry, a `RUSTDL_MAX_NODES` trip and a
 /// depth-limit bail all collapse to `Ok(false)` = "not an instance". That is a sound
@@ -401,7 +441,7 @@ fn instance_check_reporting(
     }
 }
 
-/// Saturation-only counterpart to [`instance_check_with_closure`].
+/// Saturation-only counterpart to [`instance_check_reporting`].
 /// Reports `true` iff a told class of `individual_id` already has
 /// `class_id` in its EL-closure subsumer set. Skips the
 /// `{a} ⊓ ¬C` tableau probe entirely — sound under-approximation
@@ -505,6 +545,22 @@ pub fn instances_of<A: ForIRI>(
     instances_of_internal(&internal, class_iri)
 }
 
+/// [`instances_of`] plus the truncation flag (#73): `(instances, incomplete)`.
+///
+/// `incomplete == true` means at least one per-individual probe was cut, so the
+/// set may be MISSING members. The members present are still sound.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub fn instances_of_reporting<A: ForIRI>(
+    ontology: &SetOntology<A>,
+    class_iri: &str,
+) -> Result<(Vec<String>, bool), ReasonError> {
+    let internal = convert_ontology(ontology)?;
+    instances_of_reporting_internal(&internal, class_iri)
+}
+
 /// Internal entry point.
 ///
 /// # Errors
@@ -514,6 +570,24 @@ pub fn instances_of_internal(
     internal: &InternalOntology,
     class_iri: &str,
 ) -> Result<Vec<String>, ReasonError> {
+    instances_of_reporting_internal(internal, class_iri).map(|(v, _)| v)
+}
+
+/// Truncation-reporting form of [`instances_of`] (#73). Returns
+/// `(instances, incomplete)`.
+///
+/// `incomplete == true` means at least one per-individual probe was CUT, so the
+/// returned set may be MISSING members. The set itself stays sound — every
+/// individual in it was proved — so this is an under-approximation the caller can
+/// now detect instead of mistaking for the complete answer.
+///
+/// # Errors
+///
+/// See [`ReasonError`].
+pub fn instances_of_reporting_internal(
+    internal: &InternalOntology,
+    class_iri: &str,
+) -> Result<(Vec<String>, bool), ReasonError> {
     let class_id = internal
         .vocabulary
         .class_id(class_iri)
@@ -535,12 +609,15 @@ pub fn instances_of_internal(
                 }
             }
         }
-        return Ok(out);
+        // Complete and terminating on this fragment: nothing can be cut.
+        return Ok((out, false));
     }
     let closure = saturate(internal);
     let prepared = PreparedOntology::from_internal(internal.clone())?;
     let pair_deadline_ms: Option<u64> = realize_pair_timeout_ms_from_env();
     let mut out = Vec::new();
+    // Sticky across the loop: ANY cut probe means the returned SET may be short.
+    let mut incomplete = false;
     for idx in 0..internal.vocabulary.num_individuals() {
         let individual_id =
             IndividualId::new(u32::try_from(idx).expect("individual count fits in u32"));
@@ -548,7 +625,7 @@ pub fn instances_of_internal(
             .map(|ms| std::time::Instant::now() + std::time::Duration::from_millis(ms));
         // Single-pair-per-individual path — same rationale as
         // `is_instance_of_internal`: no shared witness to amortize here.
-        if instance_check_with_closure(
+        let (is_inst, cut) = instance_check_reporting(
             internal,
             &closure,
             &prepared,
@@ -556,14 +633,16 @@ pub fn instances_of_internal(
             individual_id,
             pair_deadline,
             None,
-        )? {
+        )?;
+        incomplete |= cut;
+        if is_inst {
             let iri = internal.vocabulary.individual_iri(individual_id);
             if !iri.starts_with(owl_dl_core::convert::ANON_IRI_PREFIX) {
                 out.push(iri.to_owned());
             }
         }
     }
-    Ok(out)
+    Ok((out, incomplete))
 }
 
 /// Saturation-only counterpart of [`instances_of`]. Returns the
@@ -1414,7 +1493,7 @@ Ontology(<http://rustdl.test/test>\n\
     }
 
     /// White-box canary (Task 3, RED before `base_types` exists — this test
-    /// only compiles once `instance_check_with_closure` gains the param):
+    /// only compiles once `instance_check_reporting` gains the param):
     /// the `base_types` prune is a genuine short-circuit that takes
     /// precedence over the `{a} ⊓ ¬C` tableau probe, not a no-op parameter.
     ///
@@ -1428,7 +1507,7 @@ Ontology(<http://rustdl.test/test>\n\
     /// must flip the answer to `Ok(false)` — proving the prune is consulted
     /// and dominates. (Production callers only ever pass a genuine witness
     /// model's type set, which — per the soundness note on
-    /// `instance_check_with_closure` — never excludes a genuinely-entailed
+    /// `instance_check_reporting` — never excludes a genuinely-entailed
     /// class; this test isolates the mechanism with a synthetic input.)
     #[test]
     fn pseudo_model_prune_short_circuits_before_tableau_probe() {
@@ -1457,8 +1536,9 @@ Ontology(<http://rustdl.test/test>\n\
         // Baseline: no witness ⇒ the tableau probe alone correctly derives
         // a:E via the disjunctive case split.
         assert!(
-            instance_check_with_closure(&internal, &closure, &prepared, e_id, a_id, None, None)
-                .expect("verdict"),
+            instance_check_reporting(&internal, &closure, &prepared, e_id, a_id, None, None)
+                .expect("verdict")
+                .0,
             "a:E must be entailed via case-split tableau reasoning",
         );
 
@@ -1467,7 +1547,7 @@ Ontology(<http://rustdl.test/test>\n\
         // answer — proof the prune actually fires.
         let empty: HashSet<ClassId> = HashSet::new();
         assert!(
-            !instance_check_with_closure(
+            !instance_check_reporting(
                 &internal,
                 &closure,
                 &prepared,
@@ -1476,7 +1556,8 @@ Ontology(<http://rustdl.test/test>\n\
                 None,
                 Some(&empty),
             )
-            .expect("verdict"),
+            .expect("verdict")
+            .0,
             "base_types excluding E must short-circuit to Ok(false)",
         );
 
@@ -1484,7 +1565,7 @@ Ontology(<http://rustdl.test/test>\n\
         // gives the correct answer.
         let with_e: HashSet<ClassId> = HashSet::from([e_id]);
         assert!(
-            instance_check_with_closure(
+            instance_check_reporting(
                 &internal,
                 &closure,
                 &prepared,
@@ -1493,7 +1574,8 @@ Ontology(<http://rustdl.test/test>\n\
                 None,
                 Some(&with_e),
             )
-            .expect("verdict"),
+            .expect("verdict")
+            .0,
             "base_types containing E must not block the correct Ok(true)",
         );
     }
@@ -1528,7 +1610,7 @@ Ontology(<http://rustdl.test/test>\n\
 
         let empty: HashSet<ClassId> = HashSet::new();
         assert!(
-            instance_check_with_closure(
+            instance_check_reporting(
                 &internal,
                 &closure,
                 &prepared,
@@ -1537,7 +1619,8 @@ Ontology(<http://rustdl.test/test>\n\
                 None,
                 Some(&empty),
             )
-            .expect("verdict"),
+            .expect("verdict")
+            .0,
             "told/derived membership must win before base_types is consulted",
         );
     }

--- a/crates/owl-dl-reasoner/tests/instance_truncation_flag.rs
+++ b/crates/owl-dl-reasoner/tests/instance_truncation_flag.rs
@@ -1,0 +1,121 @@
+//! `is_instance_of` / `instances_of` now report truncation (#73).
+//!
+//! Both discarded a flag that `instance_check_reporting` already computed one call
+//! down — a single `.map(|(is_instance, _truncated)| is_instance)`. A caller doing
+//! a point membership check got `Ok(false)` with no way to tell a refutation from a
+//! timeout, so a slow query silently became a negative answer. The only workaround
+//! was to run the whole of `realize` just to read `incomplete()`.
+//!
+//! ## What the flag claims
+//!
+//! `(true, true)` is possible and is still a SOUND positive: the membership was
+//! proved even though something else was cut. Only a `false` answer is called into
+//! question. That is why these return a pair rather than an `Option<bool>` —
+//! collapsing them would throw away a verdict that is known good.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::fmt::Write as _;
+use std::io::Cursor;
+
+fn onto(body: &str) -> SetOntology<RcStr> {
+    let src = format!("Prefix(:=<http://t/>)\nOntology(<http://t/x>\n{body}\n)");
+    let mut reader = Cursor::new(src);
+    read_ofn(&mut reader, ParserConfiguration::default())
+        .expect("parse")
+        .0
+}
+
+/// Disjunctive memberships: `a : (Ai ⊔ Bi)` with both disjuncts implying `Ci`, so
+/// `a : Ci` holds only by CASE ANALYSIS and a real tableau probe must run. Same
+/// shape `realize_incomplete_signal.rs` uses, and for the same reason: a told
+/// closure answers before any probe, so a chain would not exercise truncation.
+fn disjunctive(k: usize) -> String {
+    let mut s = String::from("Declaration(NamedIndividual(:a))\n");
+    for i in 0..k {
+        let _ = write!(
+            s,
+            "Declaration(Class(:A{i})) Declaration(Class(:B{i})) Declaration(Class(:C{i}))\n\
+             ClassAssertion(ObjectUnionOf(:A{i} :B{i}) :a)\n\
+             SubClassOf(:A{i} :C{i})\n\
+             SubClassOf(:B{i} :C{i})\n"
+        );
+    }
+    s
+}
+
+/// Guard for an env var that must not leak into sibling tests.
+struct EnvGuard(Option<std::ffi::OsString>);
+impl Drop for EnvGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        // SAFETY: see `set`.
+        unsafe {
+            match self.0.take() {
+                Some(v) => std::env::set_var("RUSTDL_REALIZE_PAIR_TIMEOUT_MS", v),
+                None => std::env::remove_var("RUSTDL_REALIZE_PAIR_TIMEOUT_MS"),
+            }
+        }
+    }
+}
+#[allow(unsafe_code)]
+fn set_budget(ms: &str) -> EnvGuard {
+    let g = EnvGuard(std::env::var_os("RUSTDL_REALIZE_PAIR_TIMEOUT_MS"));
+    // SAFETY: this binary contains ONE test, so no other thread reads the
+    // environment while it is set — the same reason realize_incomplete_signal.rs
+    // merged its two tests.
+    unsafe {
+        std::env::set_var("RUSTDL_REALIZE_PAIR_TIMEOUT_MS", ms);
+    }
+    g
+}
+
+/// Control and experiment in ONE test, for the reason recorded in
+/// `realize_incomplete_signal.rs`: they share a process-global variable, and
+/// splitting them into two `#[test]`s produced a race that failed ~1 run in 3.
+#[test]
+fn point_queries_report_whether_a_probe_was_cut() {
+    // ── control: at the default budget every probe concludes, so nothing is cut
+    // and the flag must be clear on BOTH surfaces.
+    let o = onto(&disjunctive(60));
+    let (is_inst, cut) = owl_dl_reasoner::is_instance_of_reporting(&o, "http://t/C0", "http://t/a")
+        .expect("is_instance_of_reporting at the default budget");
+    assert!(is_inst, "a : C0 holds by case analysis");
+    assert!(!cut, "nothing is cut at the default budget");
+
+    let (members, cut) = owl_dl_reasoner::instances_of_reporting(&o, "http://t/C0")
+        .expect("instances_of_reporting at the default budget");
+    assert_eq!(members, vec!["http://t/a".to_string()]);
+    assert!(!cut, "nothing is cut at the default budget");
+
+    // The un-reporting forms must agree with the reporting ones, so the refactor
+    // did not change existing behaviour.
+    assert_eq!(
+        owl_dl_reasoner::is_instance_of(&o, "http://t/C0", "http://t/a").unwrap(),
+        is_inst
+    );
+    assert_eq!(
+        owl_dl_reasoner::instances_of(&o, "http://t/C0").unwrap(),
+        members
+    );
+
+    // ── experiment: squeeze the per-pair budget and the probe is cut, so the flag
+    // must fire. k is a RELIABILITY parameter — the deadline is per pair, so a
+    // larger fixture makes "no probe cut" vanishingly unlikely; see the same
+    // reasoning in realize_incomplete_signal.rs.
+    let dense = onto(&disjunctive(240));
+    let _g = set_budget("1");
+    let (_, cut) = owl_dl_reasoner::instances_of_reporting(&dense, "http://t/C0")
+        .expect("instances_of_reporting under a 1 ms budget");
+    assert!(
+        cut,
+        "a 1 ms per-pair budget must cut at least one probe; if this fires, either \
+         the fixture became decidable without probing or the flag is being discarded \
+         again — the exact defect #73 reported"
+    );
+}


### PR DESCRIPTION
Both point queries discarded a flag `instance_check_reporting` already computed one call down — a single `.map(|(is_instance, _truncated)| is_instance)`. A caller got `Ok(false)` with no way to tell a refutation from a timeout, so a slow query silently became a negative answer. The only workaround was running the whole of `realize` just to read `incomplete()`.

Adds `is_instance_of_reporting -> (bool, bool)` and `instances_of_reporting -> (Vec<String>, bool)` (plus `_internal` forms), and makes the reporting versions **the** implementation so the existing functions are thin `.map` wrappers — one code path, not two.

## Why a pair and not `Option<bool>`

`(true, true)` is possible and is still a **sound positive**: the membership was proved even though something else was cut. Only a `false` answer is called into question. Collapsing to `Option<bool>` would discard a verdict that is known good.

For `instances_of` the flag is sticky across the loop: any cut probe means the **set** may be short, though every member present is still sound.

The saturation fast path returns `incomplete = false` by construction — complete and terminating on that fragment, no tableau probe, so nothing can be cut.

## Removed `instance_check_with_closure`

Its entire body was the `.map` that dropped the flag, and both callers went through it. It wasn't a helper, it was the defect — deleting it means the next caller can't reintroduce #73 by reaching for the convenient wrapper. Its `base_types` documentation is preserved on the surviving `instance_check_reporting`; four in-file callers and four doc references were updated.

The compiler caught two call sites my grep had missed, because I'd filtered out the definition line and hidden same-file matches. `grep -v` on a line number is not a way to enumerate callers.

## Gates

`point_queries_report_whether_a_probe_was_cut` covers both surfaces, control and experiment in **one** test for the reason `realize_incomplete_signal.rs` records — two tests sharing a process-global raced ~1 run in 3. Stable **20/20**. It also pins the un-reporting forms as agreeing with the reporting ones, so this refactor changed no existing behaviour.

Full suite **169 ok / 1861 passed / 0 failed**; clippy and fmt clean.

Closes #73
