### PR TITLE
fix(convert): seed DKey disjointness between range and enumeration buckets (#42 item 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1504,12 +1504,61 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `RUSTDL_DKEY_MERGING_GATE=0` — both verified by deliberately breaking them. Spec
   `docs/superpowers/specs/2026-07-30-dkey-nonmerging-component-gate-design.md`.
 
+  **Range × enumeration disjointness (2026-09-04, #42 item 2, unflagged).**
+  `DataHasValue` and facet restrictions lower into a datatype's RANGE bucket;
+  `DataOneOf` lowers into a separate ENUMERATION bucket. Disjointness was seeded
+  WITHIN each bucket and never ACROSS, so `∃p.{5} ⊓ ∀p.{1,2}` did not clash even
+  though 5 ∉ {1,2} — `classify` reported the class satisfiable while HermiT called
+  it unsatisfiable. Same defect shape as #86 (cross-DATATYPE range×range), one
+  level down. **`seed_range_oneof_disjoint` pairs each range bucket with the
+  enumeration bucket of the SAME datatype only**, which is what keeps `contains`
+  exact: both operands reach their DKey through one datatype's parse path, so
+  equal values are bit-identical keys. Cross-datatype pairing would reintroduce
+  the f32/f64 mismatch and is not done; `∃p.{5}^^integer ⊓ ∀p.{1.0,2.0}^^double`
+  therefore stays a sound MISS, pinned by a canary that a future fix should FLIP
+  rather than delete.
+  **`xsd:string` was unaffected, and that asymmetry is what found it** — both
+  string forms lower to one `StrSet` in the `str:` bucket, so `StrSet::disjoint`
+  already compared them. **NOT a dropped construct**: `dropped` was empty on every
+  probe, the axioms converted fine, the clash was merely never derivable — a
+  SILENT miss, which is why #42 recorded it as "only `xsd:string` enums are
+  handled". Effect: integer / decimal / double / float / date / dateTime probes go
+  sat → UNSAT, string control unmoved, every value-INSIDE-the-enumeration control
+  still satisfiable.
+  **Oracles: HermiT confirms every positive; Konclude confirms all but the
+  `xsd:date` one** (it reports `A ⊑ owl:Thing`) — an eighth recorded
+  under-report, not a semantic dispute. HermiT's `xsd:date` pair is
+  DISCRIMINATING (outside ⇒ unsat, inside ⇒ sat), so it is reasoning about the
+  dates rather than refusing them; the neighbouring `seed_cross_bucket_disjoint`
+  note that HermiT throws `UnsupportedDatatypeException` on `xsd:date` is about
+  the CROSS-datatype `date` × `dateTime` construction and does not extend here.
+  **Evidence, with its limit stated:** FP=0 net 11 VERIFIED, closures exact — but
+  the curated corpus is INERT for the DKey area by `datatype_value_membership.rs`'s
+  own admission, so that shows **non-regression only**. The real evidence is 18
+  canaries plus the HermiT adjudication. ORE two-arm sweep over the **62**
+  `DataOneOf`-bearing ontologies (a grep SUPERSET — the oneof buckets are
+  reachable only from that lowering), arm order alternated: **57 IDENTICAL / 3
+  BOTH_DNF / 2 DIFFER / 0 regressions**, wall +0.25%; both DIFFERs adjudicate
+  clean (3 repeats per arm at a 120 s cap content-identical, while the UNCHANGED
+  binary produces 4 distinct byte hashes of its own at the sweep's 60 s cap).
+  24 non-bearing controls: 22 IDENTICAL / 1 BOTH_DNF / 1 DIFFER, and that one
+  contains **zero** `DataOneOf` so the pass provably cannot run on it.
+  **SABOTAGE: 4 run, 3 caught.** Deleting the seeding fails the 8 positives;
+  inverting the disjointness test fails 16 (FPs on every negative); making
+  `FloatRange::contains` ignore the inclusivity flags is caught by exactly the
+  exclusive/inclusive boundary pair written for it. **The one that SURVIVED:**
+  dropping the component-reachability gate — that gate is a *cost bound*, not an
+  FP guard, so these canaries cannot see it, the same honest limit recorded for
+  the #86 split sabotage.
+  Canaries `crates/owl-dl-reasoner/tests/dkey_range_oneof_disjointness.rs`.
+
   **Remaining datatype under-approximation (sound, all still DROP):**
   - **data cardinality** — D4 already catches the unsat-clash patterns;
     full range-size-aware counting (`≥3 p` over a 2-value range → ⊥) is a
     concrete-domain cardinality reasoner with zero measured corpus reward.
-  - `xsd:decimal`/`date`/`dateTime` `DataOneOf` enumerations (only
-    `xsd:string` enums handled); other non-ordered datatypes;
+  - ~~`xsd:decimal`/`date`/`dateTime` `DataOneOf` enumerations~~ — **CLOSED
+    2026-09-04 (#42 item 2)**; see the range × enumeration entry above. Other
+    non-ordered datatypes still drop;
     `DataComplementOf` / `DataUnionOf` / `DataIntersectionOf` ranges.
 
   Synthetic test harness: `crates/owl-dl-reasoner/tests/datatype_completeness.rs`

--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -3186,6 +3186,142 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
         std::collections::BTreeSet::is_disjoint,
         comp,
     );
+
+    // #42 item 2 — RANGE bucket vs ENUMERATION bucket of the SAME datatype.
+    //
+    // `DataHasValue` and facet restrictions land in the range bucket; `DataOneOf`
+    // lands in the set bucket just seeded above. Each bucket was compared only
+    // against ITSELF, so `∃p.{5} ⊓ ∀p.{1,2}` never clashed even though 5 ∉ {1,2}.
+    //
+    // `xsd:string` was unaffected and that is the tell: BOTH its forms lower to one
+    // `StrSet` in the `str:` bucket, so `StrSet::disjoint` already compared them.
+    // The numeric and temporal datatypes split across two buckets and lost the
+    // comparison — which is why the string control passed while the integer one did
+    // not. NOT a dropped construct: `dropped` was empty, the clash was simply never
+    // derivable, so this was a SILENT miss rather than a reported one.
+    //
+    // Needs no flag: `collect_oneof_dkeys` returns empty under
+    // `RUSTDL_DKEY_ONEOF_SEED=0`, so the flag-off path feeds these calls nothing,
+    // exactly as it does the `seed_disjoint_bucket` calls above.
+    seed_range_oneof_disjoint(
+        out,
+        &int_dkeys,
+        &int_oneof_dkeys,
+        |r: &IntegerRange, v: &i64| r.contains(*v),
+        comp,
+    );
+    seed_range_oneof_disjoint(
+        out,
+        &float_dkeys,
+        &float_oneof_dkeys,
+        |r: &FloatRange, v: &crate::data_axioms::OrdF64| r.contains(v.0),
+        comp,
+    );
+    seed_range_oneof_disjoint(
+        out,
+        &double_dkeys,
+        &double_oneof_dkeys,
+        |r: &FloatRange, v: &crate::data_axioms::OrdF64| r.contains(v.0),
+        comp,
+    );
+    seed_range_oneof_disjoint(out, &dec_dkeys, &dec_oneof_dkeys, OrdRange::contains, comp);
+    seed_range_oneof_disjoint(
+        out,
+        &date_dkeys,
+        &date_oneof_dkeys,
+        OrdRange::contains,
+        comp,
+    );
+    seed_range_oneof_disjoint(out, &dt_dkeys, &dt_oneof_dkeys, OrdRange::contains, comp);
+}
+
+/// Seed `DisjointClasses` between a RANGE bucket and an ENUMERATION bucket of the
+/// SAME datatype (#42 item 2).
+///
+/// `DataHasValue` and facet restrictions land in the range bucket; `DataOneOf`
+/// lands in a separate set bucket. Disjointness was seeded WITHIN each bucket and
+/// never ACROSS, so `∃p.{5}` never clashed with `∀p.{1,2}` even though 5 ∉ {1,2}.
+///
+/// `xsd:string` was unaffected and that is the tell: for strings BOTH forms lower
+/// to a `StrSet` in one bucket, so `StrSet::disjoint` already compared them. The
+/// numeric and temporal datatypes split into two buckets and lost the comparison.
+///
+/// FP-CRITICAL DIRECTION, as for every `DisjointClasses` seeding: a wrong
+/// "disjoint" is a false UNSAT. `disjoint` here means "no member of the set lies in
+/// the range", decided by an exact `contains` per key.
+///
+/// The precondition that makes `contains` exact is that BOTH operands of a call
+/// reached their `DKey` through the same datatype's parse path, so equal values are
+/// bit-identical keys. That holds because the caller pairs each range bucket with
+/// the enumeration bucket of the SAME datatype: `xsd:float` ranges and `xsd:float`
+/// enumerations are both f32-parsed-then-widened, `xsd:double` is f64 on both
+/// sides, `xsd:decimal` is the exact normalized-lexical `Decimal` on both, and
+/// `date`/`dateTime` are timezone-free component tuples on both. This is the same
+/// invariant the sibling `seed_disjoint_bucket` calls above already rely on — NOT
+/// the weaker one that DP-1's value-membership path lacks, where the two lexicals
+/// are independently authored and `xsd:float` must therefore be dropped.
+///
+/// Pairing ACROSS datatypes would break it and is not done here; the cross-datatype
+/// direction is `seed_cross_bucket_disjoint`'s (#86), and it covers range-vs-range
+/// only, so `∃p.{5}^^integer ⊓ ∀p.{1.0,2.0}^^double` stays a sound MISS.
+///
+/// ORACLES: HermiT confirms every same-datatype clash this seeds. Konclude confirms
+/// all but the `xsd:date` one, where it reports `A ⊑ owl:Thing` — a further instance
+/// of the under-reporting recorded elsewhere in this repo, not a semantic dispute.
+/// That verdict is safe to rely on because HermiT's own `xsd:date` pair is
+/// DISCRIMINATING: value-outside-the-enumeration is unsatisfiable and
+/// value-inside-it is satisfiable, so HermiT is reasoning about the dates rather
+/// than refusing them. (`seed_cross_bucket_disjoint`'s note that HermiT throws
+/// `UnsupportedDatatypeException` on `xsd:date` is about the CROSS-datatype
+/// `date` × `dateTime` construction, and does not extend to this same-datatype
+/// case — measured, not assumed.)
+fn seed_range_oneof_disjoint<R, V>(
+    out: &mut InternalOntology,
+    ranges: &[(ClassId, R)],
+    oneofs: &[(ClassId, std::collections::BTreeSet<V>)],
+    contains: impl Fn(&R, &V) -> bool,
+    components: Option<&DkeyComponents>,
+) {
+    if ranges.is_empty() || oneofs.is_empty() {
+        return;
+    }
+    let reach = |k: &ClassId| -> Option<Option<&Vec<usize>>> {
+        components.map_or(Some(None), |c| {
+            if c.unanchored.contains(k) {
+                return Some(None);
+            }
+            c.components.get(k).map(Some)
+        })
+    };
+    let mut emitted: std::collections::HashSet<(ClassId, ClassId)> =
+        std::collections::HashSet::new();
+    for (r_cid, r) in ranges {
+        let Some(rr) = reach(r_cid) else { continue };
+        for (o_cid, set) in oneofs {
+            let Some(ro) = reach(o_cid) else { continue };
+            let shares = match (rr, ro) {
+                (None, _) | (_, None) => true,
+                (Some(a), Some(b)) => a.iter().any(|c| b.contains(c)),
+            };
+            if !shares {
+                continue;
+            }
+            // Disjoint iff NO member of the enumeration lies in the range.
+            if set.iter().any(|v| contains(r, v)) {
+                continue;
+            }
+            let pair = if r_cid.index() <= o_cid.index() {
+                (*r_cid, *o_cid)
+            } else {
+                (*o_cid, *r_cid)
+            };
+            if emitted.insert(pair) {
+                let a = out.concepts.atomic(*r_cid);
+                let b = out.concepts.atomic(*o_cid);
+                out.axioms.push(Axiom::DisjointClasses(vec![a, b]));
+            }
+        }
+    }
 }
 
 /// One numeric-`DataOneOf` bucket: the `DKey` classes of that datatype paired

--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -3265,13 +3265,13 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
 /// direction is `seed_cross_bucket_disjoint`'s (#86), and it covers range-vs-range
 /// only, so `∃p.{5}^^integer ⊓ ∀p.{1.0,2.0}^^double` stays a sound MISS.
 ///
-/// ORACLES: HermiT confirms every same-datatype clash this seeds. Konclude confirms
+/// ORACLES: `HermiT` confirms every same-datatype clash this seeds. Konclude confirms
 /// all but the `xsd:date` one, where it reports `A ⊑ owl:Thing` — a further instance
 /// of the under-reporting recorded elsewhere in this repo, not a semantic dispute.
-/// That verdict is safe to rely on because HermiT's own `xsd:date` pair is
+/// That verdict is safe to rely on because `HermiT`'s own `xsd:date` pair is
 /// DISCRIMINATING: value-outside-the-enumeration is unsatisfiable and
-/// value-inside-it is satisfiable, so HermiT is reasoning about the dates rather
-/// than refusing them. (`seed_cross_bucket_disjoint`'s note that HermiT throws
+/// value-inside-it is satisfiable, so `HermiT` is reasoning about the dates rather
+/// than refusing them. (`seed_cross_bucket_disjoint`'s note that `HermiT` throws
 /// `UnsupportedDatatypeException` on `xsd:date` is about the CROSS-datatype
 /// `date` × `dateTime` construction, and does not extend to this same-datatype
 /// case — measured, not assumed.)

--- a/crates/owl-dl-core/src/data_axioms.rs
+++ b/crates/owl-dl-core/src/data_axioms.rs
@@ -499,6 +499,15 @@ impl IntegerRange {
     /// `other` (`None`) imposes no constraint; an unbounded end on
     /// `self` against a bounded `other` end means `self` reaches past
     /// `other`, so it is NOT contained.
+    /// Does `v` lie in this range? Inclusive bounds; `None` is unbounded.
+    ///
+    /// Used to relate a RANGE `DKey` to an ENUMERATION `DKey` of the same datatype
+    /// (#42 item 2): `DataHasValue`/facets land in the range bucket while
+    /// `DataOneOf` lands in a separate set bucket, and the two were never compared.
+    pub(crate) fn contains(self, v: i64) -> bool {
+        self.min.is_none_or(|m| v >= m) && self.max.is_none_or(|m| v <= m)
+    }
+
     pub(crate) fn subset(self, other: Self) -> bool {
         if self.is_empty() {
             return true;
@@ -573,6 +582,23 @@ pub(crate) struct FloatRange {
 }
 
 impl FloatRange {
+    /// Does `v` lie in this range? Honours the explicit inclusivity flags — the
+    /// `±1` normalization that makes [`IntegerRange`] simple is INVALID for reals,
+    /// so an exclusive bound is compared strictly.
+    pub(crate) fn contains(&self, v: f64) -> bool {
+        let lo = match self.min {
+            None => true,
+            Some(m) if self.min_incl => v >= m,
+            Some(m) => v > m,
+        };
+        let hi = match self.max {
+            None => true,
+            Some(m) if self.max_incl => v <= m,
+            Some(m) => v < m,
+        };
+        lo && hi
+    }
+
     pub(crate) const fn unbounded() -> Self {
         Self {
             min: None,
@@ -733,6 +759,23 @@ pub(crate) struct OrdRange<T> {
 }
 
 impl<T: Ord + Clone> OrdRange<T> {
+    /// Does `v` lie in this range? Honours the explicit inclusivity flags — an
+    /// EXCLUSIVE bound must not admit its endpoint, which is why this cannot be
+    /// written as a plain `>=`/`<=` pair the way [`IntegerRange::contains`] can.
+    pub(crate) fn contains(&self, v: &T) -> bool {
+        let lo = match &self.min {
+            None => true,
+            Some(m) if self.min_incl => v >= m,
+            Some(m) => v > m,
+        };
+        let hi = match &self.max {
+            None => true,
+            Some(m) if self.max_incl => v <= m,
+            Some(m) => v < m,
+        };
+        lo && hi
+    }
+
     pub(crate) const fn unbounded() -> Self {
         Self {
             min: None,

--- a/crates/owl-dl-reasoner/tests/dkey_range_oneof_disjointness.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_range_oneof_disjointness.rs
@@ -1,0 +1,268 @@
+//! #42 item 2 — a `DataOneOf` enumeration under `∀` must clash with a
+//! `DataHasValue`/facet range whose value lies OUTSIDE it.
+//!
+//! `DataHasValue` and facet restrictions lower into a RANGE bucket; `DataOneOf`
+//! lowers into a separate ENUMERATION bucket. Disjointness was seeded within each
+//! bucket and never across, so `∃p.{5} ⊓ ∀p.{1,2}` did not clash.
+//!
+//! **`xsd:string` is the discriminating control and it always passed**: both its
+//! forms lower to one `StrSet` in the `str:` bucket, so `StrSet::disjoint` already
+//! compared them. That asymmetry is what identified the defect — an
+//! integer probe missing while the structurally identical string probe hit.
+//!
+//! **The corpus cannot validate this area.** `datatype_value_membership.rs` says so
+//! itself ("the corpus has NO such clash, so these canaries are the ENTIRE safety
+//! net"), and these probes are that net plus the HermiT adjudication recorded in
+//! `docs/known-limitations/` — a green FP=0 net here shows non-regression only.
+//!
+//! Oracle: HermiT confirms every positive below. **Konclude does NOT confirm the
+//! `xsd:date` one** — it reports `A ⊑ owl:Thing` with no unsatisfiability — which is
+//! a further instance of the under-reporting this repo already records, not a
+//! disagreement about the semantics. The NEGATIVE controls are what make the
+//! positives meaningful: each is one value away from its positive twin.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use std::io::Cursor;
+use std::time::Duration;
+
+fn unsat_classes(ofn: &str) -> Vec<String> {
+    let mut reader = Cursor::new(ofn.to_string());
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    // Force the slow, complete path so a MISS here is calculus, not a
+    // trust_sat mask.
+    let result = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+    let mut out: Vec<String> = result
+        .unsatisfiable_classes()
+        .iter()
+        .map(std::string::ToString::to_string)
+        .filter(|c| !c.contains("Nothing"))
+        .collect();
+    out.sort();
+    out
+}
+
+fn fixture(value_axiom: &str, oneof: &str) -> String {
+    format!(
+        "Prefix(:=<http://ex.org/>)\n\
+         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n\
+         Ontology(<http://ex.org/o>\n\
+         Declaration(Class(:A))\n\
+         Declaration(DataProperty(:p))\n\
+         SubClassOf(:A {value_axiom})\n\
+         SubClassOf(:A DataAllValuesFrom(:p DataOneOf({oneof})))\n\
+         )\n"
+    )
+}
+
+fn assert_unsat(what: &str, value_axiom: &str, oneof: &str) {
+    let got = unsat_classes(&fixture(value_axiom, oneof));
+    assert_eq!(
+        got,
+        vec!["http://ex.org/A".to_string()],
+        "{what}: the value is OUTSIDE the enumeration, so A is unsatisfiable \
+         (HermiT agrees). Got {got:?}. If this regressed, check that \
+         `seed_range_oneof_disjoint` still pairs this datatype's range bucket \
+         with its enumeration bucket in `convert.rs`."
+    );
+}
+
+fn assert_sat(what: &str, value_axiom: &str, oneof: &str) {
+    let got = unsat_classes(&fixture(value_axiom, oneof));
+    assert!(
+        got.is_empty(),
+        "{what}: the value IS IN the enumeration, so A must stay satisfiable. \
+         Reporting it unsatisfiable is a FALSE POSITIVE — the seeding emitted \
+         `DisjointClasses` for a pair that shares a value. Got {got:?}."
+    );
+}
+
+#[test]
+fn integer_value_outside_a_oneof_under_forall_clashes() {
+    assert_unsat(
+        "xsd:integer",
+        "DataHasValue(:p \"5\"^^xsd:integer)",
+        "\"1\"^^xsd:integer \"2\"^^xsd:integer",
+    );
+}
+
+#[test]
+fn integer_value_inside_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:integer",
+        "DataHasValue(:p \"2\"^^xsd:integer)",
+        "\"1\"^^xsd:integer \"2\"^^xsd:integer",
+    );
+}
+
+#[test]
+fn integer_facet_range_disjoint_from_a_oneof_clashes() {
+    // The range side as a FACET rather than a point value: the seeding must
+    // compare a genuine interval against the set, not just singletons.
+    assert_unsat(
+        "xsd:integer facet",
+        "DataSomeValuesFrom(:p DatatypeRestriction(xsd:integer xsd:minInclusive \"10\"^^xsd:integer))",
+        "\"1\"^^xsd:integer \"2\"^^xsd:integer",
+    );
+}
+
+#[test]
+fn integer_facet_range_overlapping_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:integer facet",
+        "DataSomeValuesFrom(:p DatatypeRestriction(xsd:integer xsd:minInclusive \"2\"^^xsd:integer))",
+        "\"1\"^^xsd:integer \"2\"^^xsd:integer",
+    );
+}
+
+#[test]
+fn double_value_outside_a_oneof_under_forall_clashes() {
+    assert_unsat(
+        "xsd:double",
+        "DataSomeValuesFrom(:p DatatypeRestriction(xsd:double xsd:minInclusive \"10.0\"^^xsd:double))",
+        "\"1.0\"^^xsd:double \"2.0\"^^xsd:double",
+    );
+}
+
+#[test]
+fn double_value_inside_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:double",
+        "DataSomeValuesFrom(:p DatatypeRestriction(xsd:double xsd:minInclusive \"1.0\"^^xsd:double))",
+        "\"1.0\"^^xsd:double \"2.0\"^^xsd:double",
+    );
+}
+
+#[test]
+fn an_exclusive_lower_bound_excludes_its_own_endpoint() {
+    // FP-CRITICAL for the real datatypes: the `±1` normalization that makes
+    // integer bounds simple is INVALID here, so `contains` must compare an
+    // exclusive bound STRICTLY. `(2.0, ∞)` shares no value with {1.0, 2.0}.
+    assert_unsat(
+        "xsd:double minExclusive",
+        "DataSomeValuesFrom(:p DatatypeRestriction(xsd:double xsd:minExclusive \"2.0\"^^xsd:double))",
+        "\"1.0\"^^xsd:double \"2.0\"^^xsd:double",
+    );
+}
+
+#[test]
+fn an_inclusive_lower_bound_admits_its_own_endpoint() {
+    // The twin of the above, one facet keyword apart. If `contains` ignored the
+    // inclusivity flags, exactly one of this pair would break — which is the
+    // whole point of running them together.
+    assert_sat(
+        "xsd:double minInclusive",
+        "DataSomeValuesFrom(:p DatatypeRestriction(xsd:double xsd:minInclusive \"2.0\"^^xsd:double))",
+        "\"1.0\"^^xsd:double \"2.0\"^^xsd:double",
+    );
+}
+
+#[test]
+fn float_value_outside_a_oneof_under_forall_clashes() {
+    // `xsd:float` keeps its OWN buckets (`f:` / `fo:`), both f32-parsed then
+    // widened — pairing them is exact. Pairing a float range against a DOUBLE
+    // enumeration would re-introduce the f32/f64 mismatch and is not done.
+    assert_unsat(
+        "xsd:float",
+        "DataHasValue(:p \"5.0\"^^xsd:float)",
+        "\"1.0\"^^xsd:float \"2.0\"^^xsd:float",
+    );
+}
+
+#[test]
+fn float_value_inside_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:float",
+        "DataHasValue(:p \"2.0\"^^xsd:float)",
+        "\"1.0\"^^xsd:float \"2.0\"^^xsd:float",
+    );
+}
+
+#[test]
+fn decimal_value_outside_a_oneof_under_forall_clashes() {
+    assert_unsat(
+        "xsd:decimal",
+        "DataHasValue(:p \"5.5\"^^xsd:decimal)",
+        "\"1.5\"^^xsd:decimal \"2.5\"^^xsd:decimal",
+    );
+}
+
+#[test]
+fn decimal_value_inside_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:decimal",
+        "DataHasValue(:p \"2.5\"^^xsd:decimal)",
+        "\"1.5\"^^xsd:decimal \"2.5\"^^xsd:decimal",
+    );
+}
+
+#[test]
+fn date_value_outside_a_oneof_under_forall_clashes() {
+    // The one HermiT confirms and Konclude does not — see the module header.
+    assert_unsat(
+        "xsd:date",
+        "DataHasValue(:p \"2020-05-05\"^^xsd:date)",
+        "\"2001-01-01\"^^xsd:date \"2002-02-02\"^^xsd:date",
+    );
+}
+
+#[test]
+fn date_value_inside_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:date",
+        "DataHasValue(:p \"2002-02-02\"^^xsd:date)",
+        "\"2001-01-01\"^^xsd:date \"2002-02-02\"^^xsd:date",
+    );
+}
+
+#[test]
+fn datetime_value_outside_a_oneof_under_forall_clashes() {
+    assert_unsat(
+        "xsd:dateTime",
+        "DataHasValue(:p \"2020-05-05T00:00:00\"^^xsd:dateTime)",
+        "\"2001-01-01T00:00:00\"^^xsd:dateTime \"2002-02-02T00:00:00\"^^xsd:dateTime",
+    );
+}
+
+#[test]
+fn datetime_value_inside_the_oneof_stays_satisfiable() {
+    assert_sat(
+        "xsd:dateTime",
+        "DataHasValue(:p \"2002-02-02T00:00:00\"^^xsd:dateTime)",
+        "\"2001-01-01T00:00:00\"^^xsd:dateTime \"2002-02-02T00:00:00\"^^xsd:dateTime",
+    );
+}
+
+#[test]
+fn string_control_was_never_broken_and_must_stay_working() {
+    // The DISCRIMINATING CONTROL. Strings put both forms in one bucket, so this
+    // passed before the fix. If it ever fails, the diagnosis in the module header
+    // is wrong and the whole framing of #42 item 2 needs revisiting.
+    assert_unsat(
+        "xsd:string",
+        "DataHasValue(:p \"e\"^^xsd:string)",
+        "\"a\"^^xsd:string \"b\"^^xsd:string",
+    );
+}
+
+#[test]
+fn a_cross_datatype_pair_is_not_seeded_and_stays_a_sound_miss() {
+    // `∃p.{5}^^integer ⊓ ∀p.{1.0,2.0}^^double` IS unsatisfiable (both HermiT and
+    // Konclude say so) because the two value spaces are disjoint. rustdl misses
+    // it: the range×enumeration seeding is same-datatype only, and #86's
+    // cross-datatype seeding covers range×range only.
+    //
+    // Pinned so the MISS is deliberate rather than forgotten. A future fix should
+    // FLIP this assertion — never delete it.
+    assert_sat(
+        "integer range vs double enumeration",
+        "DataHasValue(:p \"5\"^^xsd:integer)",
+        "\"1.0\"^^xsd:double \"2.0\"^^xsd:double",
+    );
+}

