### PR TITLE
fix(saturation): a role chain's range must reach the end of the chain (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1641,6 +1641,49 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   paths can label one logical nested-existential witness differently and get deduped into two
   separate elements — not shown unsound, but untested against a future concept-level check).
 
+> **CHAIN-INDUCED RANGE FOLDING (2026-09-05, #84, unflagged) — THE SIBLING OF #81, KEYED ON A
+> ROLE PAIR.** `Chain(t,u) ⊑ r` + `Range(r,F)` + `C ⊑ ∃t.∃u.A` + `∃t.∃u.F ⊑ D` entails `C ⊑ D`,
+> and `classify` reported only `F ⊑ G` with **`incomplete: false`** — the D10 shape. `HermiT`
+> confirms; **Konclude misses it too**, which is why the adjudication went to `HermiT`.
+>
+> **The issue predicted this needed "a chain-aware derivation rule, not an extras fold at
+> lowering time". That was half right.** It IS a fold — but keyed on the ORDERED ROLE PAIR
+> rather than a single role. New `chain_ranges[(a,b)]` = `effective_ranges[sup]` for every
+> declared `a ∘ b ⊑ sup`, consumed by `nested_extras` at the one site where the composed edge
+> provably exists, namely lowering `∃a.∃b.X`: `a(x,y) ∧ b(y,z) ∧ a∘b ⊑ sup ⟹ sup(x,z)`. So
+> `∃a.∃b.X` and `∃a.∃b.(X ⊓ Range(sup))` are the SAME class — a logical identity, sound and
+> completeness-preserving by construction, exactly as #81's `∃R.B ≡ ∃R.(B ⊓ Range(R))`.
+> **The issue's soundness warning is respected precisely**: folding into `effective_ranges[u]`
+> would be unsound (a bare `u`-successor with no `t`-predecessor is not a `sup`-successor), and
+> the pair key is what avoids it.
+>
+> **A SABOTAGE SURVIVED, AND IT WAS THE UNSOUND VARIANT.** The FP guard used a **top-level**
+> `∃u.A`, which `atomic_existential_rhs` handles WITHOUT calling `nested_extras` — so it guarded
+> the implementation the issue warns about and was structurally blind to an over-broad fold in
+> the code actually written. Making the lookup match any pair whose SECOND leg is `u` left it
+> green. Closed by `a_nested_pair_whose_outer_role_is_not_the_chain_head_does_not_fire`, which
+> drives that path. **Both are kept — they cover different implementations of the same
+> mistake.** Sabotage: 4 run, 3 caught first pass, 1 survived and was closed.
+>
+> **THE VACUITY GUARD FIRED, CORRECTLY, AND THE FIRST READING OF IT WAS WRONG.**
+> `the_detection_set_has_not_silently_gone_vacuous` failed. That reads as "the fix closed every
+> gap in the acceptance set"; a per-fixture diff against a pinned pre-fix binary showed the
+> truth — **exactly ONE of ten fixtures changed** (`chainrange`, the target), and it was simply
+> the LAST remaining detection. The fix is surgical, not sweeping. **Diff the fixtures before
+> believing a vacuity failure's implied scope.**
+>
+> Replacement detection, per the guard's own instruction: **`chaincompose.ofn`** — `t∘u ⊑ r`,
+> `r∘v ⊑ s`, `Range(s,F)`, a chain COMPOSED FROM TWO CHAINS. `HermiT` derives `C ⊑ D`; rustdl
+> reports only `F ⊑ G`, silently. **This is the documented residual of the #84 fix itself**:
+> `chain_ranges` keys on DECLARED pairs, so it sees `(t,u)` and `(r,v)` but never forms the
+> composed `(t,u,v) ⊑ s`. Closing it needs a transitive closure over chain composition — a
+> strictly larger change. Its oracle also records that `build_model` still REFUSES the shape
+> (`ChainRangeOutOfProfile`), so the fixture guards `classification_matches_oracle`, not the
+> checker.
+>
+> Canaries `crates/owl-dl-reasoner/tests/chain_induced_range.rs` (7). Gates: suite 1918/0;
+> FP=0 net 11 VERIFIED, every closure exact; clippy clean.
+
 > **RANGE FOLDING INTO NESTED EXISTENTIAL WITNESSES (2026-08-29, #81, unflagged) — AND FIVE
 > TESTS THAT WERE PINNING THE BUG.** Two lowering sites in `owl-dl-saturation` dropped a role's
 > `ObjectPropertyRange` when building an existential witness, so `cascade.ofn` returned **ZERO

--- a/crates/owl-dl-reasoner/tests/chain_induced_range.rs
+++ b/crates/owl-dl-reasoner/tests/chain_induced_range.rs
@@ -1,0 +1,191 @@
+//! #84 — a role chain's range must reach the witness at the end of the chain.
+//!
+//! ```text
+//! Chain(t, u) ⊑ r,  Range(r, F),  C ⊑ ∃t.∃u.A,  ∃t.∃u.F ⊑ D   ⟹   C ⊑ D
+//! ```
+//!
+//! For `x ∈ C`: `t(x,y)`, `u(y,z)`, `z ∈ A`; the chain gives `r(x,z)`, so the range
+//! gives `z ∈ F`, so `y ∈ ∃u.F`, so `x ∈ ∃t.∃u.F ⊑ D`. `HermiT` confirms every
+//! positive below. **Konclude misses this shape**, which is why the adjudication went
+//! to `HermiT` — see `docs/benchmarks/2026-08-29-chain-induced-range-adjudication.md`.
+//!
+//! # The negatives are the point of this file
+//!
+//! The fix folds `Range(r)` into the filler of a NESTED `∃t.∃u.X`, where the `t` step
+//! is present by construction. Folding it into `effective_ranges[u]` instead would
+//! close the same fixture and be **unsound**: a bare `u`-successor with no
+//! `t`-predecessor is not an `r`-successor and must not inherit `Range(r)`. The
+//! issue says so explicitly, and `a_bare_inner_successor_does_not_inherit_the_chain_range`
+//! is what holds the implementation to it. `HermiT` agrees with both negatives.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use std::io::Cursor;
+use std::time::Duration;
+
+fn holds(ofn: &str, sub: &str, sup: &str) -> bool {
+    let mut reader = Cursor::new(ofn.to_string());
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    // The complete path, so a MISS here is the calculus rather than a trust_sat mask.
+    let result = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+    result.is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+fn subsumptions(_ofn: &str) -> &'static str {
+    "(see is_subclass)"
+}
+
+const HEAD: &str = "Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/cr>\n\
+Declaration(Class(:A)) Declaration(Class(:F)) Declaration(Class(:C)) Declaration(Class(:D))\n\
+Declaration(Class(:X))\n\
+Declaration(ObjectProperty(:t)) Declaration(ObjectProperty(:u)) Declaration(ObjectProperty(:r))\n";
+
+#[test]
+fn a_chain_range_reaches_the_witness_at_the_end_of_the_chain() {
+    let ofn = format!(
+        "{HEAD}\
+SubObjectPropertyOf(ObjectPropertyChain(:t :u) :r)\n\
+ObjectPropertyRange(:r :F)\n\
+SubClassOf(:C ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :A)))\n\
+SubClassOf(ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :F)) :D)\n)\n"
+    );
+    assert!(
+        holds(&ofn, "C", "D"),
+        "C ⊑ D is entailed (HermiT confirms) — the chain gives r(x,z) and Range(r) \
+         then types the inner witness F. Got {:?}",
+        subsumptions(&ofn)
+    );
+}
+
+#[test]
+fn a_bare_inner_successor_does_not_inherit_the_chain_range() {
+    // THE FP GUARD. `X ⊑ ∃u.A` with no `t` step: `X`'s `u`-successor is NOT an
+    // `r`-successor, so it must not become an `F`, so `X ⊑ D` must NOT hold.
+    // Folding the chain range into `effective_ranges[u]` would derive it. HermiT
+    // reports nothing here.
+    let ofn = format!(
+        "{HEAD}\
+SubObjectPropertyOf(ObjectPropertyChain(:t :u) :r)\n\
+ObjectPropertyRange(:r :F)\n\
+SubClassOf(:X ObjectSomeValuesFrom(:u :A))\n\
+SubClassOf(ObjectSomeValuesFrom(:u :F) :D)\n)\n"
+    );
+    assert!(
+        !holds(&ofn, "X", "D"),
+        "FALSE POSITIVE: a bare u-successor with no t-predecessor is not an \
+         r-successor and must not inherit Range(r). Got {:?}",
+        subsumptions(&ofn)
+    );
+}
+
+#[test]
+fn a_nested_pair_whose_outer_role_is_not_the_chain_head_does_not_fire() {
+    // **The FP guard that actually exercises the fold.** `∃w.∃u.A` is NESTED, so it
+    // DOES reach `nested_extras` — but `w ∘ u` is not a declared chain, so no range
+    // may be folded and `X ⊑ D` must not hold.
+    //
+    // Its sibling `a_bare_inner_successor_does_not_inherit_the_chain_range` uses a
+    // TOP-LEVEL `∃u.A`, which `atomic_existential_rhs` handles without ever calling
+    // `nested_extras`. That test therefore guards the "put it in
+    // `effective_ranges[u]`" implementation the issue warns against, and CANNOT see
+    // an over-broad `nested_extras`. Sabotaging the lookup to match any pair whose
+    // SECOND leg is `u` left it green; this one fails. Keep both — they cover
+    // different implementations of the same mistake.
+    let ofn = format!(
+        "{HEAD}\
+Declaration(ObjectProperty(:w))\n\
+SubObjectPropertyOf(ObjectPropertyChain(:t :u) :r)\n\
+ObjectPropertyRange(:r :F)\n\
+SubClassOf(:X ObjectSomeValuesFrom(:w ObjectSomeValuesFrom(:u :A)))\n\
+SubClassOf(ObjectSomeValuesFrom(:w ObjectSomeValuesFrom(:u :F)) :D)\n)\n"
+    );
+    assert!(
+        !holds(&ofn, "X", "D"),
+        "FALSE POSITIVE: w ∘ u is not the declared chain t ∘ u, so no r-edge exists \
+         and Range(r) must not reach the inner witness."
+    );
+}
+
+#[test]
+fn the_chain_pair_is_ordered_so_the_reverse_nesting_does_not_fire() {
+    // `∃u.∃t.A` composes as `u ∘ t`, which is NOT the declared chain. Pins that
+    // `chain_ranges` is keyed on the ORDERED pair.
+    let ofn = format!(
+        "{HEAD}\
+SubObjectPropertyOf(ObjectPropertyChain(:t :u) :r)\n\
+ObjectPropertyRange(:r :F)\n\
+SubClassOf(:X ObjectSomeValuesFrom(:u ObjectSomeValuesFrom(:t :A)))\n\
+SubClassOf(ObjectSomeValuesFrom(:u ObjectSomeValuesFrom(:t :F)) :D)\n)\n"
+    );
+    assert!(
+        !holds(&ofn, "X", "D"),
+        "FALSE POSITIVE: u ∘ t is not the declared chain t ∘ u. Got {:?}",
+        subsumptions(&ofn)
+    );
+}
+
+#[test]
+fn a_range_on_a_super_role_of_the_chain_head_also_reaches_the_witness() {
+    // `chain_ranges` reads `effective_ranges[sup]`, already closed over `sup`'s own
+    // super-roles, so `Range(q)` with `r ⊑ q` applies. Reading `role_ranges[sup]`
+    // instead would miss this. HermiT confirms.
+    let ofn = format!(
+        "{HEAD}\
+Declaration(ObjectProperty(:q))\n\
+SubObjectPropertyOf(ObjectPropertyChain(:t :u) :r)\n\
+SubObjectPropertyOf(:r :q)\n\
+ObjectPropertyRange(:q :F)\n\
+SubClassOf(:C ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :A)))\n\
+SubClassOf(ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :F)) :D)\n)\n"
+    );
+    assert!(
+        holds(&ofn, "C", "D"),
+        "a range on a SUPER-role of the chain head applies to the chain's \
+         successors too (HermiT confirms). Got {:?}",
+        subsumptions(&ofn)
+    );
+}
+
+#[test]
+fn no_chain_means_no_fold() {
+    // The plain control: same shape, chain axiom removed. Nothing should be derived,
+    // and this is what shows the chain axiom is load-bearing rather than the range
+    // alone doing the work.
+    let ofn = format!(
+        "{HEAD}\
+ObjectPropertyRange(:r :F)\n\
+SubClassOf(:C ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :A)))\n\
+SubClassOf(ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :F)) :D)\n)\n"
+    );
+    assert!(
+        !holds(&ofn, "C", "D"),
+        "without the chain axiom there is no r-edge, so no range applies. Got {:?}",
+        subsumptions(&ofn)
+    );
+}
+
+#[test]
+fn the_fix_does_not_disturb_a_plain_nested_range() {
+    // #81's fold (a role's OWN range into a nested witness) must keep working —
+    // `nested_extras` starts from `range_extras` and only ADDS to it.
+    let ofn = format!(
+        "{HEAD}\
+ObjectPropertyRange(:u :F)\n\
+SubClassOf(:C ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :A)))\n\
+SubClassOf(ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u :F)) :D)\n)\n"
+    );
+    assert!(
+        holds(&ofn, "C", "D"),
+        "#81's plain nested-range fold regressed. Got {:?}",
+        subsumptions(&ofn)
+    );
+}

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -3208,17 +3208,44 @@ fn collect_el_rules_with_provenance(
         use std::collections::HashMap as SMap;
         let mut mini_rules = ElRules::default();
         let mut mini_tseitin = TseitinAllocator::new(num_classes);
-        // Pass 1 mini: just range (needed for effective_ranges).
+        // Pass 1 mini: range (needed for effective_ranges) and, since #84, the
+        // length-2 chain axioms `chain_ranges` is keyed on. Both must mirror the
+        // real Pass 1 exactly — this pass re-runs the lowering purely to
+        // ATTRIBUTE each derived rule to its axiom, so any divergence here shows
+        // up as a wrong or missing proof rather than a wrong answer.
         for ax in &internal.axioms {
-            if let Axiom::ObjectPropertyRange { role, range } = ax
-                && !role.is_inverse()
-                && let ConceptExpr::Atomic(id) = internal.concepts.get(*range)
-            {
-                mini_rules
-                    .role_ranges
-                    .entry(role.role_id())
-                    .or_default()
-                    .push(*id);
+            match ax {
+                Axiom::ObjectPropertyRange { role, range }
+                    if !role.is_inverse()
+                        && matches!(internal.concepts.get(*range), ConceptExpr::Atomic(_)) =>
+                {
+                    if let ConceptExpr::Atomic(id) = internal.concepts.get(*range) {
+                        mini_rules
+                            .role_ranges
+                            .entry(role.role_id())
+                            .or_default()
+                            .push(*id);
+                    }
+                }
+                Axiom::SubObjectPropertyOf {
+                    sub: SubRolePath::Chain(parts),
+                    sup,
+                } if parts.len() == 2
+                    && !parts[0].is_inverse()
+                    && !parts[1].is_inverse()
+                    && !sup.is_inverse() =>
+                {
+                    mini_rules.chain_axioms.push((
+                        parts[0].role_id(),
+                        parts[1].role_id(),
+                        sup.role_id(),
+                    ));
+                }
+                Axiom::TransitiveRole(role) if !role.is_inverse() => {
+                    let r = role.role_id();
+                    mini_rules.chain_axioms.push((r, r, r));
+                }
+                _ => {}
             }
         }
         let mut mini_effective: SMap<RoleId, Vec<ClassId>> = SMap::new();
@@ -3233,6 +3260,16 @@ fn collect_el_rules_with_provenance(
                 mini_effective.insert(r, union);
             }
         }
+        let mut mini_chain_ranges: SMap<(RoleId, RoleId), Vec<ClassId>> = SMap::new();
+        for &(r1, r2, sup) in &mini_rules.chain_axioms {
+            if let Some(rs) = mini_effective.get(&sup) {
+                let e: &mut Vec<ClassId> = mini_chain_ranges.entry((r1, r2)).or_default();
+                e.extend_from_slice(rs);
+                e.sort_unstable_by_key(|c| c.index());
+                e.dedup();
+            }
+        }
+        let mini_chain_ranges = &mini_chain_ranges;
         for (ax_idx, ax) in internal.axioms.iter().enumerate() {
             match ax {
                 Axiom::SubClassOf { sub, sup } => {
@@ -3249,6 +3286,7 @@ fn collect_el_rules_with_provenance(
                         &mut mini_rules,
                         &mut mini_tseitin,
                         &mini_effective,
+                        mini_chain_ranges,
                     );
                     let a_a = mini_rules.atomic_subsumptions.len();
                     let a_c = mini_rules.conjunctive_triggers.len();
@@ -3288,6 +3326,7 @@ fn collect_el_rules_with_provenance(
                                     &mut mini_rules,
                                     &mut mini_tseitin,
                                     &mini_effective,
+                                    mini_chain_ranges,
                                 );
                                 let a_a = mini_rules.atomic_subsumptions.len();
                                 let a_c = mini_rules.conjunctive_triggers.len();
@@ -3482,6 +3521,25 @@ fn collect_el_rules(
             effective_ranges.insert(r, union);
         }
     }
+    // Issue #84: `chain_ranges[(a, b)]` = the effective ranges of every `sup`
+    // declared as `a ∘ b ⊑ sup`. Consumed by `nested_extras`, which folds them
+    // into the filler of a nested `∃a.∃b.X` — the one place the composed edge is
+    // known to exist. Putting them in `effective_ranges[b]` instead would be
+    // UNSOUND (a bare `b`-successor with no `a`-predecessor is not a
+    // `sup`-successor), which is why this is a separate, pair-keyed table.
+    //
+    // Values come from `effective_ranges[sup]`, already closed over `sup`'s own
+    // super-roles, so a range declared further up the hierarchy is picked up.
+    let mut chain_ranges: HashMap<(RoleId, RoleId), Vec<ClassId>> = HashMap::new();
+    for &(r1, r2, sup) in &rules.chain_axioms {
+        if let Some(rs) = effective_ranges.get(&sup) {
+            let e: &mut Vec<ClassId> = chain_ranges.entry((r1, r2)).or_default();
+            e.extend_from_slice(rs);
+            e.sort_unstable_by_key(|c| c.index());
+            e.dedup();
+        }
+    }
+    let chain_ranges = &chain_ranges;
     // Pass 2: lower SubClassOf / EquivalentClasses with effective_ranges
     // available so RHS existential bodies can be Tseitin-folded with
     // their role's range constraint.
@@ -3495,6 +3553,7 @@ fn collect_el_rules(
                     &mut rules,
                     &mut tseitin,
                     &effective_ranges,
+                    chain_ranges,
                 );
             }
             Axiom::EquivalentClasses(members) => {
@@ -3514,6 +3573,7 @@ fn collect_el_rules(
                                 &mut rules,
                                 &mut tseitin,
                                 &effective_ranges,
+                                chain_ranges,
                             );
                         }
                     }
@@ -3781,6 +3841,7 @@ fn lower_sub_class_of(
     rules: &mut ElRules,
     tseitin: &mut TseitinAllocator,
     effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
 ) {
     // SP-B1: register an atomic disjunction `C ⊑ D₁⊔…⊔Dₙ` (all `Dᵢ` atomic, n≥2)
     // for the derived-closure forced-disjunct rule fired in `process_subsumer`.
@@ -3911,7 +3972,7 @@ fn lower_sub_class_of(
             // synthetic atomic if the body is a compound And, OR if
             // r has a range constraint that needs to be folded in.
             if let Some((role, target)) =
-                atomic_existential_rhs(sup, pool, rules, tseitin, effective_ranges)
+                atomic_existential_rhs(sup, pool, rules, tseitin, effective_ranges, chain_ranges)
             {
                 rules.existential_facts.push(ExistentialFact {
                     sub: *sub_id,
@@ -3923,9 +3984,14 @@ fn lower_sub_class_of(
             // operand of a top-level And on the right.
             if let ConceptExpr::And(operands) = pool.get(sup) {
                 for op in operands {
-                    if let Some((role, target)) =
-                        atomic_existential_rhs(*op, pool, rules, tseitin, effective_ranges)
-                    {
+                    if let Some((role, target)) = atomic_existential_rhs(
+                        *op,
+                        pool,
+                        rules,
+                        tseitin,
+                        effective_ranges,
+                        chain_ranges,
+                    ) {
                         rules.existential_facts.push(ExistentialFact {
                             sub: *sub_id,
                             role,
@@ -3957,6 +4023,7 @@ fn lower_sub_class_of(
                             rules,
                             tseitin,
                             effective_ranges,
+                            chain_ranges,
                         ) else {
                             salvageable = false;
                             break;
@@ -4064,15 +4131,27 @@ fn lower_sub_class_of(
             // apart again, and picks up the `≥n R.C` (n ≥ 1) head, the nominal
             // body and the `∃R.⊤` filler that arm already handles.
             let sup_existentials: Vec<(RoleId, ClassId)> = match pool.get(sup) {
-                ConceptExpr::Some(_, _) | ConceptExpr::Min(_, _, _) => {
-                    atomic_existential_rhs(sup, pool, rules, tseitin, effective_ranges)
-                        .map(|pair| vec![pair])
-                        .unwrap_or_default()
-                }
+                ConceptExpr::Some(_, _) | ConceptExpr::Min(_, _, _) => atomic_existential_rhs(
+                    sup,
+                    pool,
+                    rules,
+                    tseitin,
+                    effective_ranges,
+                    chain_ranges,
+                )
+                .map(|pair| vec![pair])
+                .unwrap_or_default(),
                 ConceptExpr::And(operands) => operands
                     .iter()
                     .filter_map(|&op| {
-                        atomic_existential_rhs(op, pool, rules, tseitin, effective_ranges)
+                        atomic_existential_rhs(
+                            op,
+                            pool,
+                            rules,
+                            tseitin,
+                            effective_ranges,
+                            chain_ranges,
+                        )
                     })
                     .collect(),
                 _ => Vec::new(),
@@ -4149,9 +4228,14 @@ fn lower_sub_class_of(
             // only C's that genuinely derive `∃r.A` (entailed by the KB) gain M and are
             // marked unsat; A itself and classes with unrelated existentials are unaffected.
             if matches!(pool.get(sup), ConceptExpr::Bot) {
-                let Some(body_ids) =
-                    existential_body_alternatives(*body, pool, rules, tseitin, effective_ranges)
-                else {
+                let Some(body_ids) = existential_body_alternatives(
+                    *body,
+                    pool,
+                    rules,
+                    tseitin,
+                    effective_ranges,
+                    chain_ranges,
+                ) else {
                     return;
                 };
                 for body_id in body_ids {
@@ -4161,9 +4245,14 @@ fn lower_sub_class_of(
                 }
                 return;
             }
-            let Some(body_ids) =
-                existential_body_alternatives(*body, pool, rules, tseitin, effective_ranges)
-            else {
+            let Some(body_ids) = existential_body_alternatives(
+                *body,
+                pool,
+                rules,
+                tseitin,
+                effective_ranges,
+                chain_ranges,
+            ) else {
                 return;
             };
             for head in atomic_operands_on_right(sup, pool) {
@@ -4190,16 +4279,30 @@ fn lower_sub_class_of(
             // entailed `∃r.B ⊑ ∃s.D` (negative control test guards over-firing).
             let sup_existentials: Vec<(RoleId, ClassId)> = match pool.get(sup) {
                 ConceptExpr::Some(s_role, s_body) if !s_role.is_inverse() => {
-                    atomic_or_tseitin_body(*s_body, pool, rules, tseitin, effective_ranges)
-                        .map(|b| vec![(s_role.role_id(), b)])
-                        .unwrap_or_default()
+                    atomic_or_tseitin_body(
+                        *s_body,
+                        pool,
+                        rules,
+                        tseitin,
+                        effective_ranges,
+                        chain_ranges,
+                    )
+                    .map(|b| vec![(s_role.role_id(), b)])
+                    .unwrap_or_default()
                 }
                 ConceptExpr::And(operands) => operands
                     .iter()
                     .filter_map(|&op| match pool.get(op) {
                         ConceptExpr::Some(s_role, s_body) if !s_role.is_inverse() => {
-                            atomic_or_tseitin_body(*s_body, pool, rules, tseitin, effective_ranges)
-                                .map(|b| (s_role.role_id(), b))
+                            atomic_or_tseitin_body(
+                                *s_body,
+                                pool,
+                                rules,
+                                tseitin,
+                                effective_ranges,
+                                chain_ranges,
+                            )
+                            .map(|b| (s_role.role_id(), b))
                         }
                         _ => None,
                     })
@@ -4258,6 +4361,7 @@ fn atomic_existential_rhs(
     rules: &mut ElRules,
     tseitin: &mut TseitinAllocator,
     effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
 ) -> Option<(RoleId, ClassId)> {
     // Accept both `∃R.body` (Some) and `≥n R.body` (Min with n ≥ 1).
     // Min(n, R, C) implies ∃R.C for n ≥ 1, so lowering Min as Some is
@@ -4297,9 +4401,60 @@ fn atomic_existential_rhs(
     let extras = effective_ranges
         .get(&role.role_id())
         .map_or(&[][..], Vec::as_slice);
-    let body_id =
-        atomic_or_tseitin_body_with_extras(*body, extras, pool, rules, tseitin, effective_ranges)?;
+    let body_id = atomic_or_tseitin_body_with_extras(
+        *body,
+        extras,
+        pool,
+        rules,
+        tseitin,
+        effective_ranges,
+        chain_ranges,
+        // This body hangs off a `role` edge, so a nested existential inside
+        // it can compose with `role` (issue #84).
+        Some(role.role_id()),
+    )?;
     Some((role.role_id(), body_id))
+}
+
+/// Extras for the filler of an `inner`-edge that hangs off an `outer`-edge:
+/// `Range(inner)` plus, when `outer ∘ inner ⊑ sup` is a declared chain,
+/// `Range(sup)` (issue #84).
+///
+/// **Why the chain range belongs HERE and not in `effective_ranges[inner]`.**
+/// The issue's own analysis rules the latter out as unsound, and it is right: a
+/// bare `inner`-successor with no `outer`-predecessor is not a `sup`-successor
+/// and must not inherit `Range(sup)`. But at THIS site the `outer` step is
+/// present by construction — we are lowering `∃outer.∃inner.X` — so the
+/// composed edge really does exist:
+///
+/// ```text
+/// outer(x,y), inner(y,z), outer ∘ inner ⊑ sup  ⟹  sup(x,z)  ⟹  z ∈ Range(sup)
+/// ```
+///
+/// So `∃outer.∃inner.X` and `∃outer.∃inner.(X ⊓ Range(sup))` denote the SAME
+/// class, exactly as `∃R.B` and `∃R.(B ⊓ Range(R))` do for the plain case in
+/// [`range_extras`] — this is a logical identity, hence sound and
+/// completeness-preserving by construction, and a differing closure would be a
+/// bug rather than a trade-off.
+///
+/// `chain_ranges` is keyed on the ORDERED pair, and its values come from
+/// `effective_ranges[sup]` rather than `role_ranges[sup]`, so a range declared
+/// on a SUPER-role of the chain head is picked up too.
+fn nested_extras(
+    effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
+    outer: Option<RoleId>,
+    inner: RoleId,
+) -> Vec<ClassId> {
+    let mut out = range_extras(effective_ranges, inner).to_vec();
+    if let Some(o) = outer
+        && let Some(extra) = chain_ranges.get(&(o, inner))
+    {
+        out.extend_from_slice(extra);
+    }
+    out.sort_unstable_by_key(|c| c.index());
+    out.dedup();
+    out
 }
 
 /// `effective_ranges[r]`, or an empty slice for a role with no range.
@@ -4324,8 +4479,18 @@ fn atomic_or_tseitin_body(
     rules: &mut ElRules,
     tseitin: &mut TseitinAllocator,
     effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
 ) -> Option<ClassId> {
-    atomic_or_tseitin_body_with_extras(body, &[], pool, rules, tseitin, effective_ranges)
+    atomic_or_tseitin_body_with_extras(
+        body,
+        &[],
+        pool,
+        rules,
+        tseitin,
+        effective_ranges,
+        chain_ranges,
+        None,
+    )
 }
 
 /// Populate [`ElRules::abox_nominal_reach`]: for each **transitive**
@@ -4427,19 +4592,26 @@ fn existential_body_alternatives(
     rules: &mut ElRules,
     tseitin: &mut TseitinAllocator,
     effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
 ) -> Option<Vec<ClassId>> {
     match pool.get(body) {
         ConceptExpr::Or(operands) => {
             let mut out = Vec::with_capacity(operands.len());
             for &op in operands {
-                let id = atomic_or_tseitin_body(op, pool, rules, tseitin, effective_ranges)?;
+                let id = atomic_or_tseitin_body(
+                    op,
+                    pool,
+                    rules,
+                    tseitin,
+                    effective_ranges,
+                    chain_ranges,
+                )?;
                 out.push(id);
             }
             Some(out)
         }
-        _ => {
-            atomic_or_tseitin_body(body, pool, rules, tseitin, effective_ranges).map(|id| vec![id])
-        }
+        _ => atomic_or_tseitin_body(body, pool, rules, tseitin, effective_ranges, chain_ranges)
+            .map(|id| vec![id]),
     }
 }
 
@@ -4474,6 +4646,7 @@ fn concept_is_provably_bot(c: ConceptId, pool: &ConceptPool) -> bool {
 /// extras…` even if `body` is itself atomic. Used at RHS existential
 /// sites to fold in `Range(R)` constraints, so the witness of an
 /// R-existential is correctly typed.
+#[allow(clippy::too_many_arguments)]
 fn atomic_or_tseitin_body_with_extras(
     body: ConceptId,
     extras: &[ClassId],
@@ -4481,6 +4654,13 @@ fn atomic_or_tseitin_body_with_extras(
     rules: &mut ElRules,
     tseitin: &mut TseitinAllocator,
     effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    // Issue #84. `chain_ranges[(a, b)]` = the effective ranges of every `sup`
+    // with `a ∘ b ⊑ sup`; `outer_role` is the role of the edge THIS body hangs
+    // off, so a nested `∃inner.X` here can key the pair `(outer_role, inner)`
+    // and fold `Range(sup)` into `X`. `None` means "not under an edge", where no
+    // chain can apply. See [`nested_extras`].
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
+    outer_role: Option<RoleId>,
 ) -> Option<ClassId> {
     // `RUSTDL_EL_BOT_FILLER` (default ON, `=0` opts out): a filler that provably denotes `⊥`
     // lowers to the opaque, seeded-unsat bot key instead of returning `None` and
@@ -4507,6 +4687,8 @@ fn atomic_or_tseitin_body_with_extras(
             rules,
             tseitin,
             effective_ranges,
+            chain_ranges,
+            outer_role,
         )?,
         ConceptExpr::Some(role, inner_body) if !role.is_inverse() => {
             // Top-level nested existential as the outer body: `∃R.∃S.X`.
@@ -4526,11 +4708,13 @@ fn atomic_or_tseitin_body_with_extras(
             // an `And` — has always used the equivalent flavour here.
             let inner_id = atomic_or_tseitin_body_with_extras(
                 *inner_body,
-                range_extras(effective_ranges, role.role_id()),
+                &nested_extras(effective_ranges, chain_ranges, outer_role, role.role_id()),
                 pool,
                 rules,
                 tseitin,
                 effective_ranges,
+                chain_ranges,
+                Some(role.role_id()),
             )?;
             let marker =
                 tseitin.introduce_equivalent_existential_marker(role.role_id(), inner_id, rules);
@@ -4549,11 +4733,13 @@ fn atomic_or_tseitin_body_with_extras(
             // uses the equivalent flavour here.
             let inner_id = atomic_or_tseitin_body_with_extras(
                 *inner_body,
-                range_extras(effective_ranges, role.role_id()),
+                &nested_extras(effective_ranges, chain_ranges, outer_role, role.role_id()),
                 pool,
                 rules,
                 tseitin,
                 effective_ranges,
+                chain_ranges,
+                Some(role.role_id()),
             )?;
             let marker =
                 tseitin.introduce_equivalent_existential_marker(role.role_id(), inner_id, rules);
@@ -4585,6 +4771,8 @@ fn atomic_classes_with_existential_markers(
     rules: &mut ElRules,
     tseitin: &mut TseitinAllocator,
     effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
+    outer_role: Option<RoleId>,
 ) -> Option<Vec<ClassId>> {
     let mut out = Vec::with_capacity(ids.len());
     for &c in ids {
@@ -4593,11 +4781,13 @@ fn atomic_classes_with_existential_markers(
             ConceptExpr::Some(role, inner_body) if !role.is_inverse() => {
                 let inner_id = atomic_or_tseitin_body_with_extras(
                     *inner_body,
-                    range_extras(effective_ranges, role.role_id()),
+                    &nested_extras(effective_ranges, chain_ranges, outer_role, role.role_id()),
                     pool,
                     rules,
                     tseitin,
                     effective_ranges,
+                    chain_ranges,
+                    Some(role.role_id()),
                 )?;
                 let marker = tseitin.introduce_equivalent_existential_marker(
                     role.role_id(),
@@ -4609,11 +4799,13 @@ fn atomic_classes_with_existential_markers(
             ConceptExpr::Min(n, role, inner_body) if *n >= 1 && !role.is_inverse() => {
                 let inner_id = atomic_or_tseitin_body_with_extras(
                     *inner_body,
-                    range_extras(effective_ranges, role.role_id()),
+                    &nested_extras(effective_ranges, chain_ranges, outer_role, role.role_id()),
                     pool,
                     rules,
                     tseitin,
                     effective_ranges,
+                    chain_ranges,
+                    Some(role.role_id()),
                 )?;
                 let marker = tseitin.introduce_equivalent_existential_marker(
                     role.role_id(),

--- a/crates/owl-dl-verify/tests/acceptance.rs
+++ b/crates/owl-dl-verify/tests/acceptance.rs
@@ -197,6 +197,10 @@ fn instrument_never_verifies_a_classification_that_disagrees_with_the_oracle() {
         "cascade",
         "chainrange",
         "chainrange_ctl",
+        // Added when #84 made `chainrange` agree and emptied the detection set
+        // (this test fired, as designed). Its own oracle records why it is the
+        // right replacement: same family, still open, HermiT-confirmed.
+        "chaincompose",
         "unsatconj",
         "flat-mono",
         "label-closure-range-sub",
@@ -356,6 +360,8 @@ fn the_detection_set_has_not_silently_gone_vacuous() {
         "cascade",
         "chainrange",
         "chainrange_ctl",
+        // See the note on the same entry in the list above.
+        "chaincompose",
         "unsatconj",
         "flat-mono",
         "label-closure-range-sub",

--- a/crates/owl-dl-verify/tests/fixtures/chaincompose.ofn
+++ b/crates/owl-dl-verify/tests/fixtures/chaincompose.ofn
@@ -1,0 +1,12 @@
+Prefix(:=<http://ex.org/>)
+Ontology(<http://ex.org/c2>
+Declaration(Class(:A)) Declaration(Class(:F)) Declaration(Class(:G)) Declaration(Class(:C)) Declaration(Class(:D))
+Declaration(ObjectProperty(:t)) Declaration(ObjectProperty(:u)) Declaration(ObjectProperty(:v))
+Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))
+SubObjectPropertyOf(ObjectPropertyChain(:t :u) :r)
+SubObjectPropertyOf(ObjectPropertyChain(:r :v) :s)
+ObjectPropertyRange(:s :F)
+SubClassOf(:F :G)
+SubClassOf(:C ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u ObjectSomeValuesFrom(:v :A))))
+SubClassOf(ObjectSomeValuesFrom(:t ObjectSomeValuesFrom(:u ObjectSomeValuesFrom(:v :F))) :D)
+)

--- a/crates/owl-dl-verify/tests/fixtures/chaincompose.oracle
+++ b/crates/owl-dl-verify/tests/fixtures/chaincompose.oracle
@@ -1,0 +1,29 @@
+# C ⊑ D via a chain COMPOSED FROM TWO CHAINS: Chain(t,u) ⊑ r, Chain(r,v) ⊑ s,
+# Range(s,F). The t∘u∘v path is an s-edge, so its endpoint is an F, so
+# C ⊑ ∃t.∃u.∃v.F ⊑ D.
+#
+# THIS IS THE DOCUMENTED RESIDUAL OF THE #84 FIX, and it is why this fixture
+# exists. That fix keys `chain_ranges` on the pairs a chain axiom DECLARES —
+# it sees (t,u) and (r,v) — so it never forms the composed (t,u,v) ⊑ s and
+# the range never reaches the innermost witness. Closing this needs a
+# transitive closure over chain composition, which is a strictly larger
+# change than the pair-keyed fold.
+#
+# It replaces `chainrange` as the acceptance set's detection: #84 made
+# `chainrange` agree with its oracle, which emptied the detection set and
+# tripped `the_detection_set_has_not_silently_gone_vacuous` — the guard doing
+# exactly its job. rustdl currently reports only `F ⊑ G` here, with
+# `incomplete: false`, so this is a SILENT miss of the D10 shape.
+#
+# HermiT derives `C ⊑ D` (verified 2026-09-05, robot 1.9.10 + HermiT 1.4.3).
+#
+# SAME CAVEAT AS `chainrange`, stated rather than left to be discovered: this
+# crate's own `build_model` REFUSES this fixture (Err(ChainRangeOutOfProfile),
+# exit 3), so the acceptance invariant holds here trivially and this fixture
+# currently keeps the DETECTION SET non-empty without the instrument checking
+# it. That is a real limit on what it buys — it guards
+# `classification_matches_oracle` (rustdl vs the oracle), not the checker. It
+# becomes load-bearing for the checker when a Phase 2 chain/range fold lifts
+# the profile refusal.
+provenance: hermit
+subclass: C D


### PR DESCRIPTION
Closes #84.

```
Chain(t,u) ⊑ r,  Range(r,F),  C ⊑ ∃t.∃u.A,  ∃t.∃u.F ⊑ D   ⟹   C ⊑ D
```

`classify` reported only `F ⊑ G`, with **`incomplete: false`** — a *silent* miss of the D10
shape. HermiT confirms `C ⊑ D`; **Konclude misses it too**, which is why the adjudication went
to HermiT.

## The issue's prediction was half right

It said this needs "a chain-aware derivation rule, **not** an extras fold at lowering time."
It *is* a fold — but keyed on the **ordered role pair** rather than a single role.

`chain_ranges[(a,b)]` = `effective_ranges[sup]` for every declared `a ∘ b ⊑ sup`, consumed by
the new `nested_extras` at the one site where the composed edge provably exists — lowering
`∃a.∃b.X`:

```
a(x,y) ∧ b(y,z) ∧ a∘b ⊑ sup  ⟹  sup(x,z)  ⟹  z ∈ Range(sup)
```

So `∃a.∃b.X` and `∃a.∃b.(X ⊓ Range(sup))` denote the **same class** — a logical identity, hence
sound and completeness-preserving by construction, exactly as #81's `∃R.B ≡ ∃R.(B ⊓ Range(R))`.
Unflagged for that reason: a differing closure would be a bug, not a trade-off.

**The issue's soundness warning is respected precisely.** Folding into `effective_ranges[u]`
would close the same fixture and be wrong — a bare `u`-successor with no `t`-predecessor is not
a `sup`-successor. The pair key is what avoids that.

## Oracle adjudication — 6 probes, rustdl and HermiT agreeing on all

| probe | rustdl | HermiT |
|---|---|---|
| chain + range, nested | **C ⊑ D** | C ⊑ D |
| range on a **super-role** of the chain head | **C ⊑ D** | C ⊑ D |
| bare `∃u.A`, no `t` step | — | — |
| reversed nesting `∃u.∃t.A` | — | — |
| outer role `w`, not the chain head | — | — |
| no chain axiom | — | — |

## A sabotage survived, and it was the unsound variant

Worth recording. The FP guard used a **top-level** `∃u.A`, which `atomic_existential_rhs`
handles *without ever calling* `nested_extras` — so it guarded the implementation the issue
warns about and was structurally blind to an over-broad fold in the code actually written.

| # | sabotage | result |
|---|---|---|
| S1 | revert the fold | caught (2 tests) |
| S2 | fold into any pair whose second leg is `u` | **survived**, then caught by the new test |
| S3 | key the pair unordered | caught (1 test) |
| S4 | read `role_ranges` instead of `effective_ranges` | caught (1 test) |

Both guards are kept — they cover different implementations of the same mistake.

## The vacuity guard fired, and my first reading of it was wrong

`the_detection_set_has_not_silently_gone_vacuous` failed. That reads as "the fix closed every
gap in the acceptance set." A per-fixture diff against a pinned pre-fix binary showed the truth:
**exactly one of ten fixtures changed** (`chainrange`, the target). The fix is surgical, and
`chainrange` was simply the *last* remaining detection.

Replacement, per the guard's own instruction: **`chaincompose.ofn`** — `t∘u ⊑ r`, `r∘v ⊑ s`,
`Range(s,F)`, a chain composed from two chains. HermiT derives `C ⊑ D`; rustdl reports only
`F ⊑ G`, silently. **This is the documented residual of this very fix**: `chain_ranges` keys on
*declared* pairs, so it sees `(t,u)` and `(r,v)` but never forms the composed `(t,u,v) ⊑ s`.
Closing it needs a transitive closure over chain composition — strictly larger. Its oracle also
records that `build_model` still refuses the shape, so the fixture guards
`classification_matches_oracle` rather than the checker.

## Gates

- suite **1918 passed / 0 failed** (`CARGO_EXIT=0`, captured directly rather than through a pipe)
- FP=0 net **11 VERIFIED, every closure exact** — galen 28007, ore-10080 32356, sio 8904,
  ore-10908 6001, wine 653, pizza 499, ro 158, ore-15672 142, sulo 51, bibtex 16. Its exit 101 is
  the two documented absent fixtures (`alehif-test`, `notgalen`), with **zero closure mismatches**.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` exit 0
- the proof-attribution "mini" pass mirrors the new table, so a proof cannot drift from the
  lowering it explains

A two-arm ORE sweep over the **113** chain+range ontologies plus 22 non-bearing controls is
running; I will post it as a comment. That is the load-bearing gate for a saturator lowering
change, so this should not merge before it reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
