### PR TITLE
fix(convert): interval sets close the `DataUnionOf` of integer INTERVALS gap (#42 item 1 residual)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1588,13 +1588,99 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
     is byte-identical across arms with all 14 drops unchanged. Evidence is 7 canaries
     (3 bug + 4 controls, two oracle-adjudicated) plus Konclude on every probe.
     Canaries `crates/owl-dl-reasoner/tests/data_union_of_enumerations.rs`.
-  - **STILL DROPPED (sound), recorded rather than implied:** a union of INTERVALS
-    (`[0,5] ⊔ [10,15]`) — **Konclude derives unsat there and rustdl does not**, a
-    known MISS pinned by a canary to FLIP when an interval-set representation lands,
-    never to delete; MIXED enumeration/interval unions; unions of bare DATATYPES;
-    `DataIntersectionOf` in these positions; and qualified data CARDINALITY over a
-    union (`≥3 p.({1} ⊔ {2})`), which takes a different path and which Konclude also
-    does not call unsat.
+  - **`DataUnionOf` of `xsd:integer` INTERVALS in a `∀`/range position — CLOSED
+    2026-09-05 (#42 item 1 residual).** The enumeration half above flattens because
+    `DataOneOf(a) ⊔ DataOneOf(b)` IS `DataOneOf(a,b)`; a union of intervals has no such
+    single-range form, the integer `DKey` bucket held ONE `IntegerRange` per key, so the
+    parser chain matched nothing and the whole axiom DROPPED. `∃p.{7} ⊓ ∀p.([0,5] ⊔
+    [10,15])` came back satisfiable where Konclude derives it unsatisfiable — a SILENT
+    miss (`dropped` was empty), which is why the canary written for it pinned a gap
+    rather than a verdict.
+    The bucket now holds an `IntSet`, a union of ranges. **The non-regression argument is
+    structural, in two halves, and both are worth keeping:** every op is a QUANTIFIED
+    LIFT of the scalar `IntegerRange` op (`contains` = `∃`, `disjoint` = `∀∀`, `subset` =
+    `∀∃`), so a one-component set returns exactly the old answer — including the empty
+    range, whose conservative `disjoint` is deliberately NOT "corrected", since set
+    semantics would say `∅` is disjoint from everything and that is a change in the FP
+    direction; and a one-component set ENCODES to the historical UNTAGGED IRI,
+    byte-identical, so every pre-existing key still interns to the same `ClassId` and
+    only genuinely multi-interval keys use the new `iset:` tag. `ore_ont_9347` reads 113
+    at both, the recorded DKey discriminator unmoved.
+    `contains` and `disjoint` are EXACT (`A ∩ B = ⋃ᵢⱼ aᵢ∩bⱼ`), which they must be —
+    they drive clashes, so the direction of risk is a false POSITIVE. `subset` is the
+    `∀∃` lift, sound in the MISS direction always.
+    **INTEGER DISCRETENESS IS LOAD-BEARING AND DOES NOT TRANSFER.** Normalisation merges
+    components that merely TOUCH (`[0,5] ⊔ [6,10] → [0,10]`), valid only because the
+    integers have a successor; the result is that components are separated by at least
+    one absent integer, so `subset` is exact on normalised operands too. `xsd:float` /
+    `decimal` / `date` / `dateTime` have NO successor: they can merge only OVERLAPPING
+    components and their `subset` stays genuinely conservative. **The five remaining
+    datatypes are a separate piece of reasoning, not a mechanical follow-on** — and each
+    is a new `iset`-style tag in a 15-bucket exclusivity matrix, in the subsystem that
+    has already shipped an FP for months.
+    **MIXED enumeration/interval unions come free and are now EXACT, not dropped**: on a
+    discrete space `{v}` IS `[v,v]`, so `{1} ⊔ [10,15]` is an interval set like any
+    other. That is what makes the ALL-OR-NOTHING rule affordable rather than restrictive
+    — and all-or-nothing is still load-bearing, because keeping the representable half of
+    an unrepresentable union yields a strictly NARROWER range, which in a `∀` position
+    manufactures a clash.
+    **TWO TESTS WERE PINNING THE DEFECT, and only one of them was labelled.** The scope
+    guard `a_union_of_intervals_stays_a_sound_drop_and_is_a_known_miss` said so and was
+    flipped as instructed. `datatype_value_membership.rs`'s
+    `data_union_forall_union_dropped` did NOT: it asserted `C` satisfiable ON THE GROUNDS
+    THAT THE UNION DROPS, while Konclude had always called `C` unsatisfiable — the
+    satisfiable verdict was the miss, not the answer. **It surfaced during SABOTAGE
+    testing of the fix, not from the fix's own suite**, which is the argument for running
+    sabotages against neighbouring files and not only the ones you wrote. Flipped, not
+    deleted. See [[tests-that-pin-the-bug]].
+    **EVIDENCE, and the corpus is again not part of it.** Exactly ONE of 1,920 ORE
+    ontologies authors a `DataUnionOf` at all (`ore_ont_5964`, a grep SUPERSET), and its
+    only union is `DataUnionOf(xsd:decimal xsd:float xsd:integer xsd:long)` — bare
+    DATATYPES, which the collector correctly declines, leaving all 14 of its drops
+    unchanged. So corpus reach is provably ZERO and the FP=0 net shows inertness only.
+    The evidence is 8 canaries + 9 unit tests, plus a **Konclude adjudication on 12
+    probes agreeing 12/12** — gap interiors (`6`, `9`), inclusive boundaries (`5`, `10`),
+    adjacency, unbounded ends, and both mixed-union directions — all on real output
+    (1105 sat / 1121 unsat bytes, not the ~896-byte stub). Konclude REPORTS the relation
+    on 5 of the 12, so its silence on the other 7 is a discriminating control rather than
+    the under-reporting it is documented to do elsewhere.
+    **SABOTAGE: 7 run, 7 caught.** Reverting the arm (7 canaries); loosening
+    all-or-nothing (3, incl. two pre-existing); merging across gaps (12); relaxing
+    `subset`'s outer `∀` to `∃`; relaxing `disjoint`'s; dropping the singleton
+    byte-identity short-circuit; and reordering the arm ahead of the enumeration
+    flattener. **Two honest limits, recorded rather than rounded up.** (1) The `disjoint`
+    relaxation is caught by the UNIT test ONLY — every integration canary has a SINGLETON
+    on the `self` side, where the outer `any` and `all` coincide, so the integration
+    surface cannot see it. (2) **The first version of the `subset` canary was VACUOUS and
+    sabotage found it**: in an EXISTENTIAL position a `DataUnionOf` never becomes an
+    interval-set key at all — it is split into a class-level disjunction before
+    `data_range_dkey` is reached — so `∃p.[0,5] ⊑ ∃p.([0,5] ⊔ [10,15])` holds by
+    disjunction introduction and passed with the entire fix reverted. The `∀` position is
+    where the seeded `DKey ⊑ DKey` edge is actually consulted.
+    **PERF: +2.8% on the worst case, and THE FRAME THAT LOOKED RIGHT WAS INERT.** This
+    widens the element of `seed_bucket`'s O(k²) ordered-pair walk, so it needs measuring —
+    but the DKey-heavy ontologies this file names by pair volume (`1833`, `5368`, `2504`,
+    `4141`) are all STRING buckets carrying near-zero integer literals, so the change is
+    provably inert on every one (0.90–0.99×, content identical, `9347` negative control
+    unmoved at 194 vs 199 ms). **Selecting on them would have been the documented
+    "`ore_ont_9347` cannot discriminate" trap, one datatype over.** The discriminator is
+    **`ore_ont_15635`** — 58,794 `xsd:integer` literals, k = 7,281 distinct keys giving
+    5.3 × 10⁷ pairs, the largest integer bucket in ORE (next are `20` and `5753` at
+    k ≈ 1,650, then a cliff). Min-of-5, interleaved with alternating arm order:
+    **3341 → 3434 ms, +2.8%**, content identical. **`SmallVec<[IntegerRange; 1]>` was
+    tried and recovers 0%** (3437 ms), which REFUTES the allocation hypothesis and is why
+    the field is a plain `Vec` — shipping the inline version would have meant a doc
+    comment claiming a benefit the measurement had just contradicted. The residual ~93 ms
+    is most likely the bucket element growing and costing cache in the k² scan; if it ever
+    needs to be cheap, shrink the ELEMENT or index the loop.
+    Canaries `crates/owl-dl-reasoner/tests/data_union_of_intervals.rs`.
+  - **STILL DROPPED (sound), recorded rather than implied:** unions with any member no
+    integer interval set can express — bare DATATYPES (`xsd:decimal`), `DataComplementOf`,
+    other-datatype enumerations — which drop WHOLE and VISIBLY (`dropped` is non-empty),
+    never narrowed; interval unions over the five DENSE datatypes (see the discreteness
+    note above); `DataIntersectionOf` in these positions; and qualified data CARDINALITY
+    over a union (`≥3 p.({1} ⊔ {2})`), which takes a different path and which Konclude
+    also does not call unsat.
 
   Synthetic test harness: `crates/owl-dl-reasoner/tests/datatype_completeness.rs`
   (6 fixtures under `tests/fixtures/datatype/`; all 6 pass post-D5).

--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use crate::ConceptPool;
 use crate::Vocabulary;
 use crate::data_axioms::{
-    DataIntersectionDkey, DateKey, DateTimeKey, Decimal, FloatRange, IntegerRange, LangSet,
+    DataIntersectionDkey, DateKey, DateTimeKey, Decimal, FloatRange, IntSet, IntegerRange, LangSet,
     OrdRange, RangeBucket, StrSet, exact_lang_literal, exact_string_literal,
     parse_data_intersection_dkey, parse_date, parse_datetime, parse_decimal,
 };
@@ -73,6 +73,81 @@ fn dkey_iri(range: IntegerRange) -> String {
         b.map_or_else(|| "*".to_string(), |v| v.to_string())
     }
     format!("{DKEY_IRI_PREFIX}{}:{}", bound(range.min), bound(range.max))
+}
+
+/// Datatype tag for the `xsd:integer` INTERVAL-SET `DKey` namespace (#42 item 1).
+/// Full prefix is `urn:rustdl-dkey:iset:`, components `;`-separated
+/// (`urn:rustdl-dkey:iset:0:5;10:15`).
+///
+/// Namespace-safe against every existing decoder, and the integer one is the case
+/// worth stating: the untagged integer form splits on the FIRST `:` and parses both
+/// halves as `i64`, so `iset:0:5;10:15` yields the token `"iset"`, which fails that
+/// parse. Every other decoder uses `strip_prefix(tag)`, and `iset:` neither prefixes
+/// nor is prefixed by `f:`, `db:`, `dec:`, `date:`, `dt:`, `str:`, `lang:`, `io:`,
+/// `fo:`, `dbo:`, `deo:`, `dao:` or `dto:`. Both parser matrices pin this.
+const DKEY_INT_SET_TAG: &str = "iset:";
+
+/// Build the deterministic `xsd:integer` interval-set `DKey` IRI.
+///
+/// **A ONE-COMPONENT SET ENCODES TO THE HISTORICAL UNTAGGED IRI, BYTE-IDENTICAL.**
+/// That is the other half of the non-regression argument in [`IntSet`]'s docs: every
+/// key the pre-#42 engine could produce still interns to the same `ClassId`, so only
+/// genuinely multi-interval keys use the new form and the existing bucket is provably
+/// unmoved. It also keeps the encoding canonical — one set, one spelling, one class.
+fn int_set_dkey_iri(set: &IntSet) -> String {
+    let ranges = set.ranges();
+    if let [single] = ranges {
+        return dkey_iri(*single);
+    }
+    fn bound(b: Option<i64>) -> String {
+        b.map_or_else(|| "*".to_string(), |v| v.to_string())
+    }
+    let body = ranges
+        .iter()
+        .map(|r| format!("{}:{}", bound(r.min), bound(r.max)))
+        .collect::<Vec<_>>()
+        .join(";");
+    format!("{DKEY_IRI_PREFIX}{DKEY_INT_SET_TAG}{body}")
+}
+
+/// Parse any `xsd:integer` `DKey` IRI — untagged single interval OR `iset:`-tagged
+/// multi-interval — back into an [`IntSet`]. This is the bucket collector for
+/// `seed_dkey_subsumptions`, so it must accept BOTH forms: the untagged one carries
+/// every key written before #42 item 1.
+///
+/// The untagged case goes through [`IntSet::single`], which does not normalise. That is
+/// deliberate — see [`IntSet::single`]; normalising here would silently change the
+/// empty-range corner of a bucket this change is supposed to leave alone.
+///
+/// A tagged IRI with fewer than two components is REJECTED: the encoder never emits
+/// one (a single interval takes the untagged form), so accepting it would admit a
+/// second spelling of a set that already has a canonical `ClassId`.
+fn parse_int_set_dkey_iri(iri: &str) -> Option<IntSet> {
+    let Some(rest) = iri
+        .strip_prefix(DKEY_IRI_PREFIX)
+        .and_then(|r| r.strip_prefix(DKEY_INT_SET_TAG))
+    else {
+        return parse_dkey_iri(iri).map(IntSet::single);
+    };
+    fn bound(s: &str) -> Result<Option<i64>, ()> {
+        if s == "*" {
+            Ok(None)
+        } else {
+            s.parse::<i64>().map(Some).map_err(|_| ())
+        }
+    }
+    let mut ranges = Vec::new();
+    for comp in rest.split(';') {
+        let (min_s, max_s) = comp.split_once(':')?;
+        ranges.push(IntegerRange {
+            min: bound(min_s).ok()?,
+            max: bound(max_s).ok()?,
+        });
+    }
+    if ranges.len() < 2 {
+        return None;
+    }
+    IntSet::normalized(ranges)
 }
 
 /// Internal helper: build a float-family `DKey` IRI with the given `tag`.
@@ -839,6 +914,16 @@ fn data_range_dkey<A: ForIRI>(
     // most once.
     if let Some(flat) = flatten_union_of_oneofs(dr) {
         return data_range_dkey(&flat, dp_iri, vocab, pool);
+    }
+    // A union of xsd:integer INTERVALS (and/or integer enumerations) is one interval
+    // SET (#42 item 1 residual). MUST stay after the enumeration flattener: an
+    // all-enumeration union belongs in the `io:` bucket, whose `BTreeSet::is_subset`
+    // is exact, not here, where subsumption degrades to the `∀∃` lift. Only matches a
+    // `DataUnionOf`, so it cannot shadow the scalar `parse_integer_range` arm below.
+    if let Some(set) = crate::data_axioms::parse_integer_interval_set(dr) {
+        let role = Role::named(vocab.intern_role(dp_iri));
+        let dkey_class = vocab.intern_class(&int_set_dkey_iri(&set));
+        return Some((role, pool.atomic(dkey_class)));
     }
     let iri = if let Some(r) = crate::data_axioms::parse_integer_range(dr) {
         dkey_iri(r)
@@ -3012,10 +3097,16 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
     // The decoders are pairwise mutually exclusive on IRIs (the
     // `parser_matrix_*` canaries pin this), so a given `DKey` IRI lands in
     // exactly one bucket.
-    let int_dkeys: Vec<(ClassId, IntegerRange)> = out
+    // The integer bucket holds INTERVAL SETS (#42 item 1): `parse_int_set_dkey_iri`
+    // accepts the historical untagged single-interval IRI as a one-component set and
+    // the `iset:`-tagged form as many. Every op below is a quantified lift of the
+    // `IntegerRange` op it replaced, so the one-component keys — which is all of them
+    // on any ontology without a `DataUnionOf` of integer ranges — behave exactly as
+    // before by construction.
+    let int_dkeys: Vec<(ClassId, IntSet)> = out
         .vocabulary
         .classes()
-        .filter_map(|(cid, iri)| parse_dkey_iri(iri).map(|r| (cid, r)))
+        .filter_map(|(cid, iri)| parse_int_set_dkey_iri(iri).map(|r| (cid, r)))
         .collect();
     // xsd:float (f:) and xsd:double (db:) are SEPARATE buckets — they have
     // disjoint OWL value spaces (float is f32, double is f64); cross-bucket
@@ -3098,7 +3189,7 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
     // `DKey(r1) ⊑ DKey(r2)` iff `r1 ⊆ r2` (distinct keys ⟹ strict subset,
     // since equal ranges share one ClassId). Integer/float ranges are
     // `Copy`; the ordered ranges compare by reference.
-    seed_bucket(out, &int_dkeys, |a, b| a.subset(*b));
+    seed_bucket(out, &int_dkeys, IntSet::subset);
     seed_bucket(out, &float_dkeys, |a, b| a.subset(*b));
     seed_bucket(out, &double_dkeys, |a, b| a.subset(*b));
     seed_bucket(out, &dec_dkeys, OrdRange::subset);
@@ -3166,7 +3257,7 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
     // one O(k²) component). `=0` restores the unconditional all-pairs path.
     // Spec: docs/superpowers/specs/2026-07-20-dkey-disjointness-bounded-seeding-spec.md
     let comp = bounded_components.as_ref();
-    seed_disjoint_bucket(out, &int_dkeys, |a, b| a.disjoint(*b), comp);
+    seed_disjoint_bucket(out, &int_dkeys, IntSet::disjoint, comp);
     seed_disjoint_bucket(out, &float_dkeys, |a, b| a.disjoint(*b), comp);
     seed_disjoint_bucket(out, &double_dkeys, |a, b| a.disjoint(*b), comp);
     seed_disjoint_bucket(out, &dec_dkeys, OrdRange::disjoint, comp);
@@ -3272,7 +3363,7 @@ fn seed_dkey_subsumptions(out: &mut InternalOntology) {
         out,
         &int_dkeys,
         &int_oneof_dkeys,
-        |r: &IntegerRange, v: &i64| r.contains(*v),
+        |r: &IntSet, v: &i64| r.contains(*v),
         comp,
     );
     seed_range_oneof_disjoint(
@@ -5484,7 +5575,27 @@ mod tests {
                     .collect(),
                 )),
             ),
+            // #42 item 1: the `iset:` multi-interval form. Two components, so it
+            // cannot degenerate to the untagged encoding.
+            ("iset", int_set_dkey_iri(&sample_int_set())),
         ]
+    }
+
+    /// The interval set `[0,5] ⊔ [10,15]` used by both parser matrices.
+    fn sample_int_set() -> IntSet {
+        let Some(set) = IntSet::normalized(vec![
+            IntegerRange {
+                min: Some(0),
+                max: Some(5),
+            },
+            IntegerRange {
+                min: Some(10),
+                max: Some(15),
+            },
+        ]) else {
+            panic!("two non-empty components normalize to a non-empty set")
+        };
+        set
     }
 
     /// THE matrix: each decoder must return `Some` for EXACTLY its own
