### PR TITLE
fix(protege): verify cited proof leaves against the source ontology (#56)

### DIFF
--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlOfn.java
@@ -96,12 +96,33 @@ final class RustdlOfn {
      * mirrors rather than the softer "skip just this one" alternative.
      */
     static Set<OWLAxiom> verifiedAgainst(Set<OWLAxiom> parsed, OWLOntology source) {
+        return verifiedAgainst(parsed, source, "justification");
+    }
+
+    /**
+     * {@link #verifiedAgainst(Set, OWLOntology)} with the surface named in the log line and the
+     * thrown message, so a rejection from the PROOF surface (#56) is not reported as a
+     * "justification" one.
+     *
+     * <p>The two surfaces share this one implementation deliberately: they make the same
+     * anti-fabrication promise, and a second copy of the {@code containsAxiom} check is exactly
+     * how the two would drift apart again.</p>
+     *
+     * <p><b>Only literal source axioms may be passed here.</b> Anything ENTAILED BY rather than
+     * EQUAL TO a source axiom will be rejected as fabrication — see
+     * {@code RustdlExplanationGenerator#materialize}'s laconic carve-out, which skips this guard
+     * for exactly that reason. On the proof surface the cited {@code axioms[]} resolve from
+     * {@code axiom_refs} into the converted ontology's own axiom list and are reverse-rendered by
+     * {@code owl_dl_core::axiom_to_component}, so they ARE literal; a proof's conclusions and
+     * intermediate premises are derived and must NOT be passed.</p>
+     */
+    static Set<OWLAxiom> verifiedAgainst(Set<OWLAxiom> parsed, OWLOntology source, String what) {
         for (OWLAxiom axiom : parsed) {
             if (!source.containsAxiom(axiom, Imports.INCLUDED, AxiomAnnotations.IGNORE_AXIOM_ANNOTATIONS)) {
-                LOG.warning("Rejecting rustdl justification: axiom not found in the source "
+                LOG.warning("Rejecting rustdl " + what + ": axiom not found in the source "
                     + "ontology's imports closure (possible fabrication): " + axiom);
                 throw new ExplanationException(
-                    "rustdl justification contained an axiom not present in the source ontology "
+                    "rustdl " + what + " contained an axiom not present in the source ontology "
                         + "(possible fabrication): " + axiom);
             }
         }

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProof.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProof.java
@@ -3,6 +3,7 @@ package com.github.maastrichtu_ids.rustdl.protege;
 import org.liveontologies.puli.BaseProof;
 import org.liveontologies.puli.Inference;
 import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLOntology;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,7 +52,8 @@ final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
      *     conclusion is used instead (expected — not re-checked here — to be structurally equal
      *     to {@code goal}, since it renders the same {@code SUB ⊑ SUP} the query asked about).
      */
-    static RustdlProof fromProveJson(RustdlJson.ProveJson json, OWLAxiom goal) {
+    static RustdlProof fromProveJson(
+            RustdlJson.ProveJson json, OWLAxiom goal, OWLOntology source) {
         if (json == null) {
             throw new IllegalArgumentException("rustdl prove --json returned no result");
         }
@@ -61,13 +63,19 @@ final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
                 throw new IllegalStateException(
                     "rustdl prove --json: has_proof=true but proof is null");
             }
-            proof.buildNode(json.proof);
+            proof.buildNode(json.proof, source);
         } else {
             if (json.justification_fallback == null) {
                 throw new IllegalStateException(
                     "rustdl prove --json: has_proof=false but justification_fallback is null");
             }
-            List<OWLAxiom> premises = new ArrayList<>(RustdlOfn.parse(json.justification_fallback));
+            // #56. Every axiom in `justification_fallback` IS a literal source axiom (rustdl
+            // emits a plain minimal justification here, never a laconic-weakened one — that is
+            // a separate `justify --laconic` surface), so the whole set is verified wholesale,
+            // exactly as `RustdlExplanationGenerator#materialize` does on its own non-laconic
+            // path. Fail-hard: a fabricated axiom rejects the proof rather than being displayed.
+            List<OWLAxiom> premises = new ArrayList<>(RustdlOfn.verifiedAgainst(
+                RustdlOfn.parse(json.justification_fallback), source, "proof justification"));
             proof.produce(new SimpleInference("justification", goal, premises));
         }
         return proof;
@@ -79,7 +87,7 @@ final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
      * so the caller (a parent {@code buildNode} call, or {@link #fromProveJson}) can use it as one
      * of ITS premises.
      */
-    private OWLAxiom buildNode(RustdlJson.ProofNodeJson node) {
+    private OWLAxiom buildNode(RustdlJson.ProofNodeJson node, OWLOntology source) {
         // No conclusion de-dup guard needed here today: rustdl's `ProofNodeJson` tree is an OWNED
         // tree (each premise belongs to exactly one parent), not a shared DAG, so a shared
         // sub-conclusion is simply rebuilt (and re-produce()d, harmlessly, into this Proof) once
@@ -93,6 +101,12 @@ final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
         if (node.axioms != null) {
             for (String axiomDoc : node.axioms) {
                 OWLAxiom axiom = RustdlOfn.singleLogicalAxiom(axiomDoc);
+                // #56. THE CITED LEAVES ARE THE ONLY PART OF A PROOF NODE THAT IS A SOURCE
+                // AXIOM, and so the only part this guard may be applied to. `node.conclusion`
+                // and the child `node.premises` are DERIVED facts — running `containsAxiom` on
+                // them would (correctly) fail and reject every proof, which is why this is not
+                // a blind copy of the justify guard.
+                RustdlOfn.verifiedAgainst(Collections.singleton(axiom), source, "proof");
                 premises.add(axiom);
                 if (assertedRegistered.add(axiom)) {
                     produce(new SimpleInference("asserted", axiom, Collections.emptyList()));
@@ -101,7 +115,7 @@ final class RustdlProof extends BaseProof<Inference<OWLAxiom>> {
         }
         if (node.premises != null) {
             for (RustdlJson.ProofNodeJson child : node.premises) {
-                premises.add(buildNode(child));
+                premises.add(buildNode(child, source));
             }
         }
 

--- a/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofService.java
+++ b/protege/src/main/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofService.java
@@ -129,7 +129,7 @@ public final class RustdlProofService extends ProofService {
                     // disagree, failing loudly here is safer than fabricating an empty proof.
                     throw new UnsupportedEntailmentTypeException(entailment);
                 }
-                return RustdlProof.fromProveJson(json, entailment);
+                return RustdlProof.fromProveJson(json, entailment, ontology);
             } catch (IOException error) {
                 throw new IllegalStateException(
                     "rustdl prove --json failed: " + error.getMessage(), error);

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofTest.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlProofTest.java
@@ -7,7 +7,10 @@ import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owl.explanation.api.ExplanationException;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -15,6 +18,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * {@link RustdlProof} converts a canned {@code prove --json} result (the fixtures under
@@ -29,6 +33,29 @@ public class RustdlProofTest {
         return DF.getOWLClass(IRI.create("http://ex/#" + localName));
     }
 
+    /**
+     * A source ontology containing exactly the axioms the JSON fixtures cite as leaves.
+     *
+     * #56: `fromProveJson` now verifies every CITED LEAF axiom against the source, so a test
+     * that passed an empty ontology would make every one of these tests fail — the source is
+     * part of the fixture now, not incidental setup.
+     */
+    private static OWLOntology sourceWith(OWLAxiom... axioms) throws Exception {
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+        OWLOntology ontology = manager.createOntology();
+        for (OWLAxiom axiom : axioms) {
+            manager.addAxiom(ontology, axiom);
+        }
+        return ontology;
+    }
+
+    /** The two told axioms `prove.json` cites. */
+    private static OWLOntology proveJsonSource() throws Exception {
+        return sourceWith(
+            DF.getOWLSubClassOfAxiom(cls("A"), cls("B")),
+            DF.getOWLSubClassOfAxiom(cls("B"), cls("C")));
+    }
+
     private String fixture(String name) throws Exception {
         return new String(Files.readAllBytes(
             Paths.get(getClass().getResource("/json/" + name).toURI())));
@@ -39,7 +66,7 @@ public class RustdlProofTest {
         RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
         OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
 
-        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal, proveJsonSource());
 
         Collection<? extends Inference<OWLAxiom>> rootInferences = proof.getInferences(goal);
         assertEquals(1, rootInferences.size());
@@ -60,7 +87,7 @@ public class RustdlProofTest {
     public void nestedPremiseInferenceIsReachableAndCitesItsAxiom() throws Exception {
         RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
         OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
-        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal, proveJsonSource());
 
         OWLSubClassOfAxiom ab = DF.getOWLSubClassOfAxiom(cls("A"), cls("B"));
         Collection<? extends Inference<OWLAxiom>> abInferences = proof.getInferences(ab);
@@ -96,7 +123,9 @@ public class RustdlProofTest {
         RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove_fallback.json"));
         OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("Sub"), cls("Sup"));
 
-        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal, sourceWith(
+            DF.getOWLSubClassOfAxiom(cls("X"), cls("Y")),
+            DF.getOWLSubClassOfAxiom(cls("Y"), cls("Z"))));
 
         Collection<? extends Inference<OWLAxiom>> inferences = proof.getInferences(goal);
         assertEquals(1, inferences.size());
@@ -111,11 +140,83 @@ public class RustdlProofTest {
         assertTrue(inference.getPremises().contains(yz));
     }
 
+    /**
+     * #56 — a genuine proof survives verification unchanged.
+     *
+     * The companion to {@link #aFabricatedLeafAxiomIsRejected}: without this one, "the guard
+     * catches fabrication" would be satisfied by a guard that rejects EVERYTHING. Both cited
+     * leaves here are real source axioms, so all four inferences must still be produced.
+     */
+    @Test
+    public void aGenuineProofSurvivesLeafVerification() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal, proveJsonSource());
+
+        assertEquals(1, proof.getInferences(goal).size());
+        // Both told leaves survive, each carrying its own "asserted" inference.
+        assertEquals(2, proof.getInferences(DF.getOWLSubClassOfAxiom(cls("A"), cls("B"))).size());
+        assertEquals(2, proof.getInferences(DF.getOWLSubClassOfAxiom(cls("B"), cls("C"))).size());
+    }
+
+    /**
+     * #56 — THE ANTI-FABRICATION TEST. A cited leaf axiom absent from the source must reject the
+     * whole proof rather than being displayed as the justification for a step.
+     *
+     * The source here deliberately OMITS `SubClassOf(:B :C)` while `prove.json` cites it, which
+     * is exactly the shape a future OFN writer/parser normalization mismatch would produce: a
+     * leaf that looks well-formed and is not what the ontology asserts. Before this guard the
+     * proof view rendered it verbatim.
+     *
+     * Fail-hard, matching the justify surface — a partial proof with the offending leaf dropped
+     * would still be displayed as an explanation while no longer establishing its conclusion.
+     */
+    @Test
+    public void aFabricatedLeafAxiomIsRejected() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
+        OWLOntology missingOneLeaf = sourceWith(DF.getOWLSubClassOfAxiom(cls("A"), cls("B")));
+
+        try {
+            RustdlProof.fromProveJson(json, goal, missingOneLeaf);
+            fail("a cited leaf axiom absent from the source must be rejected as a possible "
+                + "fabrication, not rendered into the proof");
+        } catch (ExplanationException expected) {
+            assertTrue(
+                "the message must name the offending axiom and the surface: "
+                    + expected.getMessage(),
+                expected.getMessage().contains("proof")
+                    && expected.getMessage().contains("not present in the source ontology"));
+        }
+    }
+
+    /**
+     * #56 — the `justification_fallback` branch is guarded too.
+     *
+     * Every axiom on that path IS a literal source axiom (rustdl emits a plain minimal
+     * justification there, never a laconic-weakened one), so it is verified wholesale. Missed by
+     * a fix that only walked the proof tree.
+     */
+    @Test
+    public void aFabricatedFallbackAxiomIsRejected() throws Exception {
+        RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove_fallback.json"));
+        OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("Sub"), cls("Sup"));
+        OWLOntology missingOne = sourceWith(DF.getOWLSubClassOfAxiom(cls("X"), cls("Y")));
+
+        try {
+            RustdlProof.fromProveJson(json, goal, missingOne);
+            fail("a fabricated justification_fallback axiom must be rejected too");
+        } catch (ExplanationException expected) {
+            assertTrue(expected.getMessage().contains("not present in the source ontology"));
+        }
+    }
+
     @Test
     public void unreachableConclusionHasNoInferences() throws Exception {
         RustdlJson.ProveJson json = RustdlProcess.parseProve(fixture("prove.json"));
         OWLSubClassOfAxiom goal = DF.getOWLSubClassOfAxiom(cls("A"), cls("C"));
-        RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+        RustdlProof proof = RustdlProof.fromProveJson(json, goal, proveJsonSource());
 
         OWLSubClassOfAxiom unrelated = DF.getOWLSubClassOfAxiom(cls("Unrelated1"), cls("Unrelated2"));
         assertTrue(proof.getInferences(unrelated).isEmpty());

--- a/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlSmokeIT.java
+++ b/protege/src/test/java/com/github/maastrichtu_ids/rustdl/protege/RustdlSmokeIT.java
@@ -335,7 +335,12 @@ public class RustdlSmokeIT {
                 json.has_proof);
 
             OWLSubClassOfAxiom goal = df.getOWLSubClassOfAxiom(a, c);
-            RustdlProof proof = RustdlProof.fromProveJson(json, goal);
+            // #56: passing the REAL source ontology makes this the end-to-end round-trip
+            // check — the cited leaf axioms come back from the actual rustdl binary through the
+            // OFN writer and the Java parser, and must literally match what `o` contains. If
+            // the round-trip ever normalizes an axiom, this test fails rather than the proof
+            // view silently displaying something the source does not assert.
+            RustdlProof proof = RustdlProof.fromProveJson(json, goal, o);
 
             Collection<? extends Inference<OWLAxiom>> rootInferences = proof.getInferences(goal);
             assertFalse("proof must contain an inference for the root goal conclusion",


### PR DESCRIPTION
Closes #56.

The justification surface verified every axiom it displayed against the source (fail-hard
`containsAxiom`). The proof surface verified **nothing** — `RustdlProof.buildNode` parsed the
tree from `prove --json` and handed the cited axioms straight to the proof view. Two surfaces
making the same anti-fabrication promise, one of them unguarded.

## Why this is not a blind copy of the justify guard

A proof node holds three kinds of content, and only one is a source axiom:

| content | verifiable? |
|---|---|
| `conclusion` | **no** — derived |
| intermediate `premises` | **no** — derived |
| cited `axioms[]` | **yes** — the only part |

A naïve "verify everything" rejects **every** proof. That isn't hypothetical: sabotage S3 below
adds conclusion verification and 4 of 7 tests error out — which *empirically confirms* the
issue's central design constraint rather than restating it.

## What is verified, and why literal verification is safe here

Checked on the Rust side rather than inherited from the issue text:

- `axioms[]` resolves `node.axiom_refs` into `internal.axioms` and reverse-renders via
  `owl_dl_core::axiom_to_component` — **literal source axioms**.
- `justification_fallback` is a **plain** minimal justification, never a laconic one
  (`justify --laconic` is a separate surface), so it is verified wholesale. **A fix that only
  walked the proof tree would have missed this branch**; `aFabricatedFallbackAxiomIsRejected`
  covers it.

That distinction is load-bearing: `RustdlExplanationGenerator#materialize` deliberately *skips*
the guard for laconic justifications, because a weakened fragment is entailed-by rather than
equal-to a source axiom and literal verification would reject every one. Neither proof path
emits such a fragment.

Both surfaces now share **one** implementation — a second copy of `containsAxiom` is exactly how
they would drift apart again. `verifiedAgainst` gains a surface label so a proof rejection isn't
reported as a "justification" one; the 2-arg form delegates, so the justify path is
behaviour-identical.

**Failure mode: fail-hard**, matching justify. A partial proof with the offending leaf silently
dropped would still be displayed as an explanation while no longer establishing its conclusion.

## Sabotage: 3 run, 3 caught, each by exactly the right test

| # | sabotage | result |
|---|---|---|
| S1 | remove leaf verification | `aFabricatedLeafAxiomIsRejected` fails — and only it |
| S2 | remove fallback verification | `aFabricatedFallbackAxiomIsRejected` fails — and only it |
| S3 | also verify the conclusion | **4 of 7 error** — every proof rejected, confirming the constraint |

The positive test (`aGenuineProofSurvivesLeafVerification`) exists so that "the guard catches
fabrication" cannot be satisfied by a guard that rejects everything.

## End-to-end round-trip is now enforced, not assumed

`RustdlSmokeIT` passes the **real** source ontology on the real-binary path. So the Rust
writer → Java parser round-trip is checked end to end: if it ever normalizes an axiom, that test
fails, instead of the proof view displaying something the ontology does not assert. That is
precisely the empirical claim the issue's "round-trip verified faithful" note rested on.

## Gates

- `mvn clean package -Dtest='*Test,*IT'` green — **119 tests, 0 failures**, `MVN_EXIT=0`
- Java-only: no Rust crate is touched, so the FP=0 net and `classify` are structurally unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
