### PR TITLE
fix(classify): consult the wedge consistency route in the inconsistency pre-check

### DIFF
--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -2874,6 +2874,62 @@ pub(crate) fn classify_inconsistency_precheck(
                 ms => Some(std::time::Duration::from_millis(ms)),
             },
         )
+        || classify_wedge_inconsistent(internal)
+}
+
+/// `RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY` — **default ON**, `=0` reverts (#89).
+///
+/// Adds the ABox-seeded WEDGE consistency route to classify's pre-check. Without
+/// it `classify` reported `consistent: true` on ontologies `rustdl consistent`,
+/// Konclude AND Kobayashi-MaRust all call inconsistent (`ore_ont_16321`,
+/// `ore_ont_4198`).
+///
+/// # Why the wedge specifically
+///
+/// Traced on both reproducers, the verdict comes from `consistency: wedge Unsat`
+/// — not from the saturator and not from `abox_saturation`, the two signals
+/// classify already had. `abox_saturation` propagates over NAMED individuals with
+/// no witness generation, so a clash at a data successor (a `DataPropertyRange`
+/// violated by an assertion) is out of its reach by construction.
+///
+/// #89 framed the fix as needing `DKey`-aware `ABox` saturation or a `decide(Top)`
+/// probe. Neither is required. Note also that the design record calls a
+/// `decide(Top)` probe here "a measured dead-end (hangs on consistent
+/// alehif/pizza)" — that is about an UNBOUNDED probe; the wedge route is bounded
+/// and measures 2.34 ms on pizza.
+///
+/// # Cost
+///
+/// Gated on `internal_has_abox`, so `ABox`-free inputs (galen and most of ORE) pay
+/// NOTHING and the reduced-input fast path is untouched. For ABox-bearing inputs
+/// it is one `ConsistencyCache::build` plus a bounded `decide`, reusing the same
+/// budget as the `ABox` pre-check.
+fn classify_wedge_inconsistency_enabled() -> bool {
+    std::env::var_os("RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY").is_none_or(|v| v != "0")
+}
+
+/// The wedge half of [`classify_inconsistency_precheck`]. `true` only on a
+/// witnessed `Unsat`: `Sat` and `Stalled` both mean "no clash seen here", which is
+/// the same sound under-approximation classify already made.
+fn classify_wedge_inconsistent(internal: &InternalOntology) -> bool {
+    if !classify_wedge_inconsistency_enabled()
+        || !wedge_consistency_enabled()
+        || !internal_has_abox(internal)
+    {
+        return false;
+    }
+    let budget = match classify_inconsistency_budget_ms(internal) {
+        0 => None,
+        ms => Some(std::time::Instant::now() + std::time::Duration::from_millis(ms)),
+    };
+    let unsat = matches!(
+        ConsistencyCache::build(internal).decide(budget),
+        owl_dl_tableau::hyper::HyperResult::Unsat
+    );
+    if unsat && std::env::var_os("RUSTDL_TRACE").is_some() {
+        eprintln!("classify: KB inconsistent (wedge Unsat)");
+    }
+    unsat
 }
 
 /// Per-class deadline (in milliseconds) for the Phase 7 label-cache