@@ -5505,17 +5616,25 @@ mod tests {
                 "dt" => parse_datetime_dkey_iri(iri).is_some(),
                 "str" => parse_string_dkey_iri(iri).is_some(),
                 "lang" => parse_lang_dkey_iri(iri).is_some(),
+                "iset" => parse_int_set_dkey_iri(iri).is_some(),
                 _ => unreachable!(),
             }
         };
         for (decoder, _) in &iris {
             for (bucket, iri) in &iris {
                 let accepted = probe(decoder, iri);
+                // ONE deliberate off-diagonal cell, and only one: `iset` is a
+                // SUPERSET of `int` BY DESIGN — the interval-set decoder must accept
+                // the untagged single-interval IRI, because that is how every key
+                // written before #42 item 1 still reaches the integer bucket (as a
+                // one-component set, whose ops are exact lifts of the scalar ones).
+                // The REVERSE cell stays strict and is the FP-critical one: `int`
+                // accepting an `iset:` IRI would decode a multi-interval key as a
+                // truncated single range and seed edges with the wrong semantics.
+                let expected = decoder == bucket || (*decoder == "iset" && *bucket == "int");
                 assert_eq!(
-                    accepted,
-                    decoder == bucket,
-                    "decoder {decoder} on {bucket} IRI {iri:?}: expected {}",
-                    decoder == bucket
+                    accepted, expected,
+                    "decoder {decoder} on {bucket} IRI {iri:?}: expected {expected}"
                 );
             }
         }