--- a/crates/owl-dl-reasoner/tests/dkey_range_oneof_disjointness.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_range_oneof_disjointness.rs
@@ -12,10 +12,10 @@
 //!
 //! **The corpus cannot validate this area.** `datatype_value_membership.rs` says so
 //! itself ("the corpus has NO such clash, so these canaries are the ENTIRE safety
-//! net"), and these probes are that net plus the HermiT adjudication recorded in
+//! net"), and these probes are that net plus the `HermiT` adjudication recorded in
 //! `docs/known-limitations/` — a green FP=0 net here shows non-regression only.
 //!
-//! Oracle: HermiT confirms every positive below. **Konclude does NOT confirm the
+//! Oracle: `HermiT` confirms every positive below. **Konclude does NOT confirm the
 //! `xsd:date` one** — it reports `A ⊑ owl:Thing` with no unsatisfiability — which is
 //! a further instance of the under-reporting this repo already records, not a
 //! disagreement about the semantics. The NEGATIVE controls are what make the


### PR DESCRIPTION
Closes half of #42 — the `DataOneOf`-for-non-string-datatypes item.

## The defect

`DataHasValue` and facet restrictions lower into a datatype's **range** bucket;
`DataOneOf` lowers into a separate **enumeration** bucket. Disjointness was seeded
*within* each bucket and never *across*, so a value-outside-the-enumeration under a
`∀` never clashed. Same shape as #86 (cross-**datatype** range×range), one level down.

