### PR TITLE
fix(protege): plugin.xml was not well-formed XML, so Protégé registered nothing (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1707,6 +1707,25 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   over all justifications) to break an unwanted entailment; every repair is verified
   by removal (sound even when the justification set is incomplete). See
   `docs/superpowers/specs/2026-06-21-repair-suggestions-design.md`.
+> **A `String.contains` GUARD CANNOT SEE A MALFORMED FILE (2026-09-04, #79).** The Protégé
+> plugin was uninstallable in **every release from v0.4.5 to v0.4.26** — 22 of them — because
+> a `--` inside an XML comment (the literal `rustdl prove --json`) is illegal XML, so Protégé
+> rejected the whole `plugin.xml` and, with it, the **reasoner** registration that has nothing
+> to do with proofs. Verified against the published jars, not just source history: v0.4.4
+> parses, v0.4.5 onward do not.
+>
+> `PluginRegistrationTest` **already guarded that file** with four `String.contains`
+> assertions, and all four passed the entire time — a substring check cannot distinguish
+> "registered" from "present in a file the host discards". `mvn verify` was green too, because
+> Maven copies resources without validating them. **When a test asserts on a structured file,
+> parse it; `contains()` on the raw text is not a check of the thing that consumes it.**
+> Sibling of [[sabotage-your-own-guard-tests]] and of the stale-`#[ignore]` entry: there the
+> guard was absent, here it existed and did not guard.
+>
+> Two parsing tests now cover it, reading the resource off the CLASSPATH so Maven's
+> `${project.version}` filtering is covered too. Sabotage: restoring the shipped file fails
+> exactly the 2 new tests and leaves all 4 old ones passing.
+
   `report` generates a self-contained HTML debugging report (summary + diagnose
   roots/derived + per-root justification + repairs); presentation-only over the
   shipped reasoner output, read-only, no external resources. See

--- a/protege/src/main/resources/plugin.xml
+++ b/protege/src/main/resources/plugin.xml
@@ -10,10 +10,12 @@
       <class value="com.github.maastrichtu_ids.rustdl.protege.RustdlReasonerInfo"/>
    </extension>
 
-   <!-- Exposes rustdl's step-level EL proof trees (`rustdl prove --json`) in Protégé's proof
-        view, via the liveontologies proof-explanation plugin's own extension point. Requires
-        that companion plugin to be installed; this bundle itself builds and resolves without it
-        (see protege/pom.xml's Import-Package resolution:=optional entries). -->
+   <!-- Exposes rustdl's step-level EL proof trees (the JSON output of `rustdl prove`) in
+        Protégé's proof view, via the liveontologies proof-explanation plugin's own extension
+        point. NOTE: no double hyphen may appear anywhere in an XML comment - it is illegal XML
+        and makes Protégé reject the WHOLE file, silently unregistering the reasoner too (#79).
+        Requires that companion plugin to be installed; this bundle itself builds and resolves
+        without it (see protege/pom.xml's Import-Package resolution:=optional entries). -->
    <extension id="rustdl.proofs"
               point="org.liveontologies.protege.explanation.proof.service">
       <name value="rustdl ${project.version}"/>

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/PluginRegistrationTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/PluginRegistrationTest.java
@@ -2,7 +2,14 @@ package com.github.maastrichtu_ids.rustdl.protege;
 
 import org.junit.Test;
 import org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXParseException;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +50,74 @@ public class PluginRegistrationTest {
                 "plugin.xml must wire that extension point to RustdlProofService",
                 xml.contains(
                     "<class value=\"com.github.maastrichtu_ids.rustdl.protege.RustdlProofService\""));
+        }
+    }
+
+    /**
+     * plugin.xml must be WELL-FORMED XML, not merely contain the right substrings.
+     *
+     * Issue #79: a `--` inside an XML comment (from the literal `rustdl prove --json`) is
+     * illegal XML. Protege rejected the whole file with "Could not parse XML contribution",
+     * which silently unregistered the reasoner extension too - the file's FIRST element, and
+     * the one every other test here asserts on. It shipped in 22 releases, v0.4.5 through
+     * v0.4.26.
+     *
+     * Every other assertion in this class passed throughout, because they all read the file
+     * as a String and call contains(). A substring check cannot see malformed XML; only a
+     * parser can. That is the whole reason this test exists, so do not weaken it back into
+     * a contains() check.
+     *
+     * It parses the resource off the CLASSPATH rather than the source tree, so it also
+     * covers the case where Maven resource filtering itself produces something unparseable.
+     */
+    @Test public void pluginXmlIsWellFormedXml() throws Exception {
+        Document doc = parsePluginXml();
+        assertEquals("root element must be <plugin>", "plugin", doc.getDocumentElement().getTagName());
+    }
+
+    /**
+     * Both extension points must survive PARSING, not just appear in the text.
+     *
+     * The sibling contains() tests above cannot distinguish "registered" from "present in a
+     * file Protege discards", which is exactly the state #79 shipped in.
+     */
+    @Test public void bothExtensionPointsSurviveParsing() throws Exception {
+        Document doc = parsePluginXml();
+        NodeList extensions = doc.getElementsByTagName("extension");
+        List<String> points = new ArrayList<>();
+        for (int i = 0; i < extensions.getLength(); i++) {
+            points.add(((Element) extensions.item(i)).getAttribute("point"));
+        }
+        assertTrue("reasoner factory extension point must parse: " + points,
+            points.contains("org.protege.editor.owl.inference_reasonerfactory"));
+        assertTrue("proof-service extension point must parse: " + points,
+            points.contains("org.liveontologies.protege.explanation.proof.service"));
+    }
+
+    /** Parse /plugin.xml off the classpath, failing the test on any parse error or warning. */
+    private Document parsePluginXml() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        // Do not fetch anything over the network for a DTD/entity; a build must not depend
+        // on remote availability, and plugin.xml declares no external entities.
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        builder.setErrorHandler(new ErrorHandler() {
+            @Override public void warning(SAXParseException e) throws SAXParseException { throw e; }
+            @Override public void error(SAXParseException e) throws SAXParseException { throw e; }
+            @Override public void fatalError(SAXParseException e) throws SAXParseException { throw e; }
+        });
+        try (InputStream in = getClass().getResourceAsStream("/plugin.xml")) {
+            assertNotNull("plugin.xml must be on the classpath", in);
+            try {
+                return builder.parse(in);
+            } catch (SAXParseException e) {
+                fail("plugin.xml is not well-formed XML, so Protege will reject the WHOLE file "
+                    + "and register nothing (issue #79). Line " + e.getLineNumber() + ", column "
+                    + e.getColumnNumber() + ": " + e.getMessage()
+                    + "  --  the usual cause is a double hyphen inside an XML comment.");
+                throw e; // unreachable; keeps the compiler happy about the return type
+            }
         }
     }
 


### PR DESCRIPTION
Closes #79.

## Cause

A `--` inside an XML comment — from the literal `rustdl prove --json` — is **illegal XML**.
Protégé rejected the whole file, and with it the **reasoner** registration, which is the
file's first element and has nothing to do with proofs. That is why the plugin did not
appear at all rather than merely losing its proof view.

```
$ xmllint --noout protege/src/main/resources/plugin.xml
plugin.xml:13: parser error : Double hyphen within comment
```

## Which releases are affected

Checked by extracting `plugin.xml` from each **published jar**, not from source history:

| release | shipped `plugin.xml` |
|---|---|
| v0.4.4 | WELL-FORMED |
| **v0.4.5** | **MALFORMED** — introduced by d2eae90 (2026-07-26) |
| v0.4.23 | MALFORMED — the reporter's version |
| v0.4.26 | MALFORMED |

So every release from **v0.4.5 through v0.4.26** ships a plugin Protégé cannot load.

## Why 22 releases of green CI missed it

This is the part worth keeping. `PluginRegistrationTest` **already guarded this file** — with
four `String.contains` assertions. A substring check cannot see malformed XML, so
`pluginXmlRegistersRustdl` and `pluginXmlRegistersRustdlProofService` both passed the entire
time on a file that registers nothing. `mvn verify` was green too: Maven copies resources
without validating them.

Two new tests **parse** the resource off the classpath — so they also cover the case where
Maven's `${project.version}` filtering itself produces something unparseable — with an error
handler that fails on warnings as well as errors.

## Sabotage

Restoring the shipped file fails **exactly the 2 new tests** and leaves **all 4 pre-existing
ones passing**:

```
Tests run: 6, Failures: 2
  bothExtensionPointsSurviveParsing  <<< FAILURE!
  pluginXmlIsWellFormedXml           <<< FAILURE!
      plugin.xml is not well-formed XML, so Protege will reject the WHOLE file and
      register nothing (issue #79). Line 13, column 69: The string "--" is not
      permitted within comments.
```

That reproduces the escape on demand rather than asserting it.

## Verification

- `mvn clean package` green, **109 tests**, 0 failures
- `plugin.xml` extracted from the freshly built jar parses clean
- a scan of every git-tracked `.xml` in the repo finds no other malformed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