@@ -5598,20 +5717,158 @@ mod tests {
                 "deo" => parse_decimal_oneof_iri(iri).is_some(),
                 "dao" => parse_date_oneof_iri(iri).is_some(),
                 "dto" => parse_datetime_oneof_iri(iri).is_some(),
+                "iset" => parse_int_set_dkey_iri(iri).is_some(),
                 _ => unreachable!(),
             }
         };
         for (decoder, _) in &all {
             for (bucket, iri) in &all {
                 let accepted = probe(decoder, iri);
+                // ONE deliberate off-diagonal cell, and only one: `iset` is a
+                // SUPERSET of `int` BY DESIGN — the interval-set decoder must accept
+                // the untagged single-interval IRI, because that is how every key
+                // written before #42 item 1 still reaches the integer bucket (as a
+                // one-component set, whose ops are exact lifts of the scalar ones).
+                // The REVERSE cell stays strict and is the FP-critical one: `int`
+                // accepting an `iset:` IRI would decode a multi-interval key as a
+                // truncated single range and seed edges with the wrong semantics.
+                let expected = decoder == bucket || (*decoder == "iset" && *bucket == "int");
                 assert_eq!(
-                    accepted,
-                    decoder == bucket,
-                    "decoder {decoder} on {bucket} IRI {iri:?}: expected {}",
-                    decoder == bucket
+                    accepted, expected,
+                    "decoder {decoder} on {bucket} IRI {iri:?}: expected {expected}"
                 );
             }
         }
+    }
+
+    /// A ONE-COMPONENT interval set keys to the HISTORICAL UNTAGGED IRI, byte-identical.
+    ///
+    /// This is half the non-regression argument for #42 item 1's residual (the other
+    /// half is that every `IntSet` op is a quantified lift of the scalar op): every key
+    /// any pre-change ontology could produce still interns to the same `ClassId`, so the
+    /// integer bucket is provably unmoved and only genuinely multi-interval keys use the
+    /// new form. Break this and the bucket silently splits in two.
+    #[test]
+    fn a_one_component_interval_set_keys_identically_to_a_bare_range() {
+        for r in [
+            IntegerRange {
+                min: Some(0),
+                max: Some(10),
+            },
+            IntegerRange {
+                min: None,
+                max: Some(5),
+            },
+            IntegerRange::unbounded(),
+            // The empty range, which `IntSet::single` deliberately does not normalise
+            // away — see its docs.
+            IntegerRange {
+                min: Some(5),
+                max: Some(0),
+            },
+        ] {
+            assert_eq!(int_set_dkey_iri(&IntSet::single(r)), dkey_iri(r));
+        }
+    }
+
+    /// The `iset:` form round-trips, uses the documented spelling, and normalises: the
+    /// components come back sorted, merged across a touching seam, and with unbounded
+    /// ends preserved.
+    #[test]
+    fn interval_set_iri_round_trips_and_canonicalises() {
+        let two = sample_int_set();
+        assert_eq!(int_set_dkey_iri(&two), "urn:rustdl-dkey:iset:0:5;10:15");
+        assert_eq!(parse_int_set_dkey_iri(&int_set_dkey_iri(&two)), Some(two));
+
+        // Unbounded ends on both sides.
+        let Some(unb) = IntSet::normalized(vec![
+            IntegerRange {
+                min: None,
+                max: Some(5),
+            },
+            IntegerRange {
+                min: Some(10),
+                max: None,
+            },
+        ]) else {
+            panic!("two non-empty components normalize");
+        };
+        assert_eq!(int_set_dkey_iri(&unb), "urn:rustdl-dkey:iset:*:5;10:*");
+        assert_eq!(parse_int_set_dkey_iri(&int_set_dkey_iri(&unb)), Some(unb));
+
+        // Out-of-order, touching components collapse to ONE — so the canonical
+        // encoding is the untagged single-interval form, not a two-component `iset:`.
+        let Some(merged) = IntSet::normalized(vec![
+            IntegerRange {
+                min: Some(6),
+                max: Some(10),
+            },
+            IntegerRange {
+                min: Some(0),
+                max: Some(5),
+            },
+        ]) else {
+            panic!("two non-empty components normalize");
+        };
+        assert_eq!(int_set_dkey_iri(&merged), "urn:rustdl-dkey:0:10");
+    }
+
+    /// A one-component `iset:` IRI is REJECTED. The encoder never emits one (a single
+    /// interval takes the untagged form), so accepting it would admit a second spelling
+    /// of a set that already has a canonical `ClassId` — two classes for one range,
+    /// with no edge between them.
+    #[test]
+    fn a_degenerate_one_component_iset_iri_is_rejected() {
+        assert_eq!(parse_int_set_dkey_iri("urn:rustdl-dkey:iset:0:5"), None);
+        // …and the untagged decoder must not accept it either, which is what keeps the
+        // rejection from being a silent reinterpretation.
+        assert_eq!(parse_dkey_iri("urn:rustdl-dkey:iset:0:5"), None);
+    }
+
+    /// ORDERING PIN. `data_range_dkey` runs `flatten_union_of_oneofs` BEFORE the
+    /// interval-set arm, so a union whose members are ALL enumerations still lands in
+    /// the `io:` bucket — even though the interval-set parser would happily accept it
+    /// (an integer enumeration is a set of point intervals).
+    ///
+    /// This is not cosmetic. The `io:` bucket seeds subsumption with the EXACT
+    /// `BTreeSet::is_subset`; the interval bucket uses `IntSet::subset`, a `∀∃` lift
+    /// that is an under-approximation on un-normalised operands. Reordering the two arms
+    /// would silently downgrade every enumeration union's subsumption seeding — a
+    /// completeness regression with no other symptom.
+    #[test]
+    fn an_all_enumeration_union_still_lands_in_the_enumeration_bucket() {
+        use horned_owl::model::{Build, DataRange, Literal};
+
+        let b = Build::<std::rc::Rc<str>>::new();
+        let int_lit = |v: &str| Literal::Datatype {
+            literal: v.to_string(),
+            datatype_iri: b.iri("http://www.w3.org/2001/XMLSchema#integer"),
+        };
+        let union_of_oneofs: DataRange<std::rc::Rc<str>> = DataRange::DataUnionOf(vec![
+            DataRange::DataOneOf(vec![int_lit("1")]),
+            DataRange::DataOneOf(vec![int_lit("2")]),
+        ]);
+
+        // BOTH parsers accept it — so ORDER, not matching, is what decides the bucket.
+        assert!(crate::data_axioms::parse_integer_interval_set(&union_of_oneofs).is_some());
+        assert!(flatten_union_of_oneofs(&union_of_oneofs).is_some());
+
+        let mut vocab = Vocabulary::default();
+        let mut pool = ConceptPool::default();
+        let Some((_, filler)) =
+            data_range_dkey(&union_of_oneofs, "http://ex.org/p", &mut vocab, &mut pool)
+        else {
+            panic!("an all-enumeration union must lower");
+        };
+        let ConceptExpr::Atomic(cid) = pool.get(filler) else {
+            panic!("the filler is the DKey class")
+        };
+        let iri = vocab.class_iri(*cid);
+        assert!(
+            parse_int_oneof_iri(iri).is_some(),
+            "expected the exact `io:` enumeration bucket, got {iri:?} — the interval-set \
+             arm must stay AFTER `flatten_union_of_oneofs`"
+        );
     }
 
     #[test]

--- a/crates/owl-dl-core/src/data_axioms.rs
+++ b/crates/owl-dl-core/src/data_axioms.rs
@@ -558,6 +558,165 @@ impl IntegerRange {
     }
 }
 
