### PR TITLE
fix(verify): both instrument false-positive mechanisms on the ORE corpus (#87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1591,6 +1591,35 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   runtime dependency and creates no cycle (nothing in `owl-dl-reasoner`'s manifest names
   `owl-dl-verify`).
 
+> **TWO INSTRUMENT FALSE-POSITIVE MECHANISMS FIXED (2026-09-04, #87), and on the corpus they
+> were 100% of the `Violated` verdicts.** Of the 366 ORE ontologies `verify-el` can check, 8
+> reported `Violated` and **all 8 adjudicated to the instrument's own bugs**, not engine gaps —
+> so the crate's headline claim was, corpus-wide, never once earned.
+> * **F4 (= this doc's F2)** — `⊤ ⊑ C` was never applied to a Tseitin witness. The saturator
+>   gives a marker an EMPTY subsumer set by design, so the witness carried only itself and the
+>   checker reported the very axiom that should have closed it; the violation count equalled the
+>   `⊤ ⊑ C` axiom count EXACTLY on all 4 affected ontologies. `FiniteModel::intern` now closes a
+>   label containing NO named class under the ⊤-supers. **The engine was right throughout**
+>   (`rustdl subclass X C` says `yes`; the same fixture with the nesting flattened verifies).
+> * **F5** — a `BoundTripped` build produced `Violated` instead of `Unresolved`. The model was
+>   TRUNCATED, so violations ran to the order of the domain size (25,369 / 20,292 / 54,304 /
+>   92,573). Now exit 3 (no verdict), not exit 2 (defect found).
+>
+> **BOTH FIXES ARE DELIBERATELY NARROW, and the narrowness is the interesting part.** Closing
+> EVERY label under the ⊤-supers, or downgrading on ANY build reason, would each be defensible
+> one line of reasoning at a time — and each would trade this crate's false-POSITIVE problem for
+> a false-NEGATIVE one, which is strictly worse for an instrument whose purpose is finding
+> defects. A named class whose closure lacks a ⊤-super IS a genuine D10 gap; a `LabelNotClosed`
+> alongside a violation is still a real disagreement.
+>
+> **A GUARD TEST SURVIVED ITS OWN SABOTAGE HERE — the third instance recorded in this file.**
+> The scoping canary was first written end-to-end, removing `C` from a named class's element via
+> `test_only_remove_from_label`. That seam runs AFTER interning, so the check fails under either
+> scoping and the test **discriminated nothing**; it passed the "close every label" sabotage. The
+> rule is now pinned at unit level on `intern` directly, where it can be observed, and the
+> end-to-end test was RENAMED to claim only what it checks. **Sabotage: 5 run, 4 caught first
+> pass, 1 survived and was closed** — run the sabotage before believing a guard.
+
   **Measured coverage, stated as measured, not rounded up.** Inertness (no spurious `Violated` on
   ontologies rustdl is believed complete on) is established on **16 of 20** banner-selected
   pure-EL ORE ontologies; the other **4 are UNMEASURED**, not passing — they hit `timeout`'s

--- a/crates/owl-dl-cli/src/main.rs
+++ b/crates/owl-dl-cli/src/main.rs
@@ -890,6 +890,34 @@ fn fold_build_reasons(
             violations,
             mut unresolved,
         } => {
+            // #87 F5. A `BoundTripped` means `build_model` STOPPED EARLY: the
+            // model is truncated by construction, so most axioms have no
+            // witness left to satisfy them and the violations are artifacts of
+            // the cut rather than evidence of an engine defect. Measured on the
+            // four ORE ontologies that trip `max_elements = 50_000`, the
+            // violation count runs to the order of the domain size itself
+            // (25_369 / 20_292 / 54_304 / 92_573). A truncated model must
+            // therefore yield NO VERDICT (exit 3), not "defect found" (exit 2).
+            //
+            // This is deliberately narrower than "any build reason downgrades a
+            // Violated". Every OTHER reason describes something the builder
+            // finished and could not close (`LabelNotClosed`, `RunDelta`,
+            // `AxiomsDroppedAtConversion`, …), where a violation found
+            // alongside it is still a real disagreement against whatever was
+            // checked — and suppressing those would trade this crate's
+            // false-POSITIVE problem for a false-NEGATIVE one, which is the
+            // worse direction for an instrument whose whole purpose is finding
+            // defects. Only truncation invalidates the violations wholesale.
+            if build_reasons
+                .iter()
+                .any(|r| matches!(r, owl_dl_verify::UnresolvedReason::BoundTripped { .. }))
+            {
+                unresolved.append(&mut build_reasons);
+                return Verdict::Unresolved {
+                    domain_size,
+                    reasons: unresolved,
+                };
+            }
             unresolved.append(&mut build_reasons);
             Verdict::Violated {
                 domain_size,
@@ -2819,5 +2847,112 @@ mod global_budget_tests {
             global_budget_after_parse(30_000, parse),
             Duration::from_secs(30).checked_sub(parse)
         );
+    }
+}
+
+#[cfg(test)]
+mod fold_build_reasons_tests {
+    use super::fold_build_reasons;
+    use owl_dl_verify::{UnresolvedReason, Verdict};
+
+    fn violated(unresolved: Vec<UnresolvedReason>) -> Verdict {
+        Verdict::Violated {
+            domain_size: 50_738,
+            violations: vec![],
+            unresolved,
+        }
+    }
+
+    /// #87 F5. A `BoundTripped` means `build_model` STOPPED EARLY, so the model is truncated
+    /// and its violations are artifacts of the cut, not evidence of an engine defect. Measured
+    /// on the 4 ORE ontologies that trip `max_elements = 50_000`: 25369 / 20292 / 54304 /
+    /// 92573 violations, on the order of the domain size itself. Such a run must yield NO
+    /// VERDICT (exit 3), not "defect found" (exit 2).
+    #[test]
+    fn a_bound_tripped_build_downgrades_a_violated_to_unresolved() {
+        let out = fold_build_reasons(
+            violated(vec![]),
+            vec![UnresolvedReason::BoundTripped {
+                bound: "max_elements",
+                limit: Some(50_000),
+            }],
+        );
+        assert!(
+            matches!(out, Verdict::Unresolved { .. }),
+            "a truncated model must not report a defect: {out:?}"
+        );
+    }
+
+    /// A deadline `BoundTripped` (`limit: None`) truncates just as much as a count one.
+    #[test]
+    fn a_deadline_bound_tripped_also_downgrades() {
+        let out = fold_build_reasons(
+            violated(vec![]),
+            vec![UnresolvedReason::BoundTripped {
+                bound: "deadline",
+                limit: None,
+            }],
+        );
+        assert!(matches!(out, Verdict::Unresolved { .. }), "{out:?}");
+    }
+
+    /// **The negative control, and the reason F5 is scoped to `BoundTripped` alone.**
+    ///
+    /// Every OTHER build reason describes something the builder FINISHED and could not close.
+    /// A violation found alongside one of those is still a real disagreement against whatever
+    /// was checked. Downgrading them too would trade this crate's false-POSITIVE problem for a
+    /// false-NEGATIVE one — the worse direction for an instrument whose purpose is finding
+    /// defects. If someone broadens the match to "any build reason", this fails.
+    #[test]
+    fn a_non_truncating_build_reason_leaves_a_violated_alone() {
+        for reason in [
+            UnresolvedReason::AxiomsDroppedAtConversion { count: 3 },
+            UnresolvedReason::UnhandledAxiom {
+                axiom_index: 0,
+                variant: "whatever",
+            },
+        ] {
+            let out = fold_build_reasons(violated(vec![]), vec![reason]);
+            assert!(
+                matches!(out, Verdict::Violated { .. }),
+                "a finished-but-incomplete build must keep its Violated verdict: {out:?}"
+            );
+        }
+    }
+
+    /// The reasons must survive the downgrade rather than be swallowed - a caller reading
+    /// `unresolved` has to be able to see WHY there is no verdict.
+    #[test]
+    fn the_downgrade_preserves_both_the_build_reason_and_any_pre_existing_ones() {
+        let out = fold_build_reasons(
+            violated(vec![UnresolvedReason::RunDelta {
+                class: owl_dl_core::ir::ClassId::new(7),
+            }]),
+            vec![UnresolvedReason::BoundTripped {
+                bound: "max_elements",
+                limit: Some(50_000),
+            }],
+        );
+        match out {
+            Verdict::Unresolved { reasons, .. } => assert_eq!(
+                reasons.len(),
+                2,
+                "both the pre-existing reason and the build reason must survive: {reasons:?}"
+            ),
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    /// The safety-critical `Verified` arm is unchanged by F5.
+    #[test]
+    fn a_verified_check_still_downgrades_on_any_build_reason() {
+        let out = fold_build_reasons(
+            Verdict::Verified {
+                domain_size: 3,
+                axioms_checked: 1,
+            },
+            vec![UnresolvedReason::AxiomsDroppedAtConversion { count: 1 }],
+        );
+        assert!(matches!(out, Verdict::Unresolved { .. }), "{out:?}");
     }
 }

--- a/crates/owl-dl-verify/src/model.rs
+++ b/crates/owl-dl-verify/src/model.rs
@@ -193,15 +193,37 @@ pub struct FiniteModel {
     /// Running total of edges across all roles, checked against
     /// `bounds.max_edges` by `push_edge`. Shared by both expansion paths.
     edge_count: usize,
+    /// Classes asserted of EVERY domain element by a `⊤ ⊑ C` axiom, closed
+    /// through the reported subsumer closure. Applied by `intern` to
+    /// marker-only labels — see `top_supers_of` for why only those.
+    top_supers: Vec<ClassId>,
+    /// `internal.vocabulary.num_classes()` at `seed` time. A `ClassId` at or
+    /// above this is a Tseitin marker, never a named class — the same test
+    /// `lib.rs` uses to decide what is injectable.
+    num_real_classes: usize,
 }
 
 impl FiniteModel {
     /// Interns `label` (which MUST be sorted ascending) and returns its element.
-    pub fn intern(&mut self, label: Vec<ClassId>) -> Element {
+    ///
+    /// A label containing NO named class is a Tseitin witness, and is closed
+    /// under [`Self::top_supers`] before interning. See `top_supers_of` for the
+    /// argument that this is the instrument's own gap and not the engine's, and
+    /// for why the closure is applied HERE rather than to every label.
+    pub fn intern(&mut self, mut label: Vec<ClassId>) -> Element {
         debug_assert!(
             label.windows(2).all(|w| w[0] <= w[1]),
             "label must be sorted"
         );
+        if !self.top_supers.is_empty()
+            && !label
+                .iter()
+                .any(|c| (c.index() as usize) < self.num_real_classes)
+        {
+            label.extend_from_slice(&self.top_supers);
+            label.sort_unstable_by_key(|c| c.index());
+            label.dedup();
+        }
         let key: Box<[ClassId]> = label.into_boxed_slice();
         if let Some(&e) = self.label_ix.get(&key) {
             return e;
@@ -224,6 +246,80 @@ impl FiniteModel {
         self.class_of.get(&c).copied()
     }
 
+    /// The classes a `⊤ ⊑ C` axiom asserts of EVERY domain element, closed
+    /// through the reported subsumer closure.
+    ///
+    /// # Why this is the instrument's gap, not the engine's (#87 F4)
+    ///
+    /// `⊤ ⊑ C` requires every element to be a `C`. A named class picks that up
+    /// for free: its label is `subs.subsumers_of(c)`, and the engine really does
+    /// derive `X ⊑ C` for every named `X` (measured — `rustdl subclass X C`
+    /// answers `yes`, and a copy of the reproducer with the nested existential
+    /// flattened away verifies clean). A **Tseitin marker** does not: the
+    /// saturator emits no fact for a nested existential body and gives its
+    /// marker an EMPTY subsumer set BY DESIGN (`lib.rs` documents the same
+    /// property where it refuses to inject for a marker). So the witness element
+    /// carried only itself, and `verify-el` reported the very `⊤ ⊑ C` axiom that
+    /// should have closed it — on 4 ORE ontologies, with the violation count
+    /// equal to the `⊤ ⊑ C` axiom count EXACTLY.
+    ///
+    /// # Why `intern` applies this ONLY to marker-only labels
+    ///
+    /// Applying it to every label would be semantically fine — the axiom really
+    /// does hold of everything — but it would DESTROY a real detection. If the
+    /// engine ever failed to derive `X ⊑ C` for a named `X`, that element's
+    /// label would lack `C`, the `⊤ ⊑ C` check would fail on it, and that is a
+    /// genuine completeness defect of exactly the D10 shape this crate exists to
+    /// find. Unioning `C` in from the AXIOM would paper over it silently.
+    ///
+    /// Restricting to labels with no named class in them keeps that detection
+    /// completely intact, because such a label never came from the closure of a
+    /// named class in the first place. `top_supers_are_not_applied_to_a_named_
+    /// class_label` pins it.
+    fn top_supers_of(internal: &InternalOntology, subs: &Subsumers) -> Vec<ClassId> {
+        let pool = &internal.concepts;
+        let mut atoms: Vec<ClassId> = Vec::new();
+        for ax in &internal.axioms {
+            match ax {
+                Axiom::SubClassOf { sub, sup } if matches!(pool.get(*sub), ConceptExpr::Top) => {
+                    Self::required_atoms(pool, *sup, &mut atoms);
+                }
+                // `C ≡ ⊤` says the same thing in the other direction, and
+                // conversion does not rewrite it into the `SubClassOf` form the
+                // arm above matches.
+                Axiom::EquivalentClasses(members)
+                    if members
+                        .iter()
+                        .any(|m| matches!(pool.get(*m), ConceptExpr::Top)) =>
+                {
+                    for m in members {
+                        Self::required_atoms(pool, *m, &mut atoms);
+                    }
+                }
+                _ => {}
+            }
+        }
+        // Close through the REPORTED closure, not the axioms: a super-class of a
+        // ⊤-super is itself asserted of everything, and taking it from `subs`
+        // means an engine that failed to derive that step still shows up as a
+        // violation rather than being closed over here.
+        let mut out: Vec<ClassId> = Vec::new();
+        for a in &atoms {
+            if subs.is_unsatisfiable(*a) {
+                // `⊤ ⊑ C` with `C` unsatisfiable makes the whole ontology
+                // inconsistent. Seeding it into every witness label would
+                // manufacture violations everywhere and bury that; leave it for
+                // the evaluator to report against the axiom itself.
+                return Vec::new();
+            }
+            out.push(*a);
+            out.extend(subs.subsumers_of(*a));
+        }
+        out.sort_unstable_by_key(|c| c.index());
+        out.dedup();
+        out
+    }
+
     /// Seeds one element per SATISFIABLE class, over the union of the named
     /// vocabulary and every id appearing in `facts` in either position.
     ///
@@ -238,6 +334,8 @@ impl FiniteModel {
     ) -> Self {
         let mut model = Self {
             edges: vec![Vec::new(); internal.vocabulary.num_roles()],
+            top_supers: Self::top_supers_of(internal, subs),
+            num_real_classes: internal.vocabulary.num_classes(),
             ..Self::default()
         };
         let mut population: Vec<ClassId> =
@@ -950,4 +1048,82 @@ pub fn chain_range_out_of_profile(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod intern_top_supers_tests {
+    use super::{Element, FiniteModel};
+    use owl_dl_core::ir::ClassId;
+
+    /// Builds a model with `num_real_classes = 2` (so ids 0,1 are named and 2+ are Tseitin
+    /// markers) and `⊤ ⊑ class 1`.
+    fn model() -> FiniteModel {
+        FiniteModel {
+            top_supers: vec![ClassId::new(1)],
+            num_real_classes: 2,
+            ..FiniteModel::default()
+        }
+    }
+
+    /// A marker-only label is closed under the ⊤-supers: the saturator gives a Tseitin marker
+    /// an EMPTY subsumer set by design, so nothing else will ever put `⊤ ⊑ C`'s `C` there.
+    /// This is #87 F4.
+    #[test]
+    fn a_marker_only_label_gains_the_top_supers() {
+        let mut m = model();
+        let e = m.intern(vec![ClassId::new(5)]);
+        assert_eq!(
+            m.label(e),
+            &[ClassId::new(1), ClassId::new(5)],
+            "a Tseitin witness must satisfy ⊤ ⊑ C like every other domain element"
+        );
+    }
+
+    /// **The scoping rule, tested where it can actually be observed.**
+    ///
+    /// A label containing a NAMED class must come back untouched, even though the ⊤-super is
+    /// missing from it. That label came from the engine's reported closure, so a missing
+    /// ⊤-super there is a genuine completeness defect of the D10 shape this crate exists to
+    /// find — injecting it from the axiom would silently hide one.
+    ///
+    /// This has to be asserted on `intern` directly. An end-to-end test cannot see it: the
+    /// engine has no such gap to observe, and `test_only_remove_from_label` runs AFTER
+    /// interning, so it fails the check under either scoping and discriminates nothing. That
+    /// version of this test was written first and survived its own sabotage, which is how the
+    /// gap in it was found.
+    #[test]
+    fn a_label_holding_a_named_class_is_left_alone() {
+        let mut m = model();
+        let e = m.intern(vec![ClassId::new(0)]);
+        assert_eq!(
+            m.label(e),
+            &[ClassId::new(0)],
+            "closing a NAMED class's label under the ⊤-supers would hide a real engine gap"
+        );
+    }
+
+    /// The union must not duplicate a ⊤-super the label already carries, and must stay sorted:
+    /// `label_ix` keys on the label bytes, so an unsorted or duplicated key would make two
+    /// spellings of one element intern as two different elements.
+    #[test]
+    fn the_union_stays_sorted_and_deduplicated() {
+        let mut m = model();
+        let e = m.intern(vec![ClassId::new(1), ClassId::new(5)]);
+        assert_eq!(m.label(e), &[ClassId::new(1), ClassId::new(5)]);
+        // The same content reached the other way round must intern to the SAME element.
+        let e2 = m.intern(vec![ClassId::new(5)]);
+        assert_eq!(e, e2, "one label content must be one element");
+    }
+
+    /// With no ⊤-axiom at all the path is inert, so every pre-#87 label is unchanged.
+    #[test]
+    fn no_top_axiom_leaves_every_label_untouched() {
+        let mut m = FiniteModel {
+            num_real_classes: 2,
+            ..FiniteModel::default()
+        };
+        let e = m.intern(vec![ClassId::new(5)]);
+        assert_eq!(m.label(e), &[ClassId::new(5)]);
+        assert_eq!(e, Element::new(0));
+    }
 }

--- a/crates/owl-dl-verify/tests/known_limitations.rs
+++ b/crates/owl-dl-verify/tests/known_limitations.rs
@@ -75,12 +75,22 @@ SubClassOf(:A :C)
     );
 }
 
-/// F2: a nested `∃` plus an ordinary `SubClassOf(owl:Thing, C)`. An element is seeded per
-/// Tseitin marker for the nested witness, and its label comes back as `target_label`'s minimal
+/// F2 — **FIXED** (#87 F4, 2026-09-04). Kept as a regression test, not deleted, exactly as
+/// this file's header instructs.
+///
+/// It was: a nested `∃` plus an ordinary `SubClassOf(owl:Thing, C)`. An element is seeded per
+/// Tseitin marker for the nested witness, and its label came back as `target_label`'s minimal
 /// `{Q}` row — never closed under `⊤ ⊑ C`. `SubClassOf(owl:Thing, …)` is ordinary in real EL
-/// ontologies, not an exotic construct.
+/// ontologies, not an exotic construct: this fired on 4 ORE ontologies, with the violation
+/// count equal to the `⊤ ⊑ C` axiom count EXACTLY.
+///
+/// The header asks whether the underlying gap is genuinely fixed or merely untriggered by this
+/// shape. Answered by measurement, not assertion — `FiniteModel::intern` now closes any
+/// label containing NO named class under the ⊤-supers, so the sibling tests below cover a
+/// deeper nesting, the `EquivalentClasses(owl:Thing, …)` spelling, and a ⊤-super reached only
+/// through the subsumer closure. All three verify clean; none of them is this shape.
 #[test]
-fn f2_nested_exists_plus_thing_subclass_is_a_false_violated() {
+fn f2_nested_exists_plus_thing_subclass_now_verifies() {
     let ofn = r"Prefix(:=<http://ex.org/>)
 Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
 Ontology(<http://ex.org/f2>
@@ -92,8 +102,71 @@ SubClassOf(owl:Thing :C)
 ";
     let verdict = verify_ofn(ofn);
     assert!(
-        matches!(verdict, Verdict::Violated { .. }),
-        "F2 known limitation did not reproduce (fixed?): {verdict:?}"
+        matches!(verdict, Verdict::Verified { .. }),
+        "F2 regressed - a Tseitin witness is no longer closed under the ⊤-supers: {verdict:?}"
+    );
+}
+
+/// F2, a DEEPER nesting. Three levels of `∃` rather than two, so a different marker sits at a
+/// different depth. Covers the mechanism rather than the one shape F2 happened to use.
+#[test]
+fn a_thrice_nested_witness_is_also_closed_under_the_top_supers() {
+    let ofn = r"Prefix(:=<http://ex.org/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://ex.org/f2deep>
+Declaration(Class(:X)) Declaration(Class(:Y)) Declaration(Class(:C))
+Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s)) Declaration(ObjectProperty(:t))
+SubClassOf(:X ObjectSomeValuesFrom(:r ObjectSomeValuesFrom(:s ObjectSomeValuesFrom(:t :Y))))
+SubClassOf(owl:Thing :C)
+)
+";
+    let verdict = verify_ofn(ofn);
+    assert!(
+        matches!(verdict, Verdict::Verified { .. }),
+        "a 3-deep Tseitin witness must be closed under the ⊤-supers too: {verdict:?}"
+    );
+}
+
+/// F2 in its other spelling. `EquivalentClasses(owl:Thing, C)` asserts the same thing as
+/// `SubClassOf(owl:Thing, C)` and conversion does NOT rewrite it into that form, so
+/// `top_supers_of` has to match it separately. Without that arm this reports `Violated`.
+#[test]
+fn the_equivalent_classes_spelling_of_a_top_axiom_is_also_collected() {
+    let ofn = r"Prefix(:=<http://ex.org/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://ex.org/f2equiv>
+Declaration(Class(:X)) Declaration(Class(:Y)) Declaration(Class(:C))
+Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))
+SubClassOf(:X ObjectSomeValuesFrom(:r ObjectSomeValuesFrom(:s :Y)))
+EquivalentClasses(owl:Thing :C)
+)
+";
+    let verdict = verify_ofn(ofn);
+    assert!(
+        matches!(verdict, Verdict::Verified { .. }),
+        "EquivalentClasses(owl:Thing, C) asserts C of every element too: {verdict:?}"
+    );
+}
+
+/// A ⊤-super reached only THROUGH THE CLOSURE: `⊤ ⊑ C` and `C ⊑ D` make `D` true of every
+/// element, but `D` appears in no ⊤-axiom. Pins the `subs.subsumers_of` step in
+/// `top_supers_of` — collecting the axiom heads alone leaves this `Violated`.
+#[test]
+fn a_top_super_reached_through_the_closure_is_collected() {
+    let ofn = r"Prefix(:=<http://ex.org/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://ex.org/f2chain>
+Declaration(Class(:X)) Declaration(Class(:Y)) Declaration(Class(:C)) Declaration(Class(:D))
+Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))
+SubClassOf(:X ObjectSomeValuesFrom(:r ObjectSomeValuesFrom(:s :Y)))
+SubClassOf(owl:Thing :C)
+SubClassOf(:C :D)
+)
+";
+    let verdict = verify_ofn(ofn);
+    assert!(
+        matches!(verdict, Verdict::Verified { .. }),
+        "a ⊤-super's own superclass holds of every element too: {verdict:?}"
     );
 }
 
@@ -137,5 +210,63 @@ ObjectPropertyDomain(:s :D)
     assert!(
         matches!(verdict, Verdict::Violated { .. }),
         "F3 known limitation did not reproduce (fixed?): {verdict:?}"
+    );
+}
+
+/// End-to-end: a named class missing a ⊤-super is still REPORTED, i.e. the evaluator checks
+/// `⊤ ⊑ C` against named-class elements and the F2 fix did not make it stop looking.
+///
+/// **This test does NOT pin the scoping rule, despite an earlier version of it claiming to.**
+/// It was written to catch the tempting simplification of closing EVERY label under the
+/// ⊤-supers, and it SURVIVED that sabotage: `test_only_remove_from_label` runs AFTER interning,
+/// so the entry is gone under either scoping and the check fails either way. Its green never
+/// depended on the thing it advertised.
+///
+/// The scoping rule is pinned where it can actually be observed —
+/// `model::intern_top_supers_tests::a_label_holding_a_named_class_is_left_alone`, which
+/// asserts on `intern` directly and DOES fail under that sabotage. Keep both: this one covers
+/// the evaluator, that one covers the rule.
+#[test]
+fn a_named_class_missing_a_top_super_is_still_reported() {
+    let ofn = r"Prefix(:=<http://ex.org/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Ontology(<http://ex.org/f2named>
+Declaration(Class(:X)) Declaration(Class(:Y)) Declaration(Class(:C))
+Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))
+SubClassOf(:X ObjectSomeValuesFrom(:r ObjectSomeValuesFrom(:s :Y)))
+SubClassOf(owl:Thing :C)
+)
+";
+    let internal = load(ofn);
+    let (mut model, build_reasons) =
+        owl_dl_verify::build_model(&internal, &Bounds::default()).expect("builds");
+    assert!(build_reasons.is_empty(), "{build_reasons:?}");
+
+    // Clean to begin with - that is the post-fix F2 behaviour asserted above. Rebuilt rather
+    // than cloned because `FiniteModel` is deliberately not `Clone`.
+    let (clean, _) = owl_dl_verify::build_model(&internal, &Bounds::default()).expect("builds");
+    let (verdict, _) = owl_dl_verify::verify(clean, &internal, None);
+    assert!(
+        matches!(verdict, Verdict::Verified { .. }),
+        "precondition: this fixture verifies before the mutation, got {verdict:?}"
+    );
+
+    let x = internal
+        .vocabulary
+        .class_id("http://ex.org/X")
+        .expect("X is a named class");
+    let c = internal
+        .vocabulary
+        .class_id("http://ex.org/C")
+        .expect("C is a named class");
+    let elem_x = model.element_of_class(x).expect("X is satisfiable");
+    model.test_only_remove_from_label(elem_x, c);
+
+    let (verdict, _) = owl_dl_verify::verify(model, &internal, None);
+    assert!(
+        matches!(verdict, Verdict::Violated { .. }),
+        "a NAMED class missing a ⊤-super is a genuine engine defect and must still be \
+         reported. If this now says Verified, `intern` is closing named-class labels under \
+         the ⊤-supers and the instrument has gone blind to a whole defect class: {verdict:?}"
     );
 }