--- a/crates/owl-dl-reasoner/tests/classify_wedge_inconsistency.rs
+++ b/crates/owl-dl-reasoner/tests/classify_wedge_inconsistency.rs
@@ -1,0 +1,169 @@
+//! `classify` now consults the ABox-seeded WEDGE consistency route (#89).
+//!
+//! Before this, `classify --json` reported `"consistent": true` on ontologies that
+//! `rustdl consistent`, Konclude AND Kobayashi-MaRust all call inconsistent
+//! (`ore_ont_16321`, `ore_ont_4198`). Two surfaces of one binary, opposite answers.
+//!
+//! ## Why the wedge, and not the two signals classify already had
+//!
+//! Traced on both reproducers the verdict reads `consistency: wedge Unsat`. The
+//! saturator does not see it, and `abox_saturation` cannot: it propagates over
+//! NAMED individuals with no witness generation, while the clash sits at a DATA
+//! SUCCESSOR — a `DataPropertyRange` violated by an assertion. That is out of its
+//! reach by construction, not by budget.
+//!
+//! #89 framed the fix as needing DKey-aware ABox saturation or a `decide(Top)`
+//! probe. Neither was required. The design record separately calls a `decide(Top)`
+//! probe here "a measured dead-end (hangs on consistent alehif/pizza)" — that is
+//! about an UNBOUNDED probe; the wedge route is bounded and measures 2.34 ms on
+//! pizza.
+//!
+//! ## Direction of risk
+//!
+//! Only a witnessed `Unsat` returns true. `Sat` and `Stalled` both mean "no clash
+//! seen", the same sound under-approximation classify already made — so this can
+//! only ever ADD detections, never invent one. The negative controls below are the
+//! load-bearing half: a spurious inconsistency marks EVERY class unsatisfiable.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+fn onto(body: &str) -> SetOntology<RcStr> {
+    let src = format!(
+        "Prefix(:=<http://ex#>)\n\
+         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n\
+         Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n\
+         Ontology(\n{body}\n)"
+    );
+    let mut reader = Cursor::new(src);
+    read_ofn(&mut reader, ParserConfiguration::default())
+        .expect("parse")
+        .0
+}
+
+fn classify_says_consistent(o: &SetOntology<RcStr>) -> bool {
+    !owl_dl_reasoner::classify(o).unwrap().stats().inconsistent
+}
+
+/// #89's own two-axiom reproducer. `xsd:float` and `xsd:double` have disjoint
+/// value spaces, so the asserted value cannot lie in the declared range.
+const FLOAT_IN_DOUBLE_RANGE: &str = r#"Declaration(DataProperty(:p))
+    Declaration(NamedIndividual(:a))
+    DataPropertyRange(:p xsd:double)
+    DataPropertyAssertion(:p :a "1.0"^^xsd:float)"#;
+
+/// Detection, cross-surface agreement, and the flag's load-bearing-ness in ONE
+/// test — deliberately.
+///
+/// These were three `#[test]`s. Two depend on the flag being ON and the third
+/// mutates it, and cargo runs a binary's tests concurrently, so the process-global
+/// write raced the readers: **15 of 15 runs failed** at default concurrency while
+/// passing under `--test-threads=1`. That is the same defect #92/#94 documented in
+/// `realize_incomplete_signal.rs`, caught here before it shipped rather than after.
+///
+/// The negative controls below stay separate because they are flag-INDEPENDENT: the
+/// route only ever ADDS detections, so a consistent ontology stays consistent
+/// whichever way the flag is set.
+#[test]
+fn wedge_route_detects_and_the_flag_is_load_bearing() {
+    let o = onto(FLOAT_IN_DOUBLE_RANGE);
+
+    // ── the fix: classify no longer reports consistent on a KB the wedge refutes
+    assert!(
+        !classify_says_consistent(&o),
+        "classify must not report consistent on a KB the wedge refutes (#89)"
+    );
+
+    // ── the point of #89 was that the two surfaces DISAGREED; pin that they agree
+    for body in [
+        FLOAT_IN_DOUBLE_RANGE,
+        // an ordinary ABox clash, which both surfaces already caught
+        r"Declaration(Class(:A)) Declaration(Class(:B)) Declaration(NamedIndividual(:x))
+          DisjointClasses(:A :B) ClassAssertion(:A :x) ClassAssertion(:B :x)",
+    ] {
+        let each = onto(body);
+        assert_eq!(
+            classify_says_consistent(&each),
+            owl_dl_reasoner::is_consistent(&each).unwrap(),
+            "classify and is_consistent must agree on:\n{body}"
+        );
+    }
+
+    // ── the flag is load-bearing: with it off, #89 reproduces. If this ever
+    // fails, the defect closed by another route and the flag can retire.
+    let _g = EnvGuard::set("0");
+    assert!(
+        classify_says_consistent(&o),
+        "with RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY=0 the pre-existing #89 behaviour \
+         must reappear; if it does not, this fix is not what is doing the work"
+    );
+}
+
+// ── NEGATIVE CONTROLS: a spurious inconsistency marks EVERY class unsat ──────
+
+/// An ABox-bearing but perfectly consistent ontology must stay consistent. This
+/// is the shape the new route runs on, so it is where a false positive would land.
+#[test]
+fn a_consistent_abox_stays_consistent() {
+    let o = onto(
+        r#"Declaration(Class(:A)) Declaration(Class(:B))
+        Declaration(DataProperty(:p)) Declaration(NamedIndividual(:x))
+        SubClassOf(:A :B)
+        ClassAssertion(:A :x)
+        DataPropertyRange(:p xsd:double)
+        DataPropertyAssertion(:p :x "1.0"^^xsd:double)"#,
+    );
+    assert!(
+        classify_says_consistent(&o),
+        "matching datatypes must not clash"
+    );
+}
+
+/// The soundness subtlety this pre-check has always had to respect:
+/// all-named-classes-unsatisfiable is NOT inconsistency. `{A ⊑ ⊥, B ⊑ ⊥}` empties
+/// every named class yet has a non-empty model. Mirrors the canary in
+/// `classify_inconsistency.rs`, re-asserted here because this change adds a new
+/// route into the same verdict.
+#[test]
+fn all_classes_unsat_is_still_consistent() {
+    let o = onto(
+        r"Declaration(Class(:A)) Declaration(Class(:B))
+        Declaration(NamedIndividual(:x)) Declaration(ObjectProperty(:r))
+        SubClassOf(:A owl:Nothing)
+        SubClassOf(:B owl:Nothing)
+        ObjectPropertyAssertion(:r :x :x)",
+    );
+    assert!(
+        classify_says_consistent(&o),
+        "every named class empty is not an inconsistency — the test is that TOP is unsat"
+    );
+}
+
+struct EnvGuard(Option<std::ffi::OsString>);
+impl EnvGuard {
+    #[allow(unsafe_code)]
+    fn set(v: &str) -> Self {
+        let prior = std::env::var_os("RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY");
+        // SAFETY: the only test in this binary that mutates the environment.
+        unsafe { std::env::set_var("RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY", v) };
+        Self(prior)
+    }
+}
+impl Drop for EnvGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        // SAFETY: see `set`.
+        unsafe {
+            match self.0.take() {
+                Some(v) => std::env::set_var("RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY", v),
+                None => std::env::remove_var("RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY"),
+            }
+        }
+    }
+}