+/// A UNION of [`IntegerRange`]s — the `xsd:integer` INTERVAL SET (#42 item 1).
+///
+/// The gap it closes: `DataAllValuesFrom(p, DataUnionOf([0,5], [10,15]))` cannot be
+/// split into a class-level disjunction the way `DataSomeValuesFrom` can, so
+/// `data_range_dkey`'s parser chain matched nothing and the WHOLE AXIOM DROPPED.
+/// Konclude derives `∃p.{7} ⊓ ∀p.([0,5] ⊔ [10,15])` UNSATISFIABLE (7 is outside both
+/// components) and rustdl reported it satisfiable — a silent MISS, not a reported drop.
+///
+/// **All three operations are QUANTIFIED LIFTS of the corresponding [`IntegerRange`]
+/// operation, and that is load-bearing.** A one-element `IntSet` evaluates each op to
+/// *exactly* the scalar answer, so widening the integer `DKey` bucket from
+/// `IntegerRange` to `IntSet` leaves every pre-existing key's behaviour unchanged BY
+/// CONSTRUCTION rather than by assertion — including the empty-range corner, which
+/// [`Self::single`] deliberately does not normalise away. The encoding preserves the
+/// property on the other side: a one-component set keys to the historical UNTAGGED
+/// IRI, byte-identical.
+///
+/// Exactness, op by op — the FP-critical distinction:
+/// - [`Self::contains`] (`∃`) and [`Self::disjoint`] (`∀∀`) are EXACT, because
+///   `A ∩ B = ⋃ᵢⱼ (aᵢ ∩ bⱼ)`. Both drive CLASHES, so the direction of risk is a false
+///   POSITIVE and exactness is a soundness requirement, not a quality target.
+/// - [`Self::subset`] (`∀∃`) is a sound UNDER-approximation: it asks each component to
+///   fit inside ONE component of the other, so on un-normalised input it would miss
+///   `[0,10] ⊆ [0,5] ⊔ [6,10]`. It drives SUBSUMPTION seeding, where an
+///   under-approximation is a MISS.
+///
+/// **Integer discreteness is what makes that under-approximation tight here, and it
+/// does NOT transfer.** [`Self::normalized`] merges components that merely TOUCH
+/// (`[0,5] ⊔ [6,10] → [0,10]`), valid only because the integers have a successor. The
+/// result is that every component is separated from the next by at least one absent
+/// integer, so a contiguous interval can never straddle a gap and `∀∃` is exact on
+/// normalised operands. `xsd:float` / `xsd:decimal` / `xsd:date` / `xsd:dateTime` have
+/// no successor: their interval sets can only merge OVERLAPPING components, and their
+/// `subset` stays genuinely conservative. **Do not copy this type to them without
+/// redoing that argument** — the five remaining datatypes are a separate piece of
+/// reasoning, not a mechanical follow-on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct IntSet {
+    /// Never empty. [`Self::normalized`] additionally guarantees the components are
+    /// sorted, pairwise disjoint and pairwise non-adjacent; [`Self::single`] makes no
+    /// such promise, because preserving a lone empty range verbatim is what keeps the
+    /// pre-existing bucket byte-identical.
+    ///
+    /// **A `Vec`, and `SmallVec<[IntegerRange; 1]>` was tried and MEASURED OUT.** This
+    /// type is the element of `seed_dkey_subsumptions`' integer bucket, which
+    /// `seed_bucket` walks over k² ORDERED pairs, so the obvious worry is the heap
+    /// allocation this costs per key (essentially every key is one component). Measured
+    /// on `ore_ont_15635` — the largest integer bucket in ORE at k = 7,281, giving
+    /// 5.3 × 10⁷ pairs — min-of-5 interleaved: baseline 3341 ms, `Vec` 3434 ms
+    /// (**1.028×**), `SmallVec` 3437 ms (**1.029×**). **The inline version recovers 0%**,
+    /// so the ~93 ms is NOT the allocation — the likelier cause is the bucket element
+    /// growing ~40% (16 → 24+ bytes payload) and costing cache in the k² scan. Recorded
+    /// so the next person does not re-run the same refuted experiment; if this ever
+    /// needs to be cheap, shrink the ELEMENT or index the loop, do not inline the vector.
+    ranges: Vec<IntegerRange>,
+}
+
+impl IntSet {
+    /// The one-component set — the lift of a plain [`IntegerRange`]. Deliberately does
+    /// NOT normalise: an empty range must survive so that every op reproduces the
+    /// scalar answer exactly (`IntegerRange::disjoint` is conservative on an empty
+    /// range where set semantics would say "disjoint from everything", and swapping
+    /// that in would be a behaviour change in the false-positive direction).
+    pub(crate) fn single(r: IntegerRange) -> Self {
+        Self { ranges: vec![r] }
+    }
+
+    /// Canonicalise a bag of components: drop the empty ones, sort, then merge
+    /// overlapping AND adjacent neighbours. Returns `None` when nothing survives —
+    /// the set denotes `∅`, and dropping the axiom is the sound under-approximation
+    /// (the same choice `flatten_union_of_oneofs` makes for an empty literal list).
+    ///
+    /// Canonical form matters beyond tidiness: the encoded IRI is the interning key,
+    /// so two spellings of one set must produce one `ClassId` or the seeding never
+    /// relates them.
+    pub(crate) fn normalized(mut ranges: Vec<IntegerRange>) -> Option<Self> {
+        ranges.retain(|r| !r.is_empty());
+        if ranges.is_empty() {
+            return None;
+        }
+        // `None` min is −∞ (sorts first); `None` max is +∞ (sorts last).
+        fn min_key(b: Option<i64>) -> (u8, i64) {
+            b.map_or((0, i64::MIN), |v| (1, v))
+        }
+        fn max_key(b: Option<i64>) -> (u8, i64) {
+            b.map_or((1, i64::MAX), |v| (0, v))
+        }
+        ranges.sort_by(|a, b| {
+            min_key(a.min)
+                .cmp(&min_key(b.min))
+                .then(max_key(a.max).cmp(&max_key(b.max)))
+        });
+        let mut out: Vec<IntegerRange> = Vec::with_capacity(ranges.len());
+        for r in ranges {
+            match out.last_mut() {
+                Some(last) if !Self::gap_between(*last, r) => *last = Self::merge(*last, r),
+                _ => out.push(r),
+            }
+        }
+        Some(Self { ranges: out })
+    }
+
+    /// Is there at least one integer strictly between `a` and `b` (given `a` sorts
+    /// before `b`)? Only then must they stay separate components. `a.max + 1 < b.min`
+    /// is the test, written as a checked subtraction so that a span exceeding `i64`
+    /// reads as a gap rather than overflowing. An unbounded facing end reaches the
+    /// other, so there is no gap.
+    fn gap_between(a: IntegerRange, b: IntegerRange) -> bool {
+        match (a.max, b.min) {
+            (Some(amax), Some(bmin)) => bmin.checked_sub(amax).is_none_or(|d| d > 1),
+            _ => false,
+        }
+    }
+
+    /// The bounding interval of two components already known to overlap or touch.
+    /// Order-independent: an unbounded end on either side stays unbounded.
+    fn merge(a: IntegerRange, b: IntegerRange) -> IntegerRange {
+        IntegerRange {
+            min: match (a.min, b.min) {
+                (Some(x), Some(y)) => Some(x.min(y)),
+                _ => None,
+            },
+            max: match (a.max, b.max) {
+                (Some(x), Some(y)) => Some(x.max(y)),
+                _ => None,
+            },
+        }
+    }
+
+    /// The components, in encoding order.
+    pub(crate) fn ranges(&self) -> &[IntegerRange] {
+        &self.ranges
+    }
+
+    /// `v ∈ ⋃ᵢ rᵢ`. EXACT: membership in a union is membership in some component.
+    pub(crate) fn contains(&self, v: i64) -> bool {
+        self.ranges.iter().any(|r| r.contains(v))
+    }
+
+    /// `self ∩ other = ∅`. EXACT relative to [`IntegerRange::disjoint`], since
+    /// `(⋃aᵢ) ∩ (⋃bⱼ) = ⋃ᵢⱼ (aᵢ ∩ bⱼ)` — so the union is empty iff every pairwise
+    /// intersection is. FP-CRITICAL: this emits `DisjointClasses`, so a wrong `true`
+    /// is a false UNSAT.
+    pub(crate) fn disjoint(&self, other: &Self) -> bool {
+        self.ranges
+            .iter()
+            .all(|a| other.ranges.iter().all(|b| a.disjoint(*b)))
+    }
+
+    /// `self ⊆ other`, via "every component of `self` fits inside SOME component of
+    /// `other`". Sound in the MISS direction by construction; exact on normalised
+    /// operands by the discreteness argument in the type docs.
+    pub(crate) fn subset(&self, other: &Self) -> bool {
+        self.ranges
+            .iter()
+            .all(|a| other.ranges.iter().any(|b| a.subset(*b)))
+    }
+}
+
 /// Phase D6 (Part B): real-number range with EXPLICIT inclusive/exclusive
 /// bounds. Used for `xsd:float` / `xsd:double` `DatatypeRestriction`
 /// facets and float `DataHasValue` point values.
@@ -1906,6 +2065,59 @@ fn parse_integer_facets<A: ForIRI>(facets: &[FacetRestriction<A>]) -> Option<Int
         }
     }
     Some(range)
+}
+
+/// Parse a `DataUnionOf` over the `xsd:integer` value space into an [`IntSet`]
+/// (#42 item 1). Returns `None` for anything that is not a union, and for any union
+/// with a member this cannot represent.
+///
+/// **ALL-OR-NOTHING, and that is the load-bearing property.** Keeping the
+/// representable members of a mixed union would yield a strictly NARROWER range, and a
+/// narrower range in a `∀` position manufactures a clash — a false POSITIVE. The
+/// `false` fall-through below is what enforces it; `filter_map` here would be a
+/// soundness bug. (The sibling `flatten_union_of_oneofs` learned this from a sabotage:
+/// a loosened collector passed every canary because a pure-interval union flattened to
+/// an empty literal set that was rejected anyway, and only a MIXED union exposed it.)
+///
+/// An `xsd:integer` ENUMERATION is an accepted member because on a DISCRETE value
+/// space `{v}` IS the interval `[v, v]` — exact, not an approximation — so
+/// `[10,15] ⊔ {1}` is representable without weakening. That is what makes
+/// all-or-nothing affordable rather than restrictive here. It would not be for a dense
+/// datatype, where an enumeration is not an interval union.
+///
+/// Ordering note: `data_range_dkey` runs `flatten_union_of_oneofs` FIRST, so a union
+/// whose members are ALL enumerations still lands in the exact `io:` bucket
+/// (`BTreeSet::is_subset`) rather than here, where subsumption would degrade to the
+/// `∀∃` lift. Pinned by `an_all_enumeration_union_still_lands_in_the_enumeration_bucket`.
+pub(crate) fn parse_integer_interval_set<A: ForIRI>(dr: &DataRange<A>) -> Option<IntSet> {
+    fn collect<A: ForIRI>(dr: &DataRange<A>, out: &mut Vec<IntegerRange>) -> bool {
+        // Nested unions flatten; `⊔` is associative.
+        if let DataRange::DataUnionOf(ms) = dr {
+            return !ms.is_empty() && ms.iter().all(|m| collect(m, out));
+        }
+        if let Some(r) = parse_integer_range(dr) {
+            out.push(r);
+            return true;
+        }
+        if let Some(vs) = parse_integer_oneof(dr) {
+            out.extend(vs.into_iter().map(IntegerRange::point));
+            return true;
+        }
+        false
+    }
+    let DataRange::DataUnionOf(members) = dr else {
+        return None;
+    };
+    if members.is_empty() {
+        return None;
+    }
+    let mut ranges = Vec::new();
+    for m in members {
+        if !collect(m, &mut ranges) {
+            return None;
+        }
+    }
+    IntSet::normalized(ranges)
 }
 
 /// Parse an **`xsd:float`-only** `DataRange` into a [`FloatRange`] using
