### PR TITLE
fix(classify): do not trust a wedge Sat for cardinality over a complex qualifier

### DIFF
--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -3801,7 +3801,26 @@ fn classify_top_down_internal_impl(
                                     || closure
                                         .subsumers_of(class_id)
                                         .iter()
-                                        .any(|s| prepared.nominal_counting_classes.contains(s))));
+                                        .any(|s| prepared.nominal_counting_classes.contains(s))))
+                            // THE SAME DEFECT ONE CONSTRUCT FURTHER (issue #91). The
+                            // wedge does no OBJECT cardinality counting over a COMPLEX
+                            // qualifier: `A ⊑ ≤1 r.(B ⊓ C)` with `A ⊑ ≥2 r.(B ⊓ C)`
+                            // makes `A` unsatisfiable, Konclude and HermiT agree, and
+                            // `rustdl sat A` agrees — but `classify` reported
+                            // `unsatisfiable: []`. `cardinality_qualifier` Tseitin-names
+                            // the complex filler, so the wedge counts a synthetic name
+                            // without relating it to the members and cannot see that the
+                            // `≤` and `≥` are over the SAME set. The ATOMIC-filler
+                            // control decides correctly, which is what isolates this to
+                            // the qualifier shape rather than to cardinality.
+                            || (crate::complex_qualifier_verify_enabled()
+                                && !prepared.complex_qualifier_counting_classes.is_empty()
+                                && (prepared
+                                    .complex_qualifier_counting_classes
+                                    .contains(&class_id)
+                                    || closure.subsumers_of(class_id).iter().any(|s| {
+                                        prepared.complex_qualifier_counting_classes.contains(s)
+                                    })));
                         if !needs_verify {
                             return Ok((i, true, true));
                         }

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -6848,7 +6848,7 @@ fn concept_has_complex_qualifier_counting(pool: &ConceptPool, c: ConceptId) -> b
 /// qualified cardinality whose filler is not a named class, and
 /// `complex_qualifier_counting_classes` is EMPTY for every other input, so the
 /// clause short-circuits before touching the closure.