--- a/crates/owl-dl-reasoner/tests/surface_agreement.rs
+++ b/crates/owl-dl-reasoner/tests/surface_agreement.rs
@@ -184,26 +184,56 @@ fn classify_agrees_with_the_per_query_surfaces() {
     );
 }
 
+/// Shapes that USED to diverge and now must agree. A row arrives here when
+/// `the_gate_detects_the_known_divergences` fails because the defect was fixed —
+/// so the same fixture keeps working, on the other side of the ledger.
+#[test]
+fn previously_divergent_shapes_now_agree() {
+    // #89 — classify reported `consistent: true` on a KB `rustdl consistent`,
+    // Konclude and Kobayashi-MaRust all call inconsistent. Fixed by consulting the
+    // wedge consistency route in classify's pre-check.
+    let body = r#"Declaration(DataProperty(:p)) Declaration(NamedIndividual(:a))
+                  DataPropertyRange(:p xsd:double)
+                  DataPropertyAssertion(:p :a "1.0"^^xsd:float)"#;
+    let src = format!(
+        "Prefix(:=<http://ex#>)\n\
+         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n\
+         Ontology(\n{body}\n)"
+    );
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).unwrap();
+    let (d, _skipped, compared) = divergences(&onto, "#89", true);
+    assert!(
+        compared > 0,
+        "no comparison made — a green result would be vacuous"
+    );
+    assert!(
+        d.is_empty(),
+        "#89 regressed: classify and the per-query surfaces disagree again:\n{}",
+        d.join("\n")
+    );
+}
+
 /// The gate must DETECT divergence, not merely fail to find it. Each case below
 /// is a known live defect, one per leg, so all three legs are proven to fire.
 ///
 /// **This test asserts the CURRENT (broken) state deliberately.** When one of
 /// these is fixed it will FAIL, which is the signal to delete that row and — if