@@ -3437,6 +3649,160 @@ fn emit_disjoint_dp_same_value_clash(
 
 #[cfg(test)]
 mod tests {
+
+    fn ir(min: i64, max: i64) -> IntegerRange {
+        IntegerRange {
+            min: Some(min),
+            max: Some(max),
+        }
+    }
+
+    fn iset(rs: Vec<IntegerRange>) -> IntSet {
+        let Some(s) = IntSet::normalized(rs) else {
+            panic!("expected a non-empty interval set")
+        };
+        s
+    }
+
+    /// THE NON-REGRESSION PROPERTY, stated as a test: on ONE-COMPONENT sets every
+    /// `IntSet` op returns exactly what the scalar `IntegerRange` op returns.
+    ///
+    /// That is what licenses widening the integer `DKey` bucket from `IntegerRange` to
+    /// `IntSet` without re-validating the bucket — including the corners, which is why
+    /// the empty range is in the grid: `IntegerRange::disjoint` is CONSERVATIVE there
+    /// (it can answer `false` where set semantics would say `∅` is disjoint from
+    /// everything), and `IntSet::single` deliberately preserves that rather than
+    /// normalising it away, because "correcting" it would be a behaviour change in the
+    /// false-POSITIVE direction.
+    #[test]
+    fn one_component_interval_set_ops_agree_with_the_scalar_ops() {
+        let grid = [
+            ir(0, 10),
+            ir(5, 5),
+            ir(11, 20),
+            IntegerRange {
+                min: None,
+                max: Some(5),
+            },
+            IntegerRange {
+                min: Some(3),
+                max: None,
+            },
+            IntegerRange::unbounded(),
+            ir(5, 0), // empty
+        ];
+        for a in grid {
+            for v in [-1_i64, 0, 3, 5, 10, 11, 21] {
+                assert_eq!(
+                    IntSet::single(a).contains(v),
+                    a.contains(v),
+                    "contains({v}) on {a:?}"
+                );
+            }
+            for b in grid {
+                assert_eq!(
+                    IntSet::single(a).disjoint(&IntSet::single(b)),
+                    a.disjoint(b),
+                    "disjoint on {a:?} / {b:?}"
+                );
+                assert_eq!(
+                    IntSet::single(a).subset(&IntSet::single(b)),
+                    a.subset(b),
+                    "subset on {a:?} / {b:?}"
+                );
+            }
+        }
+    }
+
+    /// `normalized` sorts, drops empties, and merges components that OVERLAP or merely
+    /// TOUCH — the second being valid only because the integers are discrete. It must
+    /// NOT merge across a real gap, which is the property the gap canaries in
+    /// `data_union_of_intervals.rs` exercise end-to-end.
+    #[test]
+    fn normalized_merges_overlapping_and_touching_but_never_across_a_gap() {
+        assert_eq!(iset(vec![ir(6, 10), ir(0, 5)]).ranges(), [ir(0, 10)]);
+        assert_eq!(iset(vec![ir(0, 7), ir(5, 10)]).ranges(), [ir(0, 10)]);
+        assert_eq!(
+            iset(vec![ir(0, 5), ir(7, 10)]).ranges(),
+            [ir(0, 5), ir(7, 10)]
+        );
+        // Empties are dropped; an all-empty bag has no representation at all.
+        assert_eq!(iset(vec![ir(5, 0), ir(0, 5)]).ranges(), [ir(0, 5)]);
+        assert_eq!(IntSet::normalized(vec![ir(5, 0), ir(9, 3)]), None);
+        assert_eq!(IntSet::normalized(vec![]), None);
+        // An unbounded end swallows everything on that side.
+        assert_eq!(
+            iset(vec![
+                IntegerRange {
+                    min: None,
+                    max: Some(5)
+                },
+                ir(3, 10)
+            ])
+            .ranges(),
+            [IntegerRange {
+                min: None,
+                max: Some(10)
+            }]
+        );
+    }
+
+    /// The adjacency test is a CHECKED subtraction, so a span wider than `i64` reads as
+    /// a gap rather than overflowing. Without that, `[i64::MIN, -1]` and `[1, i64::MAX]`
+    /// would wrap and merge into one interval that swallows `0` — a strictly WIDER range
+    /// than asserted, which in a `∀` position is a lost clash, and in a `∃` position
+    /// (via the disjointness seeding) a wrong `not disjoint`.
+    #[test]
+    fn adjacency_does_not_overflow_on_extreme_bounds() {
+        let s = iset(vec![ir(i64::MIN, -1), ir(1, i64::MAX)]);
+        assert_eq!(s.ranges().len(), 2, "a two-integer-wide gap is still a gap");
+        assert!(!s.contains(0), "0 is in the gap");
+        assert!(s.contains(-1) && s.contains(1));
+        // …and a genuinely adjacent pair at the extreme still merges.
+        assert_eq!(
+            iset(vec![ir(i64::MIN, -1), ir(0, i64::MAX)]).ranges().len(),
+            1
+        );
+    }
+
+    /// `disjoint` and `contains` are EXACT lifts (`∀∀` and `∃`) because
+    /// `A ∩ B = ⋃ᵢⱼ (aᵢ ∩ bⱼ)`. FP-CRITICAL: `disjoint` emits `DisjointClasses`, so a
+    /// wrong `true` is a false UNSAT. The interleaved pair is the discriminating case —
+    /// neither set's hull is disjoint from the other's, but every component pair is.
+    #[test]
+    fn interval_set_disjointness_is_exact() {
+        let a = iset(vec![ir(0, 5), ir(10, 15)]);
+        let b = iset(vec![ir(6, 9), ir(16, 20)]);
+        assert!(a.disjoint(&b) && b.disjoint(&a), "interleaved but disjoint");
+        // One shared INCLUSIVE endpoint is an overlap, not a gap.
+        assert!(!a.disjoint(&iset(vec![ir(5, 9)])));
+        assert!(!a.disjoint(&iset(vec![ir(12, 30)])));
+        for v in [0, 3, 5, 10, 15] {
+            assert!(a.contains(v), "{v} is in [0,5] ⊔ [10,15]");
+        }
+        for v in [-1, 6, 9, 16] {
+            assert!(!a.contains(v), "{v} is outside [0,5] ⊔ [10,15]");
+        }
+    }
+
+    /// `subset` is the `∀∃` lift: sound in the MISS direction always, and EXACT on
+    /// normalised operands because integer discreteness leaves at least one absent
+    /// integer between components, so a contiguous interval cannot straddle a gap.
+    ///
+    /// The last case is the one that would be a genuine under-approximation for a DENSE
+    /// datatype and is not one here: `[0,10] ⊆ [0,5] ⊔ [6,10]` holds only because
+    /// normalisation already merged the right-hand side into `[0,10]`.
+    #[test]
+    fn interval_set_subset_is_exact_on_normalised_operands() {
+        let big = iset(vec![ir(0, 5), ir(10, 20)]);
+        assert!(iset(vec![ir(1, 4)]).subset(&big));
+        assert!(iset(vec![ir(1, 4), ir(11, 12)]).subset(&big));
+        assert!(big.subset(&big));
+        // Straddling the gap is NOT a subset — the direction that must not be lax.
+        assert!(!iset(vec![ir(4, 11)]).subset(&big));
+        assert!(!iset(vec![ir(1, 4), ir(30, 40)]).subset(&big));
+        assert!(iset(vec![ir(0, 10)]).subset(&iset(vec![ir(0, 5), ir(6, 10)])));
+    }
     use super::*;
     use crate::convert::convert_ontology;
     use horned_owl::io::ParserConfiguration;

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -6660,6 +6660,18 @@ fn build_dkey_range_map(
                 owl_dl_datatypes::CardRange::DateTimeSet(owl_dl_datatypes::FiniteSet::Set(set)),
             );
         }
+        // DELIBERATE FALL-THROUGH, not an omission: a multi-interval `iset:` key
+        // (#42 item 1, `xsd:integer` interval sets) matches NO decoder above — the
+        // untagged integer decoder rejects the tag — so it gets no side-map entry.
+        // `CardRange` carries ONE interval per variant and cannot express a union, and
+        // inventing a hull `[0,15]` for `{[0,5],[10,15]}` would over-state the
+        // concrete-domain capacity in the false-POSITIVE direction. No entry means
+        // `concept_has_dkey_counting` does not flag such a filler and no counting clash
+        // is derived from it — a sound MISS, and the same one already recorded for
+        // qualified data cardinality over a union. The DISJOINTNESS the interval-set
+        // representation exists for is seeded as native `DisjointClasses` axioms in
+        // `convert.rs` and does not come through this map. If you add a decoder here,
+        // leave this absence intentional or widen `CardRange` first.
     }
     map
 }

--- a/crates/owl-dl-reasoner/tests/data_union_of_enumerations.rs
+++ b/crates/owl-dl-reasoner/tests/data_union_of_enumerations.rs
@@ -116,20 +116,23 @@ fn a_value_inside_the_union_stays_satisfiable() {
     );
 }
 
-/// SCOPE GUARD — a union of INTERVALS is deliberately NOT flattened, and this pins a
-/// **known, oracle-confirmed sound MISS** rather than a correct answer.
+/// SCOPE MARKER, **FLIPPED 2026-09-05** when the interval-set representation landed.
 ///