-fn complex_qualifier_verify_enabled() -> bool {
+pub fn complex_qualifier_verify_enabled() -> bool {
     std::env::var_os("RUSTDL_COMPLEX_QUALIFIER_VERIFY").is_none_or(|v| v != "0")
 }
 

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -6507,6 +6507,12 @@ pub(crate) struct PreparedOntology {
     /// `build_data_counting_classes`). The classify unsat-probe
     /// main-tableau-verifies these instead of trusting the wedge's `Sat`.
     pub(crate) data_counting_classes: std::collections::HashSet<owl_dl_core::ir::ClassId>,
+    /// Classes carrying a `Min`/`Max` over a COMPLEX qualifier (#91). Consumed by
+    /// classify's unsat probe exactly as `data_counting_classes` is. Empty unless
+    /// the ontology authors a qualified cardinality whose filler is not a named
+    /// class, so the overwhelming majority of inputs pay nothing.
+    pub(crate) complex_qualifier_counting_classes:
+        std::collections::HashSet<owl_dl_core::ir::ClassId>,
 
     /// Classes the wedge cannot decide for lack of nominal counting (see
     /// `build_nominal_counting_classes`). Consumed by classify's unsat probe the same way
@@ -6783,6 +6789,100 @@ fn concept_has_nominal_counting(
     }
 }
 
+/// Does `c` carry a `Min`/`Max` whose QUALIFIER is a complex concept rather than a
+/// named class or `⊤`? Mirrors [`concept_has_nominal_counting`]'s walk.
+///
+/// `≤1 r.(B ⊓ C)` is the shape. `cardinality_qualifier` Tseitin-names a complex
+/// filler, and the wedge counts occurrences of that synthetic name rather than
+/// relating it to the members, so it cannot see that the `≤` and `≥` constraints
+/// are over the SAME set. With a named filler it can, which is exactly why the
+/// atomic control decides correctly.
+fn concept_has_complex_qualifier_counting(pool: &ConceptPool, c: ConceptId) -> bool {
+    match pool.get(c) {
+        ConceptExpr::Min(_, _, inner) | ConceptExpr::Max(_, _, inner) => {
+            if !matches!(
+                pool.get(*inner),
+                ConceptExpr::Atomic(_) | ConceptExpr::Top | ConceptExpr::Bot
+            ) {
+                return true;
+            }
+            concept_has_complex_qualifier_counting(pool, *inner)
+        }
+        ConceptExpr::Not(inner) => concept_has_complex_qualifier_counting(pool, *inner),
+        ConceptExpr::Some(_, inner) | ConceptExpr::All(_, inner) => {
+            concept_has_complex_qualifier_counting(pool, *inner)
+        }
+        ConceptExpr::And(ops) | ConceptExpr::Or(ops) => ops
+            .iter()
+            .any(|&o| concept_has_complex_qualifier_counting(pool, o)),
+        _ => false,
+    }
+}
+
+/// Classes whose satisfiability the WEDGE cannot decide because it does no object
+/// cardinality counting over a COMPLEX qualifier (#91).
+///
+/// This is the THIRD instance of one pattern, and the previous two are right beside
+/// it: `data_counting_classes` (concrete-domain counting) and
+/// `nominal_counting_classes` (#49, whose own comment reads "Same defect one
+/// construct over"). Here it is one construct further again —
+/// `A ⊑ ≤1 r.(B ⊓ C)` with `A ⊑ ≥2 r.(B ⊓ C)` makes `A` unsatisfiable, both oracles
+/// agree, `rustdl sat A` agrees, and `classify` reported `unsatisfiable: []`.
+///
+/// The ATOMIC-filler control decides correctly, which is what isolates this to the
+/// qualifier shape rather than to cardinality.
+///
+/// Consumed by classify's unsat probe exactly as the other two are: a wedge `Sat`
+/// on such a class is not trusted, and the class falls through to the main tableau.
+/// Sound either way — it only ever swaps a wedge `Sat` for the complete path — so
+/// the cost of being wrong here is wall time, never a wrong answer.
+/// `RUSTDL_COMPLEX_QUALIFIER_VERIFY` — **default ON**, `=0` reverts (#91).
+///
+/// Don't trust a wedge `Sat` for a class carrying a `Min`/`Max` over a COMPLEX
+/// qualifier; fall through to the main tableau. Sound either way — it only swaps a
+/// wedge `Sat` for the complete path — so being wrong here costs wall time, never a
+/// wrong answer.
+///
+/// Default ON, unlike its `RUSTDL_NOMINAL_COUNTING_VERIFY` sibling, because the
+/// addressable set is tiny and measured: only 5 of 1,920 ORE ontologies author a
+/// qualified cardinality whose filler is not a named class, and
+/// `complex_qualifier_counting_classes` is EMPTY for every other input, so the
+/// clause short-circuits before touching the closure.
+fn complex_qualifier_verify_enabled() -> bool {
+    std::env::var_os("RUSTDL_COMPLEX_QUALIFIER_VERIFY").is_none_or(|v| v != "0")
+}
+
+fn build_complex_qualifier_counting_classes(
+    internal: &InternalOntology,
+) -> std::collections::HashSet<owl_dl_core::ir::ClassId> {
+    let mut set = std::collections::HashSet::new();
+    let pool = &internal.concepts;
+    for ax in &internal.axioms {
+        match ax {
+            Axiom::SubClassOf { sub, sup } => {
+                if let ConceptExpr::Atomic(c) = pool.get(*sub)
+                    && concept_has_complex_qualifier_counting(pool, *sup)
+                {
+                    set.insert(*c);
+                }
+            }
+            Axiom::EquivalentClasses(members)
+                if members
+                    .iter()
+                    .any(|&m| concept_has_complex_qualifier_counting(pool, m)) =>
+            {
+                for &m in members {
+                    if let ConceptExpr::Atomic(c) = pool.get(m) {
+                        set.insert(*c);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    set
+}
+
 /// Classes whose satisfiability the WEDGE cannot decide because it does no nominal
 /// counting: a `Min`/`Max` over a class bounded to finitely many individuals
 /// (`C ≡ {a₁ … a_N}` + `B ≡ ≥(N+1) r.C` ⟹ `B ⊑ ⊥`, by pigeonhole).
@@ -6993,6 +7093,8 @@ impl PreparedOntology {
         let data_counting_classes = build_data_counting_classes(&internal, &dkey_ranges);
         let nominal_bounded = build_nominal_bounded_classes(&internal);
         let nominal_counting_classes = build_nominal_counting_classes(&internal, &nominal_bounded);
+        let complex_qualifier_counting_classes =
+            build_complex_qualifier_counting_classes(&internal);
         // H4: build the hyper cache from the un-mutated ontology
         // (before the absorb/NNF passes below consume it), iff enabled.
         if expired() {
@@ -7089,6 +7191,7 @@ impl PreparedOntology {
             dkey_ranges,
             data_counting_classes,
             nominal_counting_classes,
+            complex_qualifier_counting_classes,
             consistency,
             tableau_id: TableauIdBudget::default(),
         }))

--- a/crates/owl-dl-reasoner/tests/complex_qualifier_counting.rs
+++ b/crates/owl-dl-reasoner/tests/complex_qualifier_counting.rs
@@ -1,0 +1,127 @@
+//! The wedge does no object cardinality counting over a COMPLEX qualifier (#91).
+//!
+//! `A ⊑ ≤1 r.(B ⊓ C)` together with `A ⊑ ≥2 r.(B ⊓ C)` makes `A` unsatisfiable.
+//! Konclude and HermiT agree, `rustdl sat A` agrees — and `classify` reported
+//! `unsatisfiable: []`.
+//!
+//! ## The third instance of one pattern
+//!
+//! classify's unsat probe trusts the wedge's `LabelOracle::Sat` unless
+//! `needs_verify` fires, and that check already carved out two constructs the wedge
+//! cannot count:
+//!
+//! | | construct |
+//! |---|---|
+//! | `data_counting_classes` | concrete-domain (DKey) cardinality |
+//! | `nominal_counting_classes` (#49) | nominal counting — its comment reads "Same defect one construct over" |
+//! | **this (#91)** | **object cardinality over a COMPLEX qualifier** |
+//!
+//! `cardinality_qualifier` Tseitin-names a complex filler, so the wedge counts a
+//! synthetic name without relating it to the members and cannot see that the `≤`
+//! and `≥` range over the SAME set. With a NAMED filler it can — which is what
+//! isolates this to the qualifier shape rather than to cardinality, and why the
+//! atomic control below must keep passing.
+//!
+//! ## Direction of risk
+//!
+//! Withdrawing trust only ever swaps a wedge `Sat` for the complete tableau path,
+//! so this cannot invent an unsatisfiable class. Being wrong here costs wall time,
+//! not correctness. The controls guard the cost side and the atomic path.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::doc_markdown)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+fn unsat_classes(body: &str) -> Vec<String> {
+    let src = format!("Prefix(:=<http://ex#>)\nOntology(\n{body}\n)");
+    let mut reader = Cursor::new(src);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse");
+    let c = owl_dl_reasoner::classify(&onto).expect("classify");
+    let mut v: Vec<String> = c
+        .unsatisfiable_classes()
+        .into_iter()
+        .map(|s| s.rsplit('#').next().unwrap_or(s).to_owned())
+        .collect();
+    v.sort();
+    v
+}
+
+const HEAD: &str = "Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))
+     Declaration(ObjectProperty(:r))";
+
+/// #91's own reproducer: `≤1` and `≥2` over the same complex filler.
+#[test]
+fn complex_qualifier_counting_clash_is_detected() {
+    assert_eq!(
+        unsat_classes(&format!(
+            "{HEAD}
+             SubClassOf(:A ObjectMaxCardinality(1 :r ObjectIntersectionOf(:B :C)))
+             SubClassOf(:A ObjectMinCardinality(2 :r ObjectIntersectionOf(:B :C)))"
+        )),
+        vec!["A".to_string()],
+        "≤1 and ≥2 over the SAME complex filler makes A unsatisfiable (#91)"
+    );
+}
+
+/// THE CONTROL THAT ISOLATES THE DEFECT. With a NAMED filler the wedge counts
+/// correctly and always did — this must keep passing, or the finding would have
+/// been about cardinality rather than about the qualifier shape.
+#[test]
+fn the_atomic_filler_control_still_works() {
+    assert_eq!(
+        unsat_classes(&format!(
+            "{HEAD}
+             SubClassOf(:A ObjectMaxCardinality(1 :r :B))
+             SubClassOf(:A ObjectMinCardinality(2 :r :B))"
+        )),
+        vec!["A".to_string()]
+    );
+}
+
+// ── negative controls ───────────────────────────────────────────────────────
+
+/// A complex qualifier with CONSISTENT bounds must not become unsatisfiable.
+#[test]
+fn a_satisfiable_complex_qualifier_stays_satisfiable() {
+    assert!(
+        unsat_classes(&format!(
+            "{HEAD}
+             SubClassOf(:A ObjectMaxCardinality(3 :r ObjectIntersectionOf(:B :C)))
+             SubClassOf(:A ObjectMinCardinality(2 :r ObjectIntersectionOf(:B :C)))"
+        ))
+        .is_empty(),
+        "≥2 and ≤3 are compatible — withdrawing wedge trust must not invent a clash"
+    );
+}
+
+/// Bounds over DIFFERENT complex fillers are compatible: `≤1 r.(B⊓C)` and
+/// `≥2 r.(B⊓D)` can both hold. This is the shape a careless fix would break by
+/// treating any two complex qualifiers on one role as the same set.
+#[test]
+fn different_complex_qualifiers_do_not_clash() {
+    assert!(
+        unsat_classes(
+            "Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))
+             Declaration(Class(:D)) Declaration(ObjectProperty(:r))
+             SubClassOf(:A ObjectMaxCardinality(1 :r ObjectIntersectionOf(:B :C)))
+             SubClassOf(:A ObjectMinCardinality(2 :r ObjectIntersectionOf(:B :D)))"
+        )
+        .is_empty(),
+        "different fillers are different sets — no clash"
+    );
+}
+
+/// An ontology with no qualified cardinality at all must be untouched: the
+/// `complex_qualifier_counting_classes` set is empty and the clause short-circuits.
+#[test]
+fn ontologies_without_qualified_cardinality_are_inert() {
+    assert!(
+        unsat_classes("Declaration(Class(:A)) Declaration(Class(:B)) SubClassOf(:A :B)").is_empty()
+    );
+}

--- a/crates/owl-dl-reasoner/tests/flag_defaults.rs
+++ b/crates/owl-dl-reasoner/tests/flag_defaults.rs
@@ -188,6 +188,11 @@ fn expected() -> Vec<FlagRow> {
             true,
         ),
         (
+            "RUSTDL_COMPLEX_QUALIFIER_VERIFY",
+            owl_dl_reasoner::complex_qualifier_verify_enabled,
+            true,
+        ),
+        (
             "RUSTDL_HORN_SHORTCIRCUIT",
             owl_dl_reasoner::horn_shortcircuit_enabled,
             true,

--- a/crates/owl-dl-reasoner/tests/surface_agreement.rs
+++ b/crates/owl-dl-reasoner/tests/surface_agreement.rs
@@ -213,6 +213,31 @@ fn previously_divergent_shapes_now_agree() {
         "#89 regressed: classify and the per-query surfaces disagree again:\n{}",
         d.join("\n")
     );
+
+    // #91 — classify reported `unsatisfiable: []` for `A ⊑ ≤1 r.(B⊓C)` plus
+    // `A ⊑ ≥2 r.(B⊓C)`, which both oracles and `rustdl sat A` call unsatisfiable.
+    // Fixed by not trusting a wedge `Sat` for a class counting over a COMPLEX
+    // qualifier. This shape produced THREE divergences, not one: the missed unsat
+    // also made `A ⊑ B` and `A ⊑ C` wrong, because classify did not know `A` was
+    // unsatisfiable. All three must stay fixed.
+    let body91 = r"Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))
+                   Declaration(ObjectProperty(:r))
+                   SubClassOf(:A ObjectMaxCardinality(1 :r ObjectIntersectionOf(:B :C)))
+                   SubClassOf(:A ObjectMinCardinality(2 :r ObjectIntersectionOf(:B :C)))";
+    let src91 = format!("Prefix(:=<http://ex#>)\nOntology(\n{body91}\n)");
+    let mut r91 = Cursor::new(src91);
+    let (onto91, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut r91, ParserConfiguration::default()).unwrap();
+    let (d91, _s91, c91) = divergences(&onto91, "#91", true);
+    assert!(
+        c91 > 0,
+        "no comparison made — a green result would be vacuous"
+    );
+    assert!(
+        d91.is_empty(),
+        "#91 regressed: classify and the per-query surfaces disagree again:\n{}",
+        d91.join("\n")
+    );
 }
 
 /// The gate must DETECT divergence, not merely fail to find it. Each case below
@@ -222,7 +247,7 @@ fn previously_divergent_shapes_now_agree() {
 /// these is fixed it will FAIL, which is the signal to delete that row and — if
 /// the fixture is cheap — move it into the passing gate above.
 ///
-/// **That has already happened once, within a day.** #89 was fixed by the wedge
+/// **That has now happened TWICE, on consecutive days.** #89 was fixed by the wedge
 /// consistency route, and this test failed in CI with
 /// `the gate did NOT detect ["#89"]`. Its fixture now lives in
 /// `previously_divergent_shapes_now_agree`, where it guards against regression
@@ -233,24 +258,14 @@ fn previously_divergent_shapes_now_agree() {
 #[test]
 fn the_gate_detects_the_known_divergences() {
     // (issue, leg exercised, ontology body)
-    let cases: [(&str, &str, &str); 2] = [
-        (
-            "#91",
-            "satisfiability",
-            r"Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))
-              Declaration(ObjectProperty(:r))
-              SubClassOf(:A ObjectMaxCardinality(1 :r ObjectIntersectionOf(:B :C)))
-              SubClassOf(:A ObjectMinCardinality(2 :r ObjectIntersectionOf(:B :C)))",
-        ),
-        (
-            "#90",
-            "subsumption",
-            r"Declaration(Class(:S)) Declaration(Class(:T)) Declaration(Class(:Z))
+    let cases: [(&str, &str, &str); 1] = [(
+        "#90",
+        "subsumption",
+        r"Declaration(Class(:S)) Declaration(Class(:T)) Declaration(Class(:Z))
               Declaration(ObjectProperty(:p)) Declaration(ObjectProperty(:r))
               EquivalentClasses(:S ObjectAllValuesFrom(:p ObjectUnionOf(ObjectComplementOf(ObjectHasSelf(:r)) ObjectComplementOf(:Z))))
               SubClassOf(:T ObjectAllValuesFrom(:p ObjectUnionOf(ObjectComplementOf(ObjectHasSelf(:r)) ObjectComplementOf(:Z))))",
-        ),
-    ];
+    )];
     let mut undetected: Vec<&str> = Vec::new();
     for (issue, leg, body) in cases {
         let src = format!(


### PR DESCRIPTION
`A ⊑ ≤1 r.(B ⊓ C)` with `A ⊑ ≥2 r.(B ⊓ C)` makes `A` unsatisfiable. Konclude and HermiT agree, `rustdl sat A` agrees — and `classify` reported `unsatisfiable: []`.

## The third instance of one pattern

The previous two sit in the very same `needs_verify` expression:

| set | construct the wedge cannot count |
|---|---|
| `data_counting_classes` | concrete-domain (DKey) cardinality |
| `nominal_counting_classes` (#49) | nominal counting — its own comment already reads *"Same defect one construct over"* |
| **this (#91)** | **object cardinality over a COMPLEX qualifier** |

classify's unsat probe trusts the wedge's `LabelOracle::Sat` unless `needs_verify` fires. `cardinality_qualifier` Tseitin-names a complex filler, so the wedge counts a synthetic name without relating it to the members and can't see that the `≤` and `≥` range over the **same set**. With a *named* filler it can — which is what isolates this to the qualifier shape rather than to cardinality, and why `the_atomic_filler_control_still_works` is evidence rather than decoration.

**Why the issue reported that no flag recovers it:** `TRUST_SAT=0`, `CLASSIFY_VERIFY_REFUTATIONS=1` and `SPIKE_CARD_ATOM=1` all target the *subsumption* path. This is the *satisfiability* probe, which had no escape hatch for this construct.

## Direction of risk

Withdrawing trust only swaps a wedge `Sat` for the complete tableau path, so it cannot invent an unsatisfiable class — being wrong costs wall time, not correctness.

Both negative controls are **oracle-adjudicated**, not assumed: compatible bounds (`≥2` with `≤3`) and *different* complex fillers (`≤1 r.(B⊓C)` with `≥2 r.(B⊓D)`) are `[]` per Konclude **and** HermiT. The second is the shape a careless fix would break by treating any two complex qualifiers on one role as the same set.

## Cost

Default ON, unlike its `RUSTDL_NOMINAL_COUNTING_VERIFY` sibling, because the addressable set is measured and tiny: **5 of 1,920** ORE ontologies author a qualified cardinality with a non-named filler, and the set is empty otherwise so the clause short-circuits. Curated fixtures — identical output, flat wall: pizza, ro, sulo, bibtex, sio, go-basic.

## wine first read as a real output change, and is not

Same-arm repeats differ from **each other** (run 3 of 4 diverged), so wine is nondeterministic within one binary and one flag setting — exactly what the design record says about a truncating per-pair budget. At a non-truncating 2000 ms budget both arms give an identical row-set hash, 197 rows.

Cross-arm single-run comparison on a nondeterministic input isn't evidence. Second time that trap appeared this session.

## The gate fired again

#93's agreement gate reported `the gate did NOT detect ["#91"]` — second consecutive day it has caught a tracked defect being fixed. Its fixture moved into `previously_divergent_shapes_now_agree`.

Worth noting it reported **three** divergences for this one shape: the missed unsat also made `A ⊑ B` and `A ⊑ C` wrong, and all three cleared together — confirming a missed unsat propagates into subsumptions.

## Gates

5 canaries, sabotage-verified (flag OFF fails exactly the detection test and no control); full suite **175 ok / 1879 passed / 0 failed**; clippy and fmt clean.

Closes #91