-/// the fixture is cheap — move it into the passing gate above. That is the
+/// the fixture is cheap — move it into the passing gate above.
+///
+/// **That has already happened once, within a day.** #89 was fixed by the wedge
+/// consistency route, and this test failed in CI with
+/// `the gate did NOT detect ["#89"]`. Its fixture now lives in
+/// `previously_divergent_shapes_now_agree`, where it guards against regression
+/// instead. An `#[ignore]`d sentinel would have gone on passing silently. That is the
 /// opposite of an `#[ignore]`d sentinel, which goes stale silently: a fix here is
 /// loud. See `docs/2026-08-18-ignored-sentinels-went-stale-unobserved.md` for the
 /// failure mode this avoids.
 #[test]
 fn the_gate_detects_the_known_divergences() {
     // (issue, leg exercised, ontology body)
-    let cases: [(&str, &str, &str); 3] = [
-        (
-            "#89",
-            "consistency",
-            r#"Declaration(DataProperty(:p)) Declaration(NamedIndividual(:a))
-               DataPropertyRange(:p xsd:double)
-               DataPropertyAssertion(:p :a "1.0"^^xsd:float)"#,
-        ),
+    let cases: [(&str, &str, &str); 2] = [
         (
             "#91",
             "satisfiability",


### PR DESCRIPTION
`classify --json` reported `"consistent": true` on ontologies that `rustdl consistent`, Konclude **and** Kobayashi-MaRust all call inconsistent (`ore_ont_16321`, `ore_ont_4198`). Two surfaces of one binary, opposite answers — and the worst version of that shape, since a consumer reading `"consistent": true` builds every downstream entailment on a KB with no models.

## The fix is smaller than the issue predicted

#89 proposed DKey-aware ABox saturation or a `decide(Top)` probe. **Neither is needed.** Tracing both reproducers, the verdict already exists and reads `consistency: wedge Unsat` — it simply wasn't consulted from classify.

classify's pre-check had two signals: the saturator (`globally_inconsistent` / `top_is_unsat`) and `abox_saturation`. The latter propagates over **named individuals with no witness generation**, while this clash sits at a **data successor** (a `DataPropertyRange` violated by an assertion). Out of reach by construction, not by budget.

The design record calls a `decide(Top)` probe here *"a measured dead-end (hangs on consistent alehif/pizza)"*. That's about an **unbounded** probe. The wedge route is bounded and measures **2.34 ms on pizza** — which is why this seam was available and that one wasn't.

`ConsistencyCache::build` takes the un-mutated `internal`, so no `PreparedOntology` is required and the reduced-input classify fast path is untouched.

## Cost

Gated on `internal_has_abox`, so ABox-free inputs pay **nothing** — sio 0.14 s and go-basic 1.63 s are *identical* both ways. ABox-bearing: pizza +0.01 s, ro +0.01 s, family +0.04 s, wine +0.08 s (~9%, the worst). All 8 curated fixtures byte-identical ON vs OFF.

## Direction of risk

Only a **witnessed** `Unsat` returns true; `Sat` and `Stalled` both mean "no clash seen", the same sound under-approximation classify already made. So this can only ADD detections, never invent one.

The negative controls are the load-bearing half — a spurious inconsistency marks *every* class unsatisfiable. That includes re-asserting the all-classes-unsat-is-NOT-inconsistency subtlety, because this adds a new route into the same verdict.

## I predicted the test race and checked for it

Three canaries depended on the flag while one mutated it. At default concurrency that failed **15 of 15** runs while passing under `--test-threads=1` — the identical defect #92/#94 documented in `realize_incomplete_signal.rs`. Merged into one test *before* committing rather than after shipping; now **15/15** clean. The negative controls stay separate because they're flag-independent.

## Gates

Full suite **169 ok / 1863 passed / 0 failed**; clippy and fmt clean.

`RUSTDL_CLASSIFY_WEDGE_INCONSISTENCY`, default ON, `=0` reverts.

Closes #89