-/// `[0,5] ⊔ [10,15]` is not a single interval, and no range type here can represent a
-/// disjoint set of them. A partial flatten would produce a strictly WEAKER range, which
-/// in a `∀` position is unsound in the sufficient direction — so the axiom drops and `A`
-/// comes back satisfiable.
+/// This test was written to pin a KNOWN, oracle-confirmed sound MISS: `[0,5] ⊔ [10,15]`
+/// is not a single interval, the integer `DKey` bucket held one `IntegerRange` per key,
+/// so the axiom dropped and `A` came back satisfiable while **Konclude derived it
+/// UNSATISFIABLE** (verified 2026-09-05, 1121 bytes of real output — not the ~896-byte
+/// `Thing`/`Nothing` stub it emits on unreadable input). Its own instruction was to flip
+/// it rather than delete it when an interval-set representation arrived, so that the
+/// closure of the gap would be recorded in the place that documented the gap.
 ///
-/// **Konclude reports `A` UNSATISFIABLE here** (verified 2026-09-05, 1121 bytes of real
-/// output — not the ~896-byte Thing/Nothing stub it emits on unreadable input), and it is
-/// right: 7 is outside both intervals. So this test asserts a gap, not a verdict.
-/// **FLIP it if an interval-set representation ever lands — do not delete it.**
+/// It has arrived: the bucket now holds an `IntSet`, and this asserts the verdict rather
+/// than the gap. `7` is outside both components, `A` is unsatisfiable, and rustdl and
+/// Konclude agree. The full probe set — gap boundaries, inclusive endpoints, adjacency,
+/// unbounded ends, mixed enumeration/interval unions — lives in
+/// `data_union_of_intervals.rs`.
 #[test]