--- a/docs/known-limitations/verify-two-expansion-paths-split-a-witness.md
+++ b/docs/known-limitations/verify-two-expansion-paths-split-a-witness.md
@@ -1,4 +1,7 @@
-# The model builder can report a false `Violated` (F1/F2/F3, plus the original split-witness risk)
+# The model builder can report a false `Violated` (F1/~~F2~~/F3, plus the original split-witness risk)
+
+> **F2 is FIXED (2026-09-04, #87).** F1 and F3 remain OPEN and still reproduce. The header
+> status below is written as of 2026-08-28 and is otherwise unchanged.
 
 **Found:** 2026-08-28 (Task 14, `owl-dl-verify`); F1/F2/F3 found 2026-08-28 during the final
 whole-branch review · **Status:** OPEN. The original split-witness risk below is still
@@ -94,9 +97,31 @@ The flat control (`X ⊑ ∃r.A`, `A ⊑ C`) verifies cleanly: with a single ato
 resolves through the saturator's own closure, which already folds `A ⊑ C` into `A`'s subsumer
 set before the model is ever built. Only the conjunctive body bypasses that closure.
 
-## F2 — nested `∃` plus an ordinary `SubClassOf(owl:Thing, C)`
+## F2 — nested `∃` plus an ordinary `SubClassOf(owl:Thing, C)` — **FIXED 2026-09-04 (#87 F4)**
 
-**Reproducer:** `crates/owl-dl-verify/tests/known_limitations.rs::f2_nested_exists_plus_thing_subclass_is_a_false_violated`
+> **CLOSED.** `FiniteModel::intern` now closes any label containing NO named class under the
+> ⊤-supers (collected from `SubClassOf(⊤, C)` and `EquivalentClasses(⊤, …)`, then closed through
+> the reported subsumer closure). On the corpus this was **4 of the 8** `Violated` verdicts
+> `verify-el` produced across all 1,920 ORE ontologies — `ore_ont_11522`, `ore_ont_14128`,
+> `ore_ont_14826`, `ore_ont_7270` — and in each the violation count equalled the `⊤ ⊑ C` axiom
+> count exactly. All four now report `Verified`.
+>
+> **Scoped to marker-only labels on purpose.** Closing EVERY label would be semantically fine —
+> `⊤ ⊑ C` does hold of everything — and would silently destroy a real detection: a NAMED class
+> whose reported closure lacks a ⊤-super is a genuine engine gap of the D10 shape this crate
+> exists to find, and injecting `C` from the axiom would hide it. Pinned by
+> `model::intern_top_supers_tests::a_label_holding_a_named_class_is_left_alone`, which asserts
+> on `intern` directly. An end-to-end version of that test was written first and **survived its
+> own sabotage** — `test_only_remove_from_label` runs after interning, so it fails under either
+> scoping and discriminated nothing. That is why the pin lives at unit level.
+>
+> The sentinel test is kept and inverted (`f2_nested_exists_plus_thing_subclass_now_verifies`),
+> per this crate's rule against deleting a limitation's reproducer. Three further tests answer
+> the "fixed, or merely untriggered by this shape?" question the sentinel file asks: a 3-deep
+> nesting, the `EquivalentClasses(owl:Thing, …)` spelling, and a ⊤-super reachable only through
+> the closure.
+
+**Reproducer (now a regression test):** `crates/owl-dl-verify/tests/known_limitations.rs::f2_nested_exists_plus_thing_subclass_now_verifies`
 (control: `f2_control_flat_exists_plus_thing_subclass_verifies_cleanly`).
 
 ```


### PR DESCRIPTION
Closes #87.

Of the **366** ORE ontologies `verify-el` can check, 8 reported `Violated` and **all 8
adjudicated to the instrument's own bugs**, not engine gaps — so the crate's headline claim
("a `Violated` is a real engine defect") was, corpus-wide, never once earned. Both mechanisms
are fixed.

## F4 — `SubClassOf(owl:Thing, C)` never reached a Tseitin witness

The saturator emits no fact for a nested existential body and gives its marker an **empty
subsumer set by design**, so the witness element carried only itself and the checker reported
the very `⊤ ⊑ C` axiom that should have closed it. On all four affected ontologies the
violation count equalled the `⊤ ⊑ C` axiom count **exactly**.

**The engine was right throughout**, and the discriminating pair is what shows it: `rustdl
subclass X C` answers `yes`, and the same reproducer with the nesting flattened away verifies
clean. It reproduces in ten lines:

```
SubClassOf(:X ObjectSomeValuesFrom(:r ObjectSomeValuesFrom(:s :A)))   <- nested: Violated
SubClassOf(owl:Thing :C)
```

`FiniteModel::intern` now closes a label containing **no named class** under the ⊤-supers,
collected from both `SubClassOf(⊤, …)` and `EquivalentClasses(⊤, …)` and closed through the
**reported subsumer closure** rather than the axioms — so an engine that failed to derive a
closure step still shows up as a violation instead of being papered over.

## F5 — a truncated model reported `Violated` instead of `Unresolved`

A `BoundTripped` means `build_model` stopped early, so most axioms have no witness left and
the violations are artifacts of the cut: 25369 / 20292 / 54304 / 92573 of them, on the order
of the domain size itself. Now exit **3** (no verdict), not exit 2 (defect found).

## Both fixes are deliberately narrow

Closing **every** label under the ⊤-supers, or downgrading on **any** build reason, each reads
as the natural generalisation — and each would trade this crate's false-**positive** problem
for a false-**negative** one, which is strictly worse for an instrument whose purpose is
finding defects. A named class whose closure lacks a ⊤-super *is* a genuine D10 gap; a
`LabelNotClosed` alongside a violation is still a real disagreement against whatever was
checked.

## A guard test survived its own sabotage

Worth recording, because it nearly shipped. The scoping canary was first written end-to-end,
removing `C` from a named class's element via `test_only_remove_from_label`. That seam runs
**after** interning, so the check fails under either scoping and the test **discriminated
nothing** — it passed the "close every label" sabotage it existed to catch. The rule is now
pinned at unit level on `intern` directly, where it can be observed, and the end-to-end test
was renamed to claim only what it actually checks.

**Sabotage: 5 run, 4 caught first pass, 1 survived and was closed.**

| # | sabotage | result |
|---|---|---|
| S1 | close every label, not just marker-only | **survived**, then caught by the unit pin |
| S2 | drop the subsumer-closure step | caught (1 test) |
| S3 | drop the `EquivalentClasses` arm | caught (1 test) |
| S4 | revert the fix entirely | caught (5 tests) |
| S5 | downgrade on any build reason | caught (negative control) |

## The sentinel is inverted, not deleted

`known_limitations.rs` pins F1/F2/F3 as *current defective behaviour* and its header instructs
that a newly-passing one be updated rather than removed, and be re-checked for whether the
gap is genuinely fixed or merely untriggered by that shape. Answered by measurement: three
further tests cover a 3-deep nesting, the `EquivalentClasses(owl:Thing, …)` spelling, and a
⊤-super reachable only through the closure. **F1 and F3 remain open and still reproduce.**

## Verification

- the 4 F4 ontologies now report `verified`; the 4 F5 ones `unresolved` with exit 3
- suite **1917 passed / 0 failed** (`CARGO_EXIT=0` — captured directly, not through a pipe)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` exit 0
- a two-arm `verify-el` sweep over all 1,920 ORE ontologies is running; I will post the
  verdict-distribution delta as a comment. The risk it covers is a *new* false `Violated`
  from the added labels — the fix only ever adds labels to marker-only elements, so that is
  the direction to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