**`xsd:string` was unaffected, and that asymmetry is what found it**: both string forms
lower to one `StrSet` in the `str:` bucket, so `StrSet::disjoint` already compared them.

**Not a dropped construct.** `dropped` was empty on every probe — the axioms converted
fine and the clash was merely never derivable. A *silent* miss, which is why #42 recorded
it as "only `xsd:string` enums are handled".

## Effect

Pinned before/after binaries:

| probe | before | after | Konclude | HermiT |
|---|---|---|---|---|
| integer, value outside the enum | sat | **UNSAT** | unsat | unsat |
| decimal / double / float / dateTime | sat | **UNSAT** | unsat | unsat |
| **date**, value outside the enum | sat | **UNSAT** | *sat (under-report)* | **unsat** |
| every "value INSIDE the enum" control | sat | sat | sat | sat |
| string control (never broken) | UNSAT | UNSAT | unsat | unsat |
| integer range × double enum (cross-datatype) | sat | sat | unsat | unsat |

The last row is a deliberate, pinned **sound MISS** — the seeding is same-datatype only,
which is what keeps `contains` exact (both operands reach their DKey through one
datatype's parse path, so equal values are bit-identical keys). A future fix should
**flip** that canary, never delete it.

On `xsd:date`, HermiT's pair is **discriminating** — outside implies unsat, inside implies
sat — so it is reasoning about the dates rather than refusing them. Konclude's silence is
an eighth recorded under-report.

## Gates

- suite **1892 passed / 0 failed**
- FP=0 net **11 VERIFIED, every closure exact**. The curated corpus is INERT for the DKey
  area by `datatype_value_membership.rs`'s own admission, so this is **non-regression
  only** — the canaries and the HermiT adjudication are the evidence.
- curated fixtures: all 8 answer-identical. `wine`'s byte DIFFER is the documented
  budget-truncation row ordering — the *unchanged* binary produces 3 distinct hashes of
  its own and all 6 runs are content-identical.
- **ORE two-arm sweep, 62 `DataOneOf`-bearing ontologies** (a grep superset — the oneof
  buckets are reachable only from that lowering), arm order alternated:
  **57 IDENTICAL / 3 BOTH_DNF / 2 DIFFER / 0 regressions**, wall **+0.25%**. Both DIFFERs
  adjudicate clean: 3 repeats per arm at a 120 s cap are content-identical, while the
  unchanged binary produces **4 distinct byte hashes of its own** at the sweep's 60 s cap.
- inertness: 24 non-bearing controls, 22 IDENTICAL / 1 BOTH_DNF / 1 DIFFER — and that one
  contains **zero** `DataOneOf`, so the pass provably cannot run on it.

## Sabotage: 4 run, 3 caught

1. delete the seeding — 8 positives fail, controls survive
2. invert the disjointness test — 16 fail (false positives on every negative)
3. `FloatRange::contains` ignoring the inclusivity flags — caught by exactly the
   exclusive/inclusive boundary pair written for it
4. **survived:** dropping the component-reachability gate. That gate is a *cost bound*,
   not an FP guard, so these canaries cannot see it — the same honest limit recorded for
   the #86 split sabotage.

Unflagged: a completeness fix is not opt-in, and `collect_oneof_dkeys` already returns
empty under `RUSTDL_DKEY_ONEOF_SEED=0`, so the flag-off path feeds the new calls nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