-fn a_union_of_intervals_stays_a_sound_drop_and_is_a_known_miss() {
+fn a_union_of_intervals_now_clashes_with_a_value_in_the_gap() {
     let c = load(
         "Declaration(Class(:A)) Declaration(DataProperty(:p))
          SubClassOf(:A DataSomeValuesFrom(:p DataOneOf(\"7\"^^xsd:integer)))
@@ -137,11 +140,11 @@ fn a_union_of_intervals_stays_a_sound_drop_and_is_a_known_miss() {
            DatatypeRestriction(xsd:integer xsd:minInclusive \"0\"^^xsd:integer xsd:maxInclusive \"5\"^^xsd:integer) \
            DatatypeRestriction(xsd:integer xsd:minInclusive \"10\"^^xsd:integer xsd:maxInclusive \"15\"^^xsd:integer))))",
     );
-    assert!(
-        c.unsatisfiable_classes().is_empty(),
-        "a union of INTERVALS must stay a sound DROP — never a partial flatten. \
-         Konclude derives unsat here, so this pins a known MISS: flip it when \
-         interval-sets land, do not delete it."
+    assert_eq!(
+        c.unsatisfiable_classes(),
+        vec!["http://ex.org/A"],
+        "7 is outside both [0,5] and [10,15] — the interval-set representation makes \
+         this the clash Konclude always derived"
     );
 }
 
@@ -163,23 +166,29 @@ fn a_mixed_datatype_union_does_not_produce_a_clash() {
     );
 }
 
-/// THE SABOTAGE-DRIVEN GUARD. A union MIXING an enumeration with an interval must not
-/// be partially flattened — and this is the case that makes the enumeration-only
-/// restriction load-bearing rather than merely tidy.
+/// THE SABOTAGE-DRIVEN GUARD, **REFRAMED 2026-09-05**: still a false-positive guard,
+/// but it now guards a different mechanism, because the interval-set representation
+/// changed why it passes.
 ///
 /// `12 ∈ [10,15]`, so `A` is **satisfiable** (Konclude agrees, 1105 bytes of real
-/// output). Correct behaviour: the union has a non-enumeration member, so nothing is
-/// flattened and the axiom drops — a sound under-approximation.
+/// output) and that verdict is what this asserts either way. What changed is the route:
 ///
-/// If the flattener were loosened to accept any member, it would collect only the
-/// enumeration's literals and yield `∀p.{1}`, **silently discarding the interval half**.
-/// That is a strictly WEAKER range in a universal position, so `12 ∉ {1}` would
-/// manufacture a clash and report `A` unsatisfiable — a **false positive**.
+/// - **Then:** the union had a non-enumeration member, so `flatten_union_of_oneofs`
+///   declined and the whole axiom DROPPED — satisfiable because nothing constrained `p`.
+/// - **Now:** on a discrete value space `{1}` IS `[1,1]`, so the union is an interval
+///   set and is represented EXACTLY — satisfiable because `12` really is in it.
 ///
-/// Found by sabotage: flipping `collect`'s `_ => false` arm to `_ => true` passed every
-/// other test in this file, because a union of intervals alone flattens to an EMPTY
-/// literal set and is rejected by the `lits.is_empty()` check anyway. Only a MIXED union
-/// exposes it.
+/// The original sabotage still holds: loosening `collect`'s `_ => false` arm would
+/// collect only the enumeration's literals and yield `∀p.{1}`, silently discarding the
+/// interval half — a strictly WEAKER range in a universal position, so `12 ∉ {1}` would
+/// manufacture a clash. That sabotage was found only because a union of intervals ALONE
+/// flattens to an empty literal set the `lits.is_empty()` check rejects anyway; only a
+/// MIXED union exposes it.
+///
+/// **This test can no longer tell "represented exactly" from "dropped", so it is no
+/// longer sufficient on its own** — `a_mixed_enumeration_and_interval_union_is_
+/// represented_exactly` in `data_union_of_intervals.rs` adds the probe that
+/// discriminates them (a value in NEITHER half, which must clash).
 #[test]
 fn a_union_mixing_an_enumeration_and_an_interval_is_not_partially_flattened() {
     assert!(

--- a/crates/owl-dl-reasoner/tests/data_union_of_intervals.rs
+++ b/crates/owl-dl-reasoner/tests/data_union_of_intervals.rs
@@ -1,0 +1,251 @@
+//! A `DataUnionOf` of `xsd:integer` INTERVALS in a universal / range position was
+//! dropped (#42 item 1, residual).
+//!
+//! #42 item 1 closed the ENUMERATION half — `DataOneOf(a) ⊔ DataOneOf(b)` is
+//! `DataOneOf(a,b)`, so flattening it is a logical identity. A union of INTERVALS has
+//! no such single-range form: `[0,5] ⊔ [10,15]` is not an interval, and the integer
+//! `DKey` bucket held one `IntegerRange` per key, so `data_range_dkey`'s parser chain
+//! matched nothing and the whole axiom DROPPED. `∃p.{7} ⊓ ∀p.([0,5] ⊔ [10,15])` came
+//! back satisfiable where Konclude derives it unsatisfiable — a silent MISS, pinned by
+//! `data_union_of_enumerations.rs`'s scope guard until now.
+//!
+//! The fix widens that bucket from `IntegerRange` to `IntSet`, a union of ranges whose
+//! `contains` / `disjoint` / `subset` are QUANTIFIED LIFTS of the scalar ops. A
+//! one-component set therefore evaluates each op to exactly the old answer, and encodes
+//! to exactly the old untagged IRI — so every key any pre-#42 ontology could produce is
+//! unmoved by construction, and only genuinely multi-interval keys use the new `iset:`
+//! form.
+//!
+//! ## Direction of risk
+//!
+//! Axioms that used to drop now CONVERT, and the new keys seed `DisjointClasses`. That
+//! ADDS clashes, so the failure mode is a false POSITIVE. Hence the weight here sits on
+//! the satisfiable controls, not the unsat ones — in particular the two GAP probes
+//! (`6`, `9` outside `[0,5] ⊔ [10,15]`) paired with the two INCLUSIVE BOUNDARIES (`5`,
+//! `10` inside it), which together are what would catch an over-eager normalisation
+//! that merged the components into `[0,15]`.
+//!
+//! ## Oracle
+//!
+//! Every probe in this file was adjudicated against Konclude v0.7.0-1138 (2026-09-05):
+//! **12/12 agree**, all on real output (1105 bytes satisfiable / 1121 unsatisfiable —
+//! not the ~896-byte `Thing`/`Nothing` stub it emits on input it cannot read). Konclude
+//! *does* report the relation on the unsatisfiable probes, so its silence on the
+//! satisfiable ones is a discriminating control rather than the under-reporting it is
+//! documented to do elsewhere.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::doc_markdown)]
+
+use owl_dl_reasoner::classify;
+
+fn load(body: &str) -> owl_dl_reasoner::Classification {
+    let src = format!(
+        "Prefix(:=<http://ex.org/>)\n\
+         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n\
+         Ontology(<http://ex.org/t>\n{body}\n)\n"
+    );
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+    classify(&onto).expect("classify")
+}
+
+/// `∃p.{v} ⊓ ∀p.range` — is `A` unsatisfiable?
+fn a_is_unsat(v: i64, range: &str) -> bool {
+    !load(&format!(
+        "Declaration(Class(:A)) Declaration(DataProperty(:p))
+         SubClassOf(:A DataSomeValuesFrom(:p DataOneOf(\"{v}\"^^xsd:integer)))
+         SubClassOf(:A DataAllValuesFrom(:p {range}))"
+    ))
+    .unsatisfiable_classes()
+    .is_empty()
+}
+
+fn interval(min: i64, max: i64) -> String {
+    format!(
+        "DatatypeRestriction(xsd:integer xsd:minInclusive \"{min}\"^^xsd:integer \
+         xsd:maxInclusive \"{max}\"^^xsd:integer)"
+    )
+}
+
+/// `[0,5] ⊔ [10,15]` — the shape the scope guard in `data_union_of_enumerations.rs`
+/// pinned as a known miss.
+fn gapped_union() -> String {
+    format!("DataUnionOf({} {})", interval(0, 5), interval(10, 15))
+}
+
+/// THE FLIP. `7` lies in the gap between the two components, so `A` is unsatisfiable —
+/// the verdict Konclude has always given and rustdl used to miss.
+#[test]
+fn a_value_in_the_gap_between_two_intervals_clashes() {
+    assert!(
+        a_is_unsat(7, &gapped_union()),
+        "7 is outside both [0,5] and [10,15] — A is unsatisfiable, and Konclude agrees"
+    );
+}
+
+/// The gap probes either side of the seam, and the value past the top. These are what
+/// distinguish a real interval SET from a hull: under a normalisation that merged the
+/// components into `[0,15]`, `6` and `9` would both come back satisfiable.
+#[test]
+fn the_gap_is_not_silently_closed_into_a_hull() {
+    for v in [6, 9] {
+        assert!(
+            a_is_unsat(v, &gapped_union()),
+            "{v} is in the gap between [0,5] and [10,15]; reporting A satisfiable would \
+             mean the two components had been merged into the hull [0,15]"
+        );
+    }
+    assert!(
+        a_is_unsat(16, &gapped_union()),
+        "16 is above both components"
+    );
+}
+
+/// THE FP GUARDS, oracle-adjudicated. Every value genuinely inside the union must stay
+/// satisfiable — including both INCLUSIVE boundaries, `5` (top of the first component)
+/// and `10` (bottom of the second), which is where an off-by-one in the gap test would
+/// show up. Konclude reports no unsatisfiable class for any of these.
+///
+/// This is what separates "the fix works" from "anything with a union now clashes".
+#[test]
+fn values_inside_either_interval_stay_satisfiable() {
+    for v in [0, 3, 5, 10, 12, 15] {
+        assert!(
+            !a_is_unsat(v, &gapped_union()),
+            "{v} IS in [0,5] ⊔ [10,15] — A is satisfiable, and Konclude agrees"
+        );
+    }
+}
+
+/// ADJACENT components merge, and that is sound only because the integers are DISCRETE:
+/// `[0,5] ⊔ [6,10]` has no integer between `5` and `6`, so it IS `[0,10]`.
+///
+/// `6` must stay satisfiable (a merge that refused to join touching components would
+/// still get this right, so the discriminating half is `11`, which must clash — if the
+/// merge instead joined across a real gap, nothing here would fail but the gap probes
+/// above would). **The dense datatypes have no successor and cannot do this**, which is
+/// why they need their own reasoning rather than a copy of this type.
+#[test]
+fn touching_intervals_are_one_interval_over_the_integers() {
+    let adj = format!("DataUnionOf({} {})", interval(0, 5), interval(6, 10));
+    assert!(!a_is_unsat(6, &adj), "6 is in [0,5] ⊔ [6,10] = [0,10]");
+    assert!(a_is_unsat(11, &adj), "11 is above [0,10]");
+}
+
+/// Unbounded ends survive the encoding: `(-∞,5] ⊔ [10,∞)` keys as `iset:*:5;10:*`, and
+/// the `*` must round-trip on both sides. `7` is the only one of the three in the gap.
+#[test]
+fn unbounded_components_round_trip_through_the_encoding() {
+    let unb = "DataUnionOf(\
+       DatatypeRestriction(xsd:integer xsd:maxInclusive \"5\"^^xsd:integer) \
+       DatatypeRestriction(xsd:integer xsd:minInclusive \"10\"^^xsd:integer))";
+    assert!(!a_is_unsat(3, unb), "3 ≤ 5");
+    assert!(a_is_unsat(7, unb), "7 is in the gap (5,10)");
+    assert!(!a_is_unsat(20, unb), "20 ≥ 10");
+}
+
+/// A union MIXING an enumeration with an interval is now represented EXACTLY, not
+/// dropped — because on a discrete value space `{1}` IS the interval `[1,1]`, so
+/// `{1} ⊔ [10,15]` is an interval set like any other.
+///
+/// **The three assertions are what prove "exact" rather than "dropped" or "half".** If
+/// the axiom still dropped, `7` would come back satisfiable. If only the interval half
+/// survived, `1` would clash. If only the enumeration half survived, `12` would clash.
+/// All three hold, and Konclude agrees on all three.
+///
+/// This supersedes the scope guard
+/// `a_union_mixing_an_enumeration_and_an_interval_is_not_partially_flattened` in
+/// `data_union_of_enumerations.rs`, which asserted the same satisfiable verdicts for the
+/// opposite reason (nothing was representable, so everything dropped).
+#[test]
+fn a_mixed_enumeration_and_interval_union_is_represented_exactly() {
+    let mixed = format!(
+        "DataUnionOf(DataOneOf(\"1\"^^xsd:integer) {})",
+        interval(10, 15)
+    );
+    assert!(!a_is_unsat(1, &mixed), "1 is the enumeration member");
+    assert!(!a_is_unsat(12, &mixed), "12 is inside [10,15]");
+    assert!(
+        a_is_unsat(7, &mixed),
+        "7 is in neither half — if this were satisfiable the axiom would still be dropping"
+    );
+}
+
+/// ALL-OR-NOTHING, and this is the guard that makes it load-bearing rather than tidy.
+///
+/// `[10,15] ⊔ xsd:decimal` denotes every decimal, so `∃p.{7}` is SATISFIABLE — Konclude
+/// agrees — and the correct behaviour is to represent none of it: the union has a member
+/// no interval set can express, so the axiom drops (visibly, in `dropped`).
+///
+/// If `collect`'s `_ => false` arm were loosened to skip the unrepresentable member, it
+/// would keep `[10,15]` alone — a strictly NARROWER range, which in a `∀` position
+/// manufactures the clash `7 ∉ [10,15]` and reports `A` unsatisfiable. **A false
+/// positive.**
+///
+/// The fixture is chosen so the sabotage is *distinguishable by verdict*. The obvious
+/// candidate — union with a `xsd:string` enumeration — is NOT: there the discarded half
+/// admits no integer, so both the correct code and the loosened code end up agreeing
+/// with Konclude's `unsatisfiable`, for opposite reasons. The discarded member has to
+/// WIDEN the integer range for the sabotage to be visible, which is why this one is a
+/// bare `xsd:decimal` — and that is also the shape that actually occurs in the corpus
+/// (`ore_ont_5964`'s only union is of bare datatypes).
+#[test]
+fn a_union_with_an_unrepresentable_member_drops_whole_rather_than_narrowing() {
+    let widened = format!("DataUnionOf({} xsd:decimal)", interval(10, 15));
+    let c = load(&format!(
+        "Declaration(Class(:A)) Declaration(DataProperty(:p))
+         SubClassOf(:A DataSomeValuesFrom(:p DataOneOf(\"7\"^^xsd:integer)))
+         SubClassOf(:A DataAllValuesFrom(:p {widened}))"
+    ));
+    assert!(
+        c.unsatisfiable_classes().is_empty(),
+        "[10,15] ⊔ xsd:decimal admits 7, so A is satisfiable (Konclude agrees). Keeping \
+         only the representable half would narrow the range to [10,15] and manufacture \
+         a false positive."
+    );
+    assert!(
+        !c.stats().dropped.is_empty(),
+        "the drop must be REPORTED, not silent — that is the difference between this \
+         known miss and the one #42 item 1 closed"
+    );
+}
+
+/// SUBSUMPTION seeding, both directions — the third `IntSet` op, which none of the
+/// clash probes above reach (they all go through `disjoint` / `contains`).
+///
+/// **The position is load-bearing and the obvious choice is VACUOUS.** In an
+/// EXISTENTIAL position a `DataUnionOf` never becomes an interval-set key at all: it is
+/// split into a class-level disjunction before `data_range_dkey` is consulted, so
+/// `∃p.[0,5] ⊑ ∃p.([0,5] ⊔ [10,15])` holds by disjunction introduction and is reported
+/// with this entire fix reverted — verified by sabotage, which is how the first version
+/// of this test was caught testing nothing. A `∀` position is where the told
+/// `DKey ⊑ DKey` edge that `IntSet::subset` seeds is actually consulted.
+///
+/// `∀` is monotone in its filler, so `[0,5] ⊆ [0,5] ⊔ [10,15]` gives `Part ⊑ Whole`. The
+/// converse must NOT be reported: a union is not contained in one of its parts. That
+/// negative half is the FP guard — relaxing `IntSet::subset`'s outer `∀` to an `∃` would
+/// emit the backwards edge and manufacture an unsound subsumption.
+#[test]
+fn a_part_is_subsumed_by_the_union_but_not_the_other_way_round() {
+    let c = load(&format!(
+        "Declaration(Class(:Part)) Declaration(Class(:Whole)) Declaration(DataProperty(:p))
+         EquivalentClasses(:Part DataAllValuesFrom(:p {}))
+         EquivalentClasses(:Whole DataAllValuesFrom(:p {}))",
+        interval(0, 5),
+        gapped_union()
+    ));
+    assert!(
+        c.is_subclass("http://ex.org/Part", "http://ex.org/Whole"),
+        "[0,5] ⊆ [0,5] ⊔ [10,15] and ∀ is monotone in its filler, so Part ⊑ Whole"
+    );
+    assert!(
+        !c.is_subclass("http://ex.org/Whole", "http://ex.org/Part"),
+        "a union is NOT contained in one of its parts — Whole ⊑ Part would be an \
+         unsound subsumption"
+    );
+}

--- a/crates/owl-dl-reasoner/tests/datatype_value_membership.rs
+++ b/crates/owl-dl-reasoner/tests/datatype_value_membership.rs
@@ -1149,11 +1149,30 @@ fn data_union_drop_on_unrecognized_member() {
     );
 }
 
-/// ∀-union is dropped (sound under-approximation): `C ⊑ ∀p.DataUnionOf(...)`
-/// does NOT fire — the axiom drops, so a conflicting ∃ assertion does NOT
-/// produce a clash.  No FP.
+/// **FLIPPED 2026-09-05 — this test was PINNING THE DEFECT, and its own name said so.**
+///
+/// It asserted that `C ⊑ ∀p.DataUnionOf([0,5], [10,15])` alongside `C ⊑ ∃p.[20,25]`
+/// leaves `C` satisfiable, ON THE GROUNDS THAT THE UNION DROPS — a sound
+/// under-approximation, correctly framed at the time. But `20..25` is disjoint from both
+/// components, so **Konclude has always derived `C` unsatisfiable here** (re-verified
+/// 2026-09-05, 1121 bytes of real output). The satisfiable verdict was the MISS, not the
+/// answer, and this test was the thing that would have to change for the miss to close.
+///
+/// #42 item 1's interval-set representation closed it: the union now converts (`dropped`
+/// is empty) and the clash fires. The assertion is inverted rather than deleted, so the
+/// file keeps a record of which verdict moved and why.
+///
+/// Sibling `data_union_drop_on_unrecognized_member` above still asserts a DROP and
+/// still passes — its union carries a `DataComplementOf`, which no interval set can
+/// express, so the all-or-nothing rule correctly declines the whole range. That is the
+/// difference between a representable union and an unrepresentable one, and it is why
+/// only this one flipped.
+///
+/// See [[tests-that-pin-the-bug]]: a fixture chosen for a DEFECT becomes a bug-pin, and
+/// there is no signal until someone fixes the bug. This one surfaced during sabotage
+/// testing of the fix, not from the fix's own suite.
 #[test]
-fn data_union_forall_union_dropped() {
+fn data_union_forall_union_now_clashes() {
     let c = classify(
         r#"    Declaration(Class(:C))
     Declaration(DataProperty(:p))
@@ -1164,11 +1183,12 @@ fn data_union_forall_union_dropped() {
     SubClassOf(:C DataSomeValuesFrom(:p DatatypeRestriction(xsd:integer xsd:minInclusive "20"^^xsd:integer xsd:maxInclusive "25"^^xsd:integer)))
 "#,
     );
-    // ∀-union dropped → no ∀p.DKey filler → no clash with ∃p.[20,25].
-    // C must remain satisfiable.
+    // ∀-union now lowers to an interval-set DKey → [20,25] is disjoint from
+    // [0,5] ⊔ [10,15] → clash. Konclude agrees.
     assert!(
-        !c.unsatisfiable_classes().iter().any(|u| u.ends_with("/C")),
-        "∀p.DataUnionOf should be dropped: C must remain satisfiable"
+        c.unsatisfiable_classes().iter().any(|u| u.ends_with("/C")),
+        "[20,25] is disjoint from [0,5] ⊔ [10,15], so C is unsatisfiable — the verdict \
+         Konclude always gave and this test used to pin the miss of"
     );
 }
 


### PR DESCRIPTION
Closes the residual of #42 item 1: a `DataUnionOf` of `xsd:integer` **INTERVALS** in a `∀`/range position.

## The gap

The enumeration half (`3914b1a`) flattens because `DataOneOf(a) ⊔ DataOneOf(b)` **is** `DataOneOf(a,b)` — a logical identity. A union of intervals has no such single-range form, and the integer `DKey` bucket held exactly ONE `IntegerRange` per key, so `data_range_dkey`'s parser chain matched nothing and the **whole axiom dropped**:

```
∃p.{7} ⊓ ∀p.([0,5] ⊔ [10,15])   → rustdl: satisfiable      Konclude: UNSAT
```

A **silent** miss — `dropped` was empty, the axiom converted fine, the clash was merely never derivable. That is why the canary written for it pinned a gap rather than a verdict.

## The fix

The bucket now holds an `IntSet`, a union of ranges. **The non-regression argument is structural, in two halves:**

- Every op is a **quantified lift** of the scalar `IntegerRange` op — `contains` = `∃`, `disjoint` = `∀∀`, `subset` = `∀∃` — so a one-component set returns exactly the old answer *by construction*. Including the empty range, whose conservative `disjoint` is deliberately NOT "corrected": set semantics would say `∅` is disjoint from everything, and that is a change in the FP direction.
- A one-component set **encodes to the historical untagged IRI, byte-identically**, so every pre-existing key interns to the same `ClassId`. Only genuinely multi-interval keys use the new `iset:` tag. `ore_ont_9347` reads 113 at both arms — the recorded DKey discriminator unmoved.

`contains` and `disjoint` are **exact** (`A ∩ B = ⋃ᵢⱼ aᵢ∩bⱼ`), which they must be: they drive clashes, so the direction of risk is a false POSITIVE. `subset` is the `∀∃` lift, sound in the MISS direction always.

**Integer discreteness is load-bearing and does not transfer.** Normalisation merges components that merely *touch* (`[0,5] ⊔ [6,10] → [0,10]`), valid only because the integers have a successor — which leaves components separated by at least one absent integer and makes `subset` exact on normalised operands too. `xsd:float` / `decimal` / `date` / `dateTime` have no successor; they can merge only *overlapping* components and their `subset` stays genuinely conservative. Those five are a separate piece of reasoning, not a mechanical follow-on.

**Mixed enumeration/interval unions come free and are now exact, not dropped** — on a discrete space `{v}` IS `[v,v]`. That is what makes the all-or-nothing rule affordable rather than restrictive, and all-or-nothing stays load-bearing: keeping the representable half of an unrepresentable union yields a strictly NARROWER range, which in a `∀` position manufactures a clash.

## Two tests were pinning the defect, and only one was labelled

`data_union_of_enumerations.rs`'s scope guard said so in its own doc and is flipped as instructed. `datatype_value_membership.rs::data_union_forall_union_dropped` did **not**: it asserted `C` satisfiable *on the grounds that the union drops*, while Konclude had always called `C` unsatisfiable — the satisfiable verdict was the miss, not the answer. It surfaced during **sabotage testing**, not from this fix's own suite, which is the argument for sabotaging neighbouring files. Flipped, not deleted.

## Evidence — and the corpus is not part of it

Exactly **one** of 1,920 ORE ontologies authors a `DataUnionOf` at all (`ore_ont_5964`, a grep *superset* since the collector is reachable only from that construct), and its only union is `DataUnionOf(xsd:decimal xsd:float xsd:integer xsd:long)` — bare DATATYPES, which the collector correctly declines, leaving all 14 of its drops unchanged. **Corpus reach is provably zero**, so the FP=0 net shows inertness only.

The real evidence is **8 canaries + 9 unit tests**, plus a **Konclude adjudication on 12 probes agreeing 12/12** — gap interiors (`6`, `9`), inclusive boundaries (`5`, `10`), adjacency, unbounded ends, and both mixed-union directions, all on real output (1105 sat / 1121 unsat bytes, not the ~896-byte stub). Konclude *reports* the relation on 5 of the 12, so its silence on the other 7 is a **discriminating control** rather than the under-reporting it is documented to do elsewhere.

**Sabotage: 7 run, 7 caught** — reverting the arm; loosening all-or-nothing; merging across gaps; relaxing `subset`'s outer `∀`; relaxing `disjoint`'s; dropping the singleton byte-identity short-circuit; reordering the arm ahead of the enumeration flattener.

Two honest limits, recorded rather than rounded up:
1. The `disjoint` relaxation is caught by the **unit test only** — every integration canary has a singleton on the `self` side, where the outer `any` and `all` coincide, so the integration surface cannot see it.
2. **The first version of the `subset` canary was vacuous, and sabotage found it.** In an *existential* position a `DataUnionOf` never becomes an interval-set key at all — it is split into a class-level disjunction before `data_range_dkey` is reached — so `∃p.[0,5] ⊑ ∃p.([0,5] ⊔ [10,15])` holds by disjunction introduction and passed with the entire fix reverted. The `∀` position is where the seeded `DKey ⊑ DKey` edge is actually consulted.

## Gates

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- Full suite **1935 passed / 0 failed / 83 ignored** (`--exclude owl-dl-py`: pyo3 cannot link on this host)
- `--ignored` triage clean — all 6 `datatype_completeness` fixtures pass, no third bug-pin
- FP=0 net `./scripts/run-soundness-diff.sh`: **22 passed / 0 failed, 11 fixtures VERIFIED, every closure exact** (galen 27997, notgalen 32739, sio 8904, wine 653, ore-10908 6001, pizza 499, alehif 247, ro 158, ore-15672 142, sulo 51, bibtex 16). Reported as **inertness only**, per this area's standing caveat.
- Both parser-exclusivity matrices extended with the `iset` bucket. The one hand-written off-diagonal exemption (`decoder == "iset" && bucket == "int"`, the singleton byte-identity) is documented; the FP-critical reverse cell (`int` decoder on a two-component `iset:` IRI) is in the grid and asserts `false`. Deleting the `"iset"` arm from the `numeric_oneof` probe alone makes it panic on `unreachable!()` — verified, so that half of the FP check genuinely runs rather than silently skipping, which is the failure mode #72 hit.

## Perf: +2.8% on the worst case, accepted

This widens the element of `seed_bucket`'s O(k²) ordered-pair walk. **The frame that looked right was inert:** the DKey-heavy ontologies this repo names by pair volume (`1833`, `5368`, `2504`, `4141`) are all STRING buckets with near-zero integer literals — 0.90–0.99×, content identical. Selecting on them would have been the documented "`ore_ont_9347` cannot discriminate" trap, one datatype over.

The discriminator is **`ore_ont_15635`** — 58,794 `xsd:integer` literals, k = 7,281 distinct keys, the largest integer bucket in ORE. Min-of-5, interleaved with alternating arm order: **3341 → 3434 ms, +2.8%**, content identical.

`SmallVec<[IntegerRange; 1]>` was tried and **recovers 0%** (3437 ms), which refutes the allocation hypothesis — hence a plain `Vec`, rather than shipping a doc comment claiming a benefit the measurement had just contradicted. The refuted experiment is recorded in the type's docs.

## Still dropped (sound), recorded rather than implied

Unions carrying any member no integer interval set can express — bare datatypes, `DataComplementOf`, other-datatype enumerations — which drop **whole and visibly** (`dropped` non-empty), never narrowed; interval unions over the five dense datatypes; `DataIntersectionOf` in these positions; and qualified data cardinality over a union (`≥3 p.({1} ⊔ {2})`), which takes a different path and which Konclude also does not call unsat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzVE2TSVVMc3n8Wrce65Jg
