### PR TITLE
docs(verify): NO-GO on widening `verify-el` to Horn, and retract the lever that named it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1783,6 +1783,19 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   dropping the conjunctive domain filler (which `role_domains` does silently — its own D10 "Bug B"
   comment says so) leaves `X` with NO EL subsumer, hence in `P`'s own tier. **The discriminating
   control is the ATOMIC filler**, `Domain(r, :P)`, which derives `X ⊑ P` correctly at the default.
+  **`ObjectPropertyRange` HAS THE SAME DEFECT AND IS THE LARGER HALF** — `Range(r, P ⊓ Q)` +
+  `X ⊑ ∃r.B` + `∃r.(B ⊓ P) ⊑ W` misses `X ⊑ W` with the identical signature (`subclass` proves it,
+  `TRUST_SAT=0`/`HYPERTABLEAU=0` do not recover it, `SAME_TIER=1` does), and of the 14 ORE
+  candidates **13 are `Range` against 4 `Domain`**. A fix touching only `role_domains` closes half.
+  **`DisjointClasses(A ⊓ B, C)` — the OTHER hole in the same two-list analysis — is CLEAN**
+  (`D` correctly unsatisfiable): disjointness surfaces as an unsat class, which never enters the
+  tier walk, whereas a domain/range fold needs a positive subsumption derived, which does.
+  **AND A NEAR-MISS WORTH THE READ:** the first `Range` probe used `∃r.⊤` and rustdl returned zero
+  rows on the ATOMIC control too — which reads as a pure-EL miss, i.e. far worse. It is not a
+  defect: `∃r.⊤` lowers to a deliberately subsumer-less ⊤-witness so folding `Range(r)` in cannot
+  destroy the `domain(r)` inference the witness exists for — the documented `topwitness.ofn`
+  DESIGN DECISION. Use a concrete filler, not `⊤`, or the control cannot discriminate. Mirror of
+  [[tests-that-pin-the-bug]], applied to choosing a REPRODUCER rather than a fixture.
   **Filed as #110. Corpus reach MEASURED and it is ZERO**: two-arm run (`RUSTDL_CLASSIFY_SAME_TIER`
   0 vs 1, arm order alternated, triple compared) over the 14 conjunctive-`Domain`/`Range`-filler
   ORE ontologies — **13 IDENTICAL, 0 gained, 0 lost, 1 UNMEASURED** (`ore_ont_10080`, which DNFs SYMMETRICALLY at a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1725,11 +1725,77 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   compute converts 37% of that bucket and **63% is immune** — those are genuinely hard, not
   marginal — buying coverage **18.9% → 21.0%** and finding nothing. Do not spend more compute
   there. **The binding constraint is the FRAGMENT: 1,392 of 1,920 (72.5%) are `unresolved`
-  (off-fragment/refused) against 124 (6.5%) lost to the cap**, so extending `verify-el` past
-  `is_pure_el` to the Horn fragment is the lever, and it is engine-side work. The retry also
+  (off-fragment/refused) against 124 (6.5%) lost to the cap**. The retry also
   *increased* unresolved by 31 — several slow ontologies were off-fragment all along, so part of
   the timeout bucket was never checkable. See
   `docs/benchmarks/2026-09-05-verify-el-cap-is-a-weak-lever.md`.
+  **AND THAT DOC'S OWN RECOMMENDATION — "extend `verify-el` past `is_pure_el` to the Horn
+  fragment" — IS RETRACTED (2026-09-05). The 1,392 is NOT a market.** `verify` reaches
+  `Verified` only with ZERO unresolved axioms (`lib.rs:494-520`), and a two-list comparison of
+  {constructs that make an ontology Horn-but-not-EL} against `eval.rs`'s arms finds that **every
+  one of them is refused**: the six concept-level generators (`∃r⁻`, `∀`, `≥n`, `≤n`, nominal,
+  `Self`) by explicit `Unresolved` arms, the twelve axiom-level ones (`Functional`,
+  `InverseFunctional`, `Reflexive`, `Irreflexive`, `Asymmetric`, `DisjointObjectProperties`,
+  `DisjointUnion`, the five ABox forms) by `unhandled`, the inverse-role role-axiom cases by
+  their own guards — and `SymmetricRole` / `InverseObjectProperties`, which LOOK handled, hold
+  only when the role has **no edges**, i.e. exactly the bare declaration `is_pure_el` already
+  admits. So a widened gate would admit ontologies whose distinguishing axioms are all
+  `Unresolved` and verify them vacuously.
+  **EXACTLY TWO HOLES, and it took reading the arms to find them — both the same mechanism, the
+  EL gate demanding ATOMIC where `eval.rs` accepts any concept it can evaluate, and `CE::And` is
+  one.** (1) `is_el_axiom:2163` requires every `DisjointClasses` member ATOMIC while `eval.rs:342`
+  has no atomicity check, so `DisjointClasses(A ⊓ B, C)` is Horn, non-EL and genuinely `Verified`.
+  (2) `is_el_axiom:2183-2188` requires an atomic `ObjectPropertyDomain`/`Range` filler while
+  `eval.rs:366` checks only non-inverseness, so `Domain(r, P ⊓ Q)` is Horn and reaches a verdict.
+  Measured in `crates/owl-dl-verify/tests/horn_widening_market.rs`. **No third hole:**
+  `SubClassOf`/`EquivalentClasses` recurse into `is_el_concept`, whose accepted set
+  (`Top`/`Atomic`/`Bot`/`And`/`Some(!inverse)`) is IDENTICAL to `eval_concept`'s
+  (`Top`/`Bot`/`Atomic`/`And`/`Some(Named)`) — printed, not eyeballed.
+  **Grep superset ≤8 ontologies for hole 1, ≤14 for hole 2; do NOT add them to 22** — a verdict
+  needs EVERY departure from `is_el_axiom` to be one of the two holes, so each count is a superset
+  of its own conjunct. `ore_ont_10908` is in the 14, is a curated fixture, and classifies at
+  MISSED=0, so the shape does not bite there.
+  **The FP hazard is the other half.** `build_model` reads
+  `owl_dl_saturation::saturate_with_exists_facts` — the EL saturator — while post-D10
+  `saturator_complete_fragment` deliberately routes Horn-not-EL to the HYBRID path. On the
+  ontologies a widened gate admits, the model would come from an engine that is not the one
+  answering the query and is known-incomplete there, so a `Violated` would be an artifact, not a
+  D10 detection. Closing the gap properly means a different model source — an interpretation
+  built from the wedge's Horn fixpoint completion graph — which is a sub-project wanting a spec,
+  with the CB arc as its sizing precedent. **The first draft of this analysis claimed the market
+  was ZERO and carried a `∎`; it was written over five unread `eval.rs` arms and one of them was
+  the hole. Enumerate every arm a universal quantifies over, or do not write the universal.** See
+  `docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md`.
+  **THE SPIKE'S ACTUAL PAYOFF IS A LIVE D10 DEFECT IN `classify`'s TIER WALK, unrelated to
+  `verify-el` (2026-09-05, UNFIXED).** `ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B` entails
+  `X ⊑ P` and `X ⊑ Q`. **`classify --json` returns `direct_subsumptions: []` with
+  `incomplete: false` and `dropped: {}`** under `# mode: hybrid` /
+  `# fragment: Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)`, while
+  **Konclude AND HermiT both derive both pairs** and rustdl's own `subclass X P` answers `yes`.
+  Silent miss, gate certifying complete — the D10 shape.
+  **NOT the calculus, and no subsumption-path flag recovers it** (`TRUST_SAT=0`,
+  `RUSTDL_HYPERTABLEAU=0`, `CLASSIFY_VERIFY_REFUTATIONS=1`, `DOMAIN_ABSORPTION=0` all return zero
+  rows) — **`RUSTDL_CLASSIFY_SAME_TIER=1` recovers both.** It is the documented tier-walk
+  limitation: the walk groups by EL/told subsumer count and never compares same-tier classes, and
+  dropping the conjunctive domain filler (which `role_domains` does silently — its own D10 "Bug B"
+  comment says so) leaves `X` with NO EL subsumer, hence in `P`'s own tier. **The discriminating
+  control is the ATOMIC filler**, `Domain(r, :P)`, which derives `X ⊑ P` correctly at the default.
+  **Filed as #110. Corpus reach MEASURED and it is ZERO**: two-arm run (`RUSTDL_CLASSIFY_SAME_TIER`
+  0 vs 1, arm order alternated, triple compared) over the 14 conjunctive-`Domain`/`Range`-filler
+  ORE ontologies — **12 IDENTICAL, 0 gained, 0 lost, 2 UNMEASURED** (cap, not disagreement — `ore_ont_10080` still
+  DNFs at a 600 s cap sequentially on an idle host in the `=0` arm, so it is out of reach, not a
+  contention artifact). So
+  that flag's corpus-invisible default-OFF justification **stands UNQUALIFIED**; this is a second
+  SYNTHETIC pattern, as `sp11sub` was, and nothing here argues for flipping it. The narrower fix
+  is to stop `role_domains` dropping a conjunctive filler, which would give `X` its EL subsumers
+  and correct the tier as a side effect.
+  **AND THE 1,392 DECOMPOSES — the builder-refusal half is 9 ontologies, not a population.** Full
+  1,920 scan at a 60 s cap: **361 verified / 1,351 refused by the CLI GATE (662 `Horn` + 689
+  `OutOfFragment`) / 9 past the gate and refused by the builder (6 `AxiomsDroppedAtConversion`,
+  3 `BoundTripped`) / 199 timeout / 1 error**. `ChainRangeOutOfProfile`, `LabelNotClosed` and
+  `RunDelta` fire on **ZERO** ORE ontologies, so the "no fragment work needed" lever hiding in
+  that bucket is measured out as well — the "off-fragment/**refused**" slash is 99.3% the first
+  word.
   **A trap worth carrying beyond this crate**, from F4: any oracle comparison that counts `Thing`
   rows reports spurious MISSED on any ontology asserting `⊤ ⊑ C`. This project has been bitten
   once already — 73% of an apparent ~1,795-row gap against Kobayashi-MaRust was the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1782,9 +1782,16 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   control is the ATOMIC filler**, `Domain(r, :P)`, which derives `X ⊑ P` correctly at the default.
   **Filed as #110. Corpus reach MEASURED and it is ZERO**: two-arm run (`RUSTDL_CLASSIFY_SAME_TIER`
   0 vs 1, arm order alternated, triple compared) over the 14 conjunctive-`Domain`/`Range`-filler
-  ORE ontologies — **12 IDENTICAL, 0 gained, 0 lost, 2 UNMEASURED** (cap, not disagreement — `ore_ont_10080` still
-  DNFs at a 600 s cap sequentially on an idle host in the `=0` arm, so it is out of reach, not a
-  contention artifact). So
+  ORE ontologies — **13 IDENTICAL, 0 gained, 0 lost, 1 UNMEASURED** (`ore_ont_10080`, which DNFs SYMMETRICALLY at a
+  600 s cap sequentially on an idle host — 600 s / 601 s, both arms — so it is out of reach, not a
+  contention artifact). **`ore_ont_12451` was nearly recorded as a LOSS and was not one:** at 600 s
+  its `=0` arm finished in 230 s while `=1` hit the cap, a ONE-SIDED timeout, which is the shape
+  that reads as "the flag lost an ontology". At a 1500 s cap with 2 repeats per arm it completes in
+  **777 s / 775 s against 229 s / 228 s — 3.4× slower with all four triples IDENTICAL** (3,733 rows,
+  1 unsat, 0 equiv; the 2-byte size difference is cosmetic). That is a measured instance of the
+  flag's documented ~2× wall cost on this corpus rather than the quoted ore-15672 figure.
+  **A one-sided timeout at a cap is a CANDIDATE loss, not a loss — raise the cap before recording
+  it.** So
   that flag's corpus-invisible default-OFF justification **stands UNQUALIFIED**; this is a second
   SYNTHETIC pattern, as `sp11sub` was, and nothing here argues for flipping it. The narrower fix
   is to stop `role_domains` dropping a conjunctive filler, which would give `X` its EL subsumers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1771,8 +1771,11 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `X ⊑ P` and `X ⊑ Q`. **`classify --json` returns `direct_subsumptions: []` with
   `incomplete: false` and `dropped: {}`** under `# mode: hybrid` /
   `# fragment: Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)`, while
-  **Konclude AND HermiT both derive both pairs** and rustdl's own `subclass X P` answers `yes`.
-  Silent miss, gate certifying complete — the D10 shape.
+  **Konclude, HermiT AND Kobayashi-MaRust all derive both pairs** and rustdl's own `subclass X P`
+  answers `yes`. Silent miss, gate certifying complete — the D10 shape. **KM is the informative
+  peer**: a one-pass CB read-off with NO tier walk, so the same-tier pruning that loses the pair
+  here has no analogue there and the answer falls out of the saturation; both engines report
+  `dropped: 0`, so the gap is entirely in which pairs get COMPARED, not in what is represented.
   **NOT the calculus, and no subsumption-path flag recovers it** (`TRUST_SAT=0`,
   `RUSTDL_HYPERTABLEAU=0`, `CLASSIFY_VERIFY_REFUTATIONS=1`, `DOMAIN_ABSORPTION=0` all return zero
   rows) — **`RUSTDL_CLASSIFY_SAME_TIER=1` recovers both.** It is the documented tier-walk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1751,7 +1751,10 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `SubClassOf`/`EquivalentClasses` recurse into `is_el_concept`, whose accepted set
   (`Top`/`Atomic`/`Bot`/`And`/`Some(!inverse)`) is IDENTICAL to `eval_concept`'s
   (`Top`/`Bot`/`Atomic`/`And`/`Some(Named)`) — printed, not eyeballed.
-  **Grep superset ≤8 ontologies for hole 1, ≤14 for hole 2; do NOT add them to 22** — a verdict
+  **Grep superset ≤8 ontologies for hole 1, ≤27 for hole 2 (NOT ≤14 — that scan's `break` fired
+  after the first axiom body matching a broad construct regex, so an ontology whose FIRST
+  Domain/Range axiom was non-conjunctive was wrongly excluded; two instruments now agree at 27);
+  do NOT add them together** — a verdict
   needs EVERY departure from `is_el_axiom` to be one of the two holes, so each count is a superset
   of its own conjunct. `ore_ont_10908` is in the 14, is a curated fixture, and classifies at
   MISSED=0, so the shape does not bite there.
@@ -1766,8 +1769,21 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   was ZERO and carried a `∎`; it was written over five unread `eval.rs` arms and one of them was
   the hole. Enumerate every arm a universal quantifies over, or do not write the universal.** See
   `docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md`.
-  **THE SPIKE'S ACTUAL PAYOFF IS A LIVE D10 DEFECT IN `classify`'s TIER WALK, unrelated to
-  `verify-el` (2026-09-05, UNFIXED).** `ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B` entails
+  **THE SPIKE'S ACTUAL PAYOFF WAS A LIVE D10 DEFECT IN `classify`, unrelated to `verify-el`
+  (2026-09-05) — FILED AS #110 AND FIXED ON `main` BY #112 (`ed2ab5f`), WITH TWO RESIDUALS THEN
+  FIXED BY #120 (#118, #119). The description below is the PRE-FIX state; read it as the
+  diagnosis, not as current behaviour.**
+  **AND THE MECHANISM ATTRIBUTION BELOW IS HALF WRONG.** It reads as a tier-walk defect; the ROOT
+  cause is that the saturator dropped the conjunctive filler, which left `X` with no EL subsumer
+  and therefore in `P`'s own tier. #112 fixed the ENGINE and the tier problem dissolved — the
+  tier walk was never touched. `RUSTDL_CLASSIFY_SAME_TIER=1` recovering it was a symptom, not a
+  pointer to the fix, and treating it as one cost a wrong corpus measurement (below).
+  **ALSO: the tier-walk diagnosis was NOT novel.** Commit `2341ff8` (2026-07-29, "Bug B") had
+  already recorded it in the doc comment of
+  `crates/owl-dl-reasoner/tests/conjunctive_unsat.rs::domain_conjunctive_filler_derives_subsumptions`,
+  along with an interim mitigation (refuse the filler at the gate, route to hybrid). What was
+  never filed is the residual that mitigation left: the default `classify()` still returned zero
+  rows, and that test passed only via `classify_n2`. `ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B` entails
   `X ⊑ P` and `X ⊑ Q`. **`classify --json` returns `direct_subsumptions: []` with
   `incomplete: false` and `dropped: {}`** under `# mode: hybrid` /
   `# fragment: Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)`, while
@@ -1787,6 +1803,20 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   `X ⊑ ∃r.B` + `∃r.(B ⊓ P) ⊑ W` misses `X ⊑ W` with the identical signature (`subclass` proves it,
   `TRUST_SAT=0`/`HYPERTABLEAU=0` do not recover it, `SAME_TIER=1` does), and of the 14 ORE
   candidates **13 are `Range` against 4 `Domain`**. A fix touching only `role_domains` closes half.
+  (Frame corrected: the superset is **27**, not 14 — see the note above.)
+  **RETRACTION (2026-09-06) — the `ore_ont_4796` "2 entailments gained" recorded below is NOT the
+  fix's effect, and the corpus reward for this class of fix is measured ZERO.** That measurement
+  compared `RUSTDL_CLASSIFY_SAME_TIER=0` vs `=1` **within one binary**, which measures the FLAG,
+  not a code change — the same gain is present in the pre-#112 binary. Two *pinned binaries* over
+  the corrected 27-ontology frame give **45 IDENTICAL / 0 DIFFER / 2 UNMEASURED / 0 lost
+  entailments** and **zero fragment-routing movers across all 1,920**; and `ore_ont_4796` provably
+  cannot be affected, since all four of its conjunctive fillers carry `ObjectComplementOf` (which
+  the decomposition declines) and it is `OutOfFragment` in both arms.
+  **This file already carried the rule that would have caught it**, from the label-cache probe
+  work: *measuring a flag's effect and measuring the ship delta are different questions.* Using
+  the flag as a proxy was legitimate while no fix existed — it was the only way to observe the
+  defect — and stopped being legitimate the moment a real binary was diffable. The figure went
+  zero → non-zero → zero, and only the last was measured the right way.
   **`DisjointClasses(A ⊓ B, C)` — the OTHER hole in the same two-list analysis — is CLEAN**
   (`D` correctly unsatisfiable): disjointness surfaces as an unsat class, which never enters the
   tier walk, whereas a domain/range fold needs a positive subsumption derived, which does.
@@ -1798,7 +1828,7 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   [[tests-that-pin-the-bug]], applied to choosing a REPRODUCER rather than a fixture.
   **Filed as #110. Corpus reach MEASURED and it is ZERO**: two-arm run (`RUSTDL_CLASSIFY_SAME_TIER`
   0 vs 1, arm order alternated, triple compared) over the 14 conjunctive-`Domain`/`Range`-filler
-  ORE ontologies — **13 IDENTICAL, 0 gained, 0 lost, 1 UNMEASURED** (`ore_ont_10080`, which DNFs SYMMETRICALLY at a
+  ORE ontologies — **RETRACTED, see below** — **13 IDENTICAL, 0 gained, 0 lost, 1 UNMEASURED** (`ore_ont_10080`, which DNFs SYMMETRICALLY at a
   600 s cap sequentially on an idle host — 600 s / 601 s, both arms — so it is out of reach, not a
   contention artifact). **`ore_ont_12451` was nearly recorded as a LOSS and was not one:** at 600 s
   its `=0` arm finished in 230 s while `=1` hit the cap, a ONE-SIDED timeout, which is the shape

--- a/crates/owl-dl-verify/tests/horn_widening_market.rs
+++ b/crates/owl-dl-verify/tests/horn_widening_market.rs
@@ -1,0 +1,129 @@
+//! Is there ANY ontology the `verify-el` CLI gate refuses as non-`PureEl`,
+//! that is nonetheless `Horn` AND that this crate can actually check?
+//!
+//! `docs/benchmarks/2026-09-05-verify-el-horn-widening-is-analytically-empty.md`
+//! argues the market is empty: every construct that makes an ontology
+//! Horn-but-not-EL is refused by `eval.rs`, and `verify` reaches `Verified`
+//! only with ZERO unresolved axioms. These tests are the discriminating
+//! probes for that claim — they call `build_model`/`verify` DIRECTLY, which
+//! bypasses `main.rs`'s `analyze_fragment != PureEl` early exit, so they can
+//! observe what the checker would say if the gate were widened.
+//!
+//! They exist because the claim was nearly shipped over four unread
+//! `eval.rs` arms.
+
+use owl_dl_reasoner::FragmentClassification as FC;
+use owl_dl_verify::{Bounds, Verdict};
+
+mod common;
+use common::load;
+
+const HEADER: &str = "Prefix(:=<http://rustdl.test/>)\n\
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n";
+
+fn verdict_of(ofn: &str) -> (FC, Verdict) {
+    let internal = load(ofn);
+    let fragment = owl_dl_reasoner::analyze_fragment(&internal);
+    let verdict = match owl_dl_verify::build_model(&internal, &Bounds::default()) {
+        Err(reason) => Verdict::Unresolved {
+            domain_size: 0,
+            reasons: vec![reason],
+        },
+        Ok((model, build_reasons)) => {
+            let (v, _) = owl_dl_verify::verify(model, &internal, None);
+            assert!(
+                build_reasons.is_empty(),
+                "unexpected build-time refusal: {build_reasons:?}"
+            );
+            v
+        }
+    };
+    (fragment, verdict)
+}
+
+/// A `∀` is the canonical Horn-∖-EL generator, and `eval.rs:87` refuses it.
+/// The verdict must therefore be `Unresolved` — widening the gate to admit
+/// this ontology would buy no coverage.
+#[test]
+fn a_forall_is_horn_but_not_el_and_the_evaluator_refuses_it() {
+    let (fragment, verdict) = verdict_of(&format!(
+        "{HEADER}Ontology(\n\
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(ObjectProperty(:r))\n\
+  SubClassOf(:A ObjectSomeValuesFrom(:r :B))\n\
+  SubClassOf(:A ObjectAllValuesFrom(:r :B))\n)\n"
+    ));
+    assert_ne!(fragment, FC::PureEl, "the CLI gate must refuse this today");
+    assert!(
+        matches!(verdict, Verdict::Unresolved { .. }),
+        "a widened gate must not reach a verdict here, got {verdict:?}"
+    );
+}
+
+/// THE COUNTEREXAMPLE TO "ZERO". `is_el_axiom` requires every
+/// `DisjointClasses` member to be ATOMIC, so a conjunctive member leaves the
+/// EL fragment — but `eval.rs`'s `DisjointClasses` arm has no atomicity check
+/// and `eval_concept` handles `CE::And` without complaint.
+///
+/// If this reports `Verified`, the admissible market is non-empty and the
+/// analytical claim must be stated as "these shapes only", not "zero".
+#[test]
+fn a_conjunctive_disjointclasses_member_is_the_one_admissible_shape() {
+    let (fragment, verdict) = verdict_of(&format!(
+        "{HEADER}Ontology(\n\
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))\n\
+  Declaration(Class(:X)) Declaration(ObjectProperty(:r))\n\
+  SubClassOf(:X ObjectSomeValuesFrom(:r :A))\n\
+  SubClassOf(:A :B)\n\
+  DisjointClasses(ObjectIntersectionOf(:A :B) :C)\n)\n"
+    ));
+    eprintln!("fragment = {fragment:?}\nverdict  = {verdict:?}");
+    assert_ne!(fragment, FC::PureEl, "the CLI gate must refuse this today");
+}
+
+/// THE SECOND HOLE. `is_el_axiom:2183-2188` requires an `ObjectPropertyDomain`
+/// filler to be atomic — the D10 "Bug B" tightening, whose own comment says
+/// the engine's `role_domains` accepts ONLY `Atomic` fillers and **silently
+/// drops** a conjunctive one. `eval.rs:366` checks only that the role is not
+/// inverse, then calls `eval_concept`, which handles `CE::And` fine. So this
+/// shape is `Horn`, non-EL, and reachable by the checker.
+///
+/// # What it reports, and why that is NOT simply a false positive
+///
+/// `build_model` reads the EL saturation closure, which dropped this axiom, so
+/// the model has an `r`-edge whose source is outside `P ⊓ Q` and the checker
+/// reports `Violated`. The obvious reading is "instrument artifact": the gate
+/// correctly routes this ontology to the HYBRID path, so a complaint about the
+/// EL closure says nothing about the engine that answers the query.
+///
+/// **We adjudicated it, and the obvious reading was wrong.** `classify` returns
+/// **zero rows** on this fixture with `incomplete: false` and `dropped: {}`,
+/// while Konclude and `HermiT` both derive `X ⊑ P` and `X ⊑ Q`, and rustdl's own
+/// `subclass` proves `X ⊑ P`. It is a live D10-shaped defect in the hybrid
+/// path, recovered by `RUSTDL_CLASSIFY_SAME_TIER=1` (the tier walk never
+/// compares same-tier classes, and dropping the conjunctive domain leaves `X`
+/// with no EL subsumer, hence in `P`'s own tier). The ATOMIC-filler control
+/// classifies correctly at the default, which is what isolates the conjunctive
+/// filler as the cause.
+///
+/// So the lesson for a widened gate is the one the crate's own doc already
+/// states: a `Violated` built on a mismatched model source is a **LEAD
+/// requiring adjudication**, not a proof — and here the adjudication paid.
+#[test]
+fn a_conjunctive_domain_filler_is_horn_non_el_and_the_checker_reaches_a_verdict() {
+    let (fragment, verdict) = verdict_of(&format!(
+        "{HEADER}Ontology(\n\
+  Declaration(Class(:P)) Declaration(Class(:Q)) Declaration(Class(:X))\n\
+  Declaration(Class(:B)) Declaration(ObjectProperty(:r))\n\
+  SubClassOf(:X ObjectSomeValuesFrom(:r :B))\n\
+  ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))\n)\n"
+    ));
+    assert_eq!(
+        fragment,
+        FC::Horn,
+        "this shape must sit in the widening's candidate population"
+    );
+    assert!(
+        !matches!(verdict, Verdict::Unresolved { .. }),
+        "the checker must REACH a verdict here — that is what makes this a hole, got {verdict:?}"
+    );
+}

--- a/docs/benchmarks/2026-09-05-verify-el-cap-is-a-weak-lever.md
+++ b/docs/benchmarks/2026-09-05-verify-el-cap-is-a-weak-lever.md
@@ -58,6 +58,14 @@ statement can be made at all, since before #87 every `Violated` it produced was 
 
 ## Recommendation
 
-Stop raising the cap. If `verify-el` coverage is worth increasing, the lever is the
-**fragment restriction** — 72.5% of the corpus is refused before checking begins, against
-6.5% lost to the cap. Per-ontology rows: `2026-09-05-verify-el-timeout-retry.tsv`.
+Stop raising the cap. Per-ontology rows: `2026-09-05-verify-el-timeout-retry.tsv`.
+
+> **RETRACTED THE SAME DAY — the second half of this recommendation was wrong.** It said the
+> lever is the fragment restriction, since 72.5% of the corpus is refused before checking begins
+> against 6.5% lost to the cap. **The 72.5% is not a market.** `verify` reaches `Verified` only
+> with zero unresolved axioms, and every construct that makes an ontology Horn-but-not-EL is
+> refused by `eval.rs` — except one (a non-atomic `DisjointClasses` member). A widened gate would
+> admit ontologies whose distinguishing axioms are all `Unresolved` and verify them vacuously,
+> while `build_model`'s EL-saturator model source would make any `Violated` there an artifact.
+> See `2026-09-05-verify-el-horn-widening-market.md`. **A count of refusals is not a count of
+> recoverable cases** — that inference is what this file got wrong.

--- a/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
+++ b/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
@@ -108,7 +108,10 @@ the same test file reports `fragment = Horn`, `verdict = Violated`.
 So the market is **non-empty**, and the honest form of the claim is the one stated above: two
 shapes, not zero, and not 1,392.
 
-**Corpus reach, by grep SUPERSET: ≤8 ontologies for hole 1, ≤14 for hole 2.** Eight carry a
+**Corpus reach, by grep SUPERSET: ≤8 ontologies for hole 1, ≤27 for hole 2.** (An earlier draft
+said ≤14; that scan's `break` fired after the first axiom body matching a broad construct regex,
+so an ontology whose FIRST Domain/Range axiom was non-conjunctive was wrongly excluded. Two
+instruments now agree at 27.) Eight carry a
 `DisjointClasses` with a non-atomic member (a same-line grep and a whitespace-insensitive
 balanced-paren scan agree at 8); fourteen carry a conjunctive `ObjectPropertyDomain`/`Range`
 filler (4 domain, 13 range, union 14).
@@ -244,7 +247,8 @@ evaluator could judge if it stopped refusing them.
 ## The `RUSTDL_CLASSIFY_SAME_TIER` corpus question is now answered: 0 of 12
 
 Two-arm run over the 14 conjunctive-filler candidates, `RUSTDL_CLASSIFY_SAME_TIER` `0` vs `1`,
-arm order alternated, comparing (rows, unsat, equivalence groups): **13 IDENTICAL, 0 gained, 0
+arm order alternated, comparing (rows, unsat, equivalence groups) — **THE GAIN BELOW IS RETRACTED;
+see the note at the end of this section** — **13 IDENTICAL, 0 gained, 0
 lost, 1 UNMEASURED.** The unmeasured one is `ore_ont_10080`, which re-run sequentially on an IDLE
 host still DNFs at a **600 s** cap in **both** arms (600 s / 601 s) — symmetric, so genuinely out
 of reach rather than a contention artifact.
@@ -270,3 +274,21 @@ not a loss; raise the cap before recording it.**
 So the flag's **corpus-invisible default-OFF justification stands unqualified**. The defect filed
 as #110 is a second *synthetic* pattern, exactly as `sp11sub` was, and nothing here argues for
 flipping the flag.
+
+## RETRACTION (2026-09-06): the `ore_ont_4796` gain was the FLAG's effect, not a fix's
+
+The two-arm run above compared `RUSTDL_CLASSIFY_SAME_TIER=0` vs `=1` **within one binary**, which
+measures the flag rather than a code change. Once #110 was actually fixed (on `main`, by #112),
+two *pinned binaries* over the corrected 27-ontology frame gave **45 IDENTICAL / 0 DIFFER /
+2 UNMEASURED / 0 lost entailments**, with **zero fragment-routing movers across all 1,920** — and
+`ore_ont_4796` provably cannot be affected, since all four of its conjunctive fillers carry
+`ObjectComplementOf`, which the decomposition declines, and it measures `OutOfFragment` in both
+arms.
+
+**Corpus reward for this class of fix is ZERO.** The evidence for such a fix is peer adjudication
+and canaries, not the corpus; an FP=0 net's green here is inertness.
+
+The transferable rule was already in `CLAUDE.md` from the label-cache probe work: *measuring a
+flag's effect and measuring the ship delta are different questions.* Using the flag as a proxy was
+legitimate while no fix existed — it was the only way to observe the defect — and stopped being
+legitimate the moment there was a real binary to diff.

--- a/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
+++ b/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
@@ -1,0 +1,245 @@
+# Widening `verify-el` past `is_pure_el` to Horn buys TWO shapes — do not build it
+
+`2026-09-05-verify-el-cap-is-a-weak-lever.md` closed by naming the fragment as the binding
+constraint (**1,392 of 1,920 unresolved, 72.5%**, against 124 lost to the cap) and recommending
+"extending `verify-el` past `is_pure_el` to the Horn fragment" as the lever.
+
+**That recommendation is retracted here.** The market is not the 1,392 `unresolved` count, nor
+anything close to it: **all but TWO structural shapes** are refused by the evaluator regardless of
+what the gate does, and the argument is a two-list comparison that takes minutes, not a census.
+
+**It also turned up a live, peer-confirmed engine defect** — see the last section. That was
+incidental to the scoping and is the more valuable half of the day.
+
+## The claim
+
+Widening the CLI gate at `crates/owl-dl-cli/src/main.rs:2558` from `PureEl` to `PureEl | Horn`
+can reach a verdict **only** on an ontology whose sole departures from `is_el_axiom` are
+**non-atomic `DisjointClasses` members** and **non-atomic `ObjectPropertyDomain` / `Range`
+fillers**. Every other route out of EL that stays Horn is refused by `eval.rs`, and one refusal
+sinks the whole verdict.
+
+Both holes are the same mechanism: the EL gate demands an **atomic** concept in a position where
+`eval.rs` accepts anything it can evaluate, and `CE::And` is something it can evaluate.
+
+> **An earlier draft of this file claimed the market was ZERO and carried a `∎`.** That claim was
+> written over five unread `eval.rs` arms, and **two** of them were holes. It was caught by
+> reading the arms, not by any test — which is why all 25 `Axiom` variants are now enumerated
+> rather than summarised.
+
+## The proof
+
+Three facts compose.
+
+**(1) `Verified` requires ZERO unresolved axioms.** `verify` (`crates/owl-dl-verify/src/lib.rs:494-520`)
+returns `Violated` if any violation exists, then `Unresolved` if any `unresolved` reason exists,
+and only reaches `Verified` when both lists are empty. One refused axiom sinks the whole verdict.
+
+**(2) Every construct that makes an ontology Horn-but-not-EL is refused by the evaluator.**
+`Horn-but-not-EL` means `is_el_axiom` (`classify.rs:2143-2195`) says no while
+`clausify_with_stats` reports `disjunctive == 0 && deferred == 0`. Enumerating the generators
+against `eval.rs`:
+
+| generator of Horn ∖ EL | source | `eval.rs` |
+|---|---|---|
+| `∃r⁻.C` | `is_el_concept` requires `!role.is_inverse()` | `Unresolved("Some(Inverse)")` :82 |
+| `∀r.C` | `_ => false` | `Unresolved("All")` :87 |
+| `≥n r.C` | `_ => false` | `Unresolved("Min")` :88 |
+| `≤n r.C` | `_ => false` | `Unresolved("Max")` :89 |
+| `{a}` | `_ => false` | `Unresolved("Nominal")` :83 |
+| `Self(r)` | `_ => false` | `Unresolved("SelfRestriction")` :84 |
+| `FunctionalRole` | axiom `_ => false` | `unhandled` :566 |
+| `InverseFunctionalRole` | axiom `_ => false` | `unhandled` :567 |
+| `ReflexiveRole` | axiom `_ => false` | `unhandled` :564 |
+| `IrreflexiveRole` | axiom `_ => false` | `unhandled` :565 |
+| `AsymmetricRole` | axiom `_ => false` | `unhandled` :563 |
+| `DisjointObjectProperties` | axiom `_ => false` | `unhandled` :562 |
+| `DisjointUnion` | axiom `_ => false` | `unhandled` :561 |
+| `ClassAssertion` / `ObjectPropertyAssertion` / `NegativeOPA` / `SameIndividual` / `DifferentIndividuals` | axiom `_ => false` | `unhandled` :568-574 |
+
+`¬C` and `⊔` are absent from this table on purpose: they clausify DISJUNCTIVE, so they generate
+`OutOfFragment`, not `Horn`. They are refused too, but they are not part of the widening's market.
+
+The remaining ways `is_el_axiom` says no are role-shaped, and `eval.rs` refuses each of them at
+exactly the sub-case that makes it non-EL — verified by reading the arms, not inferred:
+
+| generator of Horn ∖ EL | `is_el_axiom` | `eval.rs` |
+|---|---|---|
+| inverse `sub`/`sup` in `SubObjectPropertyOf` | :2169 requires `!r.is_inverse()` | `unhandled("SubObjectPropertyOf(Role, Inverse)")` :425 |
+| a chain with an inverse leg | :2170-2174 | `unhandled("SubObjectPropertyOf(Chain, Inverse)")` :448 |
+| a chain of length ≠ 2 | :2170-2174 | `unhandled("SubObjectPropertyOf(Chain, len != 2)")` :445 |
+| inverse member of `EquivalentObjectProperties` | :2175 | `unhandled("EquivalentObjectProperties(Inverse)")` :474 |
+| inverse `TransitiveRole` | :2176 | `unhandled("TransitiveRole(Inverse)")` :500 |
+| inverse role in `ObjectPropertyDomain` / `Range` | :2183-2188 | `Unresolved("ObjectPropertyDomain(Inverse)")` :367, `Range` :393 |
+
+**(3) The two arms that LOOK like exceptions are guarded on exactly the case that matters.**
+`SymmetricRole` (:527) and `InverseObjectProperties` (:543) are the only Horn ∖ EL role axioms
+`eval.rs` has arms for — and both return `Holds` **only when the role has no edges**, otherwise
+`Unresolved(GuardedRoleHasEdges)`. An edge-free symmetric/inverse declaration is precisely the
+*bare declaration* that `RUSTDL_FRAGMENT_BARE_DECL` already admits to `is_pure_el`. The moment the
+role is genuinely read — the only way it pushes an ontology out of EL — the guard fires.
+
+## The two counterexamples — measured, not argued
+
+### Hole 1 — a non-atomic `DisjointClasses` member
+
+`is_el_axiom:2163` requires every `DisjointClasses` member to be
+**atomic**, so `DisjointClasses(ObjectIntersectionOf(A B), C)` leaves the EL fragment. It
+clausifies Horn (`A(x) ∧ B(x) ∧ C(x) → ⊥`, no disjunctive head). And `eval.rs:342`'s
+`DisjointClasses` arm has **no atomicity check at all** — it calls `eval_concept` on each member,
+and `CE::And` is handled at :43 without complaint.
+
+`crates/owl-dl-verify/tests/horn_widening_market.rs` calls `build_model`/`verify` directly,
+bypassing the CLI gate, and reports on that shape:
+
+```
+fragment = Horn
+verdict  = Verified { axioms_checked: 8, domain_size: 4 }
+```
+
+### Hole 2 — a non-atomic `ObjectPropertyDomain` / `Range` filler
+
+`is_el_axiom:2183-2188` requires an atomic (or `⊤`/`⊥`) filler — the D10 "Bug B" tightening, whose
+own comment records that the engine's `role_domains` accepts **only** `Atomic` fillers and
+silently drops a conjunctive one. `eval.rs:366` checks only that the role is not inverse, then
+calls `eval_concept`. So `ObjectPropertyDomain(r, P ⊓ Q)` is Horn, non-EL, and reachable —
+the same test file reports `fragment = Horn`, `verdict = Violated`.
+
+So the market is **non-empty**, and the honest form of the claim is the one stated above: two
+shapes, not zero, and not 1,392.
+
+**Corpus reach, by grep SUPERSET: ≤8 ontologies for hole 1, ≤14 for hole 2.** Eight carry a
+`DisjointClasses` with a non-atomic member (a same-line grep and a whitespace-insensitive
+balanced-paren scan agree at 8); fourteen carry a conjunctive `ObjectPropertyDomain`/`Range`
+filler (4 domain, 13 range, union 14).
+
+**Do not add these to 22.** An ontology reaches a verdict only if **every** departure from
+`is_el_axiom` is one of the two holes, so each count is a superset of its own conjunct and the
+real market is smaller than either — a member of the 14 that also contains a single `∀` anywhere
+is refused on the `∀`. `ore_ont_10908` is the demonstration: it is in the 14, it is a curated
+corpus fixture, and it classifies at MISSED=0 against its Konclude oracle, so the shape does not
+bite there. For comparison, the CB arc was deferred at a market of 16 *measured by gate*, not by
+grep.
+
+## The model source is mismatched, and that is what a `Violated` here would mean
+
+Suppose someone "fixed" the guard so a read symmetric role could be checked. `build_model`
+(`lib.rs:324-328`) constructs its model from `owl_dl_saturation::saturate_with_exists_facts` —
+the **EL saturator**, which has no symmetry and no inverse rule at all (a grep of
+`crates/owl-dl-saturation/src/` for `SymmetricRole` / `InverseObjectProperties` returns
+**nothing**, confirming the note in CLAUDE.md's `BareRoleDecls` doc). The model would therefore be
+missing exactly the backward edges the symmetric axiom asserts, and the check would report
+`Violated`, and it would say nothing about the engine that answers the query — because
+`saturator_complete_fragment` routes this ontology to the HYBRID path, not the saturator.
+That is a **LEAD requiring adjudication**, which is exactly what the crate's own design spec
+says a violation is until spurious violations are proven zero.
+
+The same holds structurally for the whole widening: post-D10, `saturator_complete_fragment`
+deliberately routes Horn-not-EL away from the saturator to the hybrid path. On the ontologies a
+widened gate would admit, `build_model` would be reading a closure from an engine that is **not
+the one answering the query** and is known-incomplete there. A `Violated` from that is not a D10
+detection — D10 is "the gate certifies complete while the engine drops the axiom", and here the
+gate correctly declines.
+
+**Closing the gap properly means a different model source** — building the interpretation from
+the wedge's Horn fixpoint completion graph rather than a subsumer closure. That is a sub-project
+wanting its own spec, not a gate relaxation, and its precedent is the CB arc: real work went in
+before the market was sized, and it reached 16 ontologies and was deferred.
+
+## Method note
+
+The two-list comparison is a **read**, not a sweep: three files, minutes. It was run *before* any
+1,920-ontology census, on the advice that a constraint which can bound an arc analytically should
+be checked before compute is spent. Had the census run first it would have produced a Horn count —
+a number that looks like a market and, per the table above, is not one.
+
+But the read is only as good as the arms actually read. The first draft's `∎` covered fourteen
+arms and skipped five; one of the five was the hole. **Enumerate every arm the claim quantifies
+over, or do not write a universal.**
+
+## THE VALUABLE PART: adjudicating hole 2 found a live D10 defect
+
+Hole 2's `Violated` looked like an instrument artifact. It was adjudicated anyway, on the crate's
+own rule that a violation is a lead. It is a **real, silent, peer-confirmed engine defect**.
+
+Fixture (`ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B`; `X ⊑ P` and `X ⊑ Q` are entailed):
+
+| | verdict |
+|---|---|
+| **rustdl `classify --json`** | **`direct_subsumptions: []`**, `incomplete: false`, `dropped: {}` |
+| banner | `# mode: hybrid`, `# fragment: Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)` |
+| Konclude v0.7.0-1138 | `X ⊑ P`, `X ⊑ Q` (1,880 bytes — not the 896-byte failure stub) |
+| HermiT 1.4.3 | `X ⊑ P`, `X ⊑ Q` |
+| rustdl `subclass X P` | **`yes`** |
+
+The D10 shape exactly: the gate certifies the fragment complete, the engine drops the axiom, and
+the answer is reported with `incomplete: false`. `dropped` is empty, so it is a SILENT miss, not
+a degradation.
+
+**Root-caused, and it is NOT the calculus.** `subclass` proves the pair, and no flag on the
+subsumption path recovers it — `RUSTDL_HYPERTABLEAU_TRUST_SAT=0`, `RUSTDL_HYPERTABLEAU=0`,
+`RUSTDL_CLASSIFY_VERIFY_REFUTATIONS=1` and `RUSTDL_DOMAIN_ABSORPTION=0` all still return zero
+rows. **`RUSTDL_CLASSIFY_SAME_TIER=1` recovers both.** This is the documented tier-walk
+limitation: the walk groups classes by EL/told subsumer count and never compares same-tier
+classes. Dropping the conjunctive domain leaves `X` with **no** EL subsumer, so it lands in the
+same tier as `P` and `Q` and is never compared against them.
+
+**The discriminating control is the atomic filler.** `ObjectPropertyDomain(r, :P)` derives
+`X ⊑ P` correctly at the default. So the cause is the conjunctive filler, not the domain
+mechanism, and not the fixture's shape in general.
+
+**What this does and does not say about `RUSTDL_CLASSIFY_SAME_TIER`.** That flag ships OFF partly
+because it is *corpus-invisible* — "the pattern occurs only in the `sp11sub` synthetic". This is a
+**second synthetic pattern** it closes, arrived at independently from the `verify-el` direction.
+**Its corpus reach was then MEASURED and it is ZERO** — see the two-arm run at the end of this
+file. So the flag's corpus-invisible justification stands **unqualified**, and nothing here argues
+for flipping it: its ~2× wall cost is unchanged, and the narrower fix is to make the tier
+assignment aware of a domain/range filler the saturator drops, or to stop dropping it.
+
+**The defect is independent of the widening.** It lives in `classify`'s tier walk, not in
+`verify-el`; it would have been findable from the classification side at any time. The spike is
+what happened to point at the shape, not an instrument that detected it — `verify-el` cannot even
+run on this ontology today.
+
+**No third hole.** `SubClassOf` / `EquivalentClasses` recurse into `is_el_concept`, which is where
+the same atomic-vs-`And` asymmetry could have hidden one. Printed rather than eyeballed:
+`eval_concept` accepts exactly `Top`, `Bot`, `Atomic`, `And`, `Some(Role::Named)` (:41-80) and
+`is_el_concept` accepts exactly `Top`/`Atomic`/`Bot`, `And`, `Some(!is_inverse)` (:2207-2210) —
+identical sets, no guard on either side the other lacks.
+
+## THE FULL 1,920 DECOMPOSITION — the builder-refusal half is 9 ontologies, not a population
+
+The `unresolved` bucket was suspected of hiding a second, engine-change-free lever: the
+`UnresolvedReason` variants `ChainRangeOutOfProfile` / `LabelNotClosed` / `BoundTripped` /
+`RunDelta` are **builder** refusals that fire on ontologies which ARE `is_pure_el`, so that
+population would need no fragment work at all. Measured over all 1,920 at a 60 s cap (pinned
+binary, first line for the gate refusals, full captured stdout for the builder reasons):
+
+| bucket | count |
+|---|---:|
+| `verified` (exit 0) | 361 |
+| **refused by the CLI GATE** (`analyze_fragment != PureEl`) | **1,351** — 662 `Horn`, 689 `OutOfFragment` |
+| **passed the gate, refused by the builder/evaluator** | **9** |
+| timeout at 60 s — UNMEASURED | 199 |
+| I/O or parse error | 1 |
+
+**The builder-refusal half is 9 ontologies** — 6 `AxiomsDroppedAtConversion` and 3
+`BoundTripped`. `ChainRangeOutOfProfile`, `LabelNotClosed` and `RunDelta` fire on **zero** ORE
+ontologies. So that lever is measured out too, and the "off-fragment/**refused**" slash in the
+72.5% headline is 99.3% the first word.
+
+**662 Horn is a real population and still not a market**, which is the point of the two-list
+comparison above: the constraint is not how many ontologies the gate refuses, it is how many the
+evaluator could judge if it stopped refusing them.
+
+## The `RUSTDL_CLASSIFY_SAME_TIER` corpus question is now answered: 0 of 12
+
+Two-arm run over the 14 conjunctive-filler candidates, `RUSTDL_CLASSIFY_SAME_TIER` `0` vs `1`,
+arm order alternated, comparing (rows, unsat, equivalence groups): **12 IDENTICAL, 0 gained, 0
+lost, 2 UNMEASURED** (`ore_ont_10080`, `ore_ont_12451` — cap, not disagreement; `ore_ont_10080`
+re-run sequentially on an IDLE host still DNFs at a **600 s** cap in the `=0` arm, so it is
+genuinely out of reach rather than a contention artifact).
+
+So the flag's **corpus-invisible default-OFF justification stands unqualified**. The defect filed
+as #110 is a second *synthetic* pattern, exactly as `sp11sub` was, and nothing here argues for
+flipping the flag.

--- a/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
+++ b/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
@@ -171,6 +171,7 @@ Fixture (`ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B`; `X ⊑ P` and `X �
 | Konclude v0.7.0-1138 | `X ⊑ P`, `X ⊑ Q` (1,880 bytes — not the 896-byte failure stub) |
 | HermiT 1.4.3 | `X ⊑ P`, `X ⊑ Q` |
 | rustdl `subclass X P` | **`yes`** |
+| Kobayashi-MaRust (Sequoia-CB, `c6ced84`) | `X ⊑ P`, `X ⊑ Q`, `dropped: 0` |
 
 The D10 shape exactly: the gate certifies the fragment complete, the engine drops the axiom, and
 the answer is reported with `incomplete: false`. `dropped` is empty, so it is a SILENT miss, not
@@ -185,8 +186,16 @@ classes. Dropping the conjunctive domain leaves `X` with **no** EL subsumer, so 
 same tier as `P` and `Q` and is never compared against them.
 
 **The discriminating control is the atomic filler.** `ObjectPropertyDomain(r, :P)` derives
-`X ⊑ P` correctly at the default. So the cause is the conjunctive filler, not the domain
-mechanism, and not the fixture's shape in general.
+`X ⊑ P` correctly at the default — in rustdl and in all three peers. So the cause is the
+conjunctive filler, not the domain mechanism, and not the fixture's shape in general.
+
+**KM is worth more than a third vote.** It is a one-pass consequence-based read-off with **no
+tier walk**, so the pruning that loses the pair here — group by EL/told subsumer count, never
+compare same-tier — has no analogue in that architecture and the answer falls out of the
+saturation directly. Together with rustdl's own `subclass` proving the pair, that is good
+evidence the defect is in this orchestration rather than intrinsic to the shape. Both engines
+also report `dropped: 0`, so the axiom is represented in both; the gap is entirely in which
+pairs get compared.
 
 **What this does and does not say about `RUSTDL_CLASSIFY_SAME_TIER`.** That flag ships OFF partly
 because it is *corpus-invisible* — "the pattern occurs only in the `sp11sub` synthetic". This is a

--- a/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
+++ b/docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
@@ -235,10 +235,28 @@ evaluator could judge if it stopped refusing them.
 ## The `RUSTDL_CLASSIFY_SAME_TIER` corpus question is now answered: 0 of 12
 
 Two-arm run over the 14 conjunctive-filler candidates, `RUSTDL_CLASSIFY_SAME_TIER` `0` vs `1`,
-arm order alternated, comparing (rows, unsat, equivalence groups): **12 IDENTICAL, 0 gained, 0
-lost, 2 UNMEASURED** (`ore_ont_10080`, `ore_ont_12451` — cap, not disagreement; `ore_ont_10080`
-re-run sequentially on an IDLE host still DNFs at a **600 s** cap in the `=0` arm, so it is
-genuinely out of reach rather than a contention artifact).
+arm order alternated, comparing (rows, unsat, equivalence groups): **13 IDENTICAL, 0 gained, 0
+lost, 1 UNMEASURED.** The unmeasured one is `ore_ont_10080`, which re-run sequentially on an IDLE
+host still DNFs at a **600 s** cap in **both** arms (600 s / 601 s) — symmetric, so genuinely out
+of reach rather than a contention artifact.
+
+**`ore_ont_12451` was nearly recorded as a LOSS, and raising the cap is what stopped that.** At
+600 s idle its `=0` arm completed in 230 s while `=1` hit the cap — a ONE-SIDED timeout, exactly
+the shape that reads as "the flag lost an ontology". Re-run at a 1500 s cap, 2 repeats per arm,
+sequential and idle:
+
+| arm | wall | rows | unsat | equiv |
+|---|---:|---:|---:|---:|
+| `=0` run 1 | 229 s | 3,733 | 1 | 0 |
+| `=0` run 2 | 228 s | 3,733 | 1 | 0 |
+| `=1` run 1 | **777 s** | 3,733 | 1 | 0 |
+| `=1` run 2 | **775 s** | 3,733 | 1 | 0 |
+
+All four triples **identical**; the 2-byte output-size difference is cosmetic. So it is not a
+loss — it is **3.4× slower with the same answer**, a concrete and reproducible instance of
+`RUSTDL_CLASSIFY_SAME_TIER`'s documented ~2× wall cost, measured on this corpus rather than
+quoted from the recorded ore-15672 figure. **A one-sided timeout at a cap is a CANDIDATE loss,
+not a loss; raise the cap before recording it.**
 
 So the flag's **corpus-invisible default-OFF justification stands unqualified**. The defect filed
 as #110 is a second *synthetic* pattern, exactly as `sp11sub` was, and nothing here argues for

--- a/docs/superpowers/plans/2026-09-06-conjunctive-domain-range-filler-110.md
+++ b/docs/superpowers/plans/2026-09-06-conjunctive-domain-range-filler-110.md
@@ -10,6 +10,27 @@
 
 **Spec:** `docs/superpowers/plans/2026-09-06-d10-arc-roadmap.md` § WS1, and issue #110.
 
+## A scope decision this plan makes CONSCIOUSLY: the GCI sibling (#114)
+
+`SubClassOf(ObjectSomeValuesFrom(:r owl:Thing), C)` is the GCI spelling of `Domain(:r, C)`. With a
+non-atomic `C` it is dropped by `atomic_operands_on_right` (`owl-dl-saturation/src/lib.rs:4924`,
+reached from `:4197`), while `is_el_concept` admits it — and that ontology is certified
+**`pure-EL`**, a stronger claim than #110's `Horn`. Confirmed against Konclude and KM; filed as
+**#114**.
+
+**This plan does NOT fix #114.** It fixes the `ObjectPropertyDomain`/`Range` *axiom variants*.
+That is a deliberate scope line, not an oversight, and the reason to draw it here is that #114
+sits on the `SubClassOf` lowering path with its own consumers and its own gate arm
+(`is_el_concept`), so folding it in would double the change and its blast radius.
+
+**But it qualifies this plan's central thesis, and the qualification must travel with it.** "One
+shared function, therefore no drift" is true only for the two axiom variants. The same semantic
+construct already has **three** other decomposers in tree — `atomic_operands_on_right`
+(`lib.rs:4924`), the inline `And` loop in `abox_saturation.rs:469-477`, and the provenance mirror
+(`lib.rs:3150`) — and this plan adds a fourth. `atomic_operands_on_right` is the natural thing to
+unify with `decompose_role_filler`: it is the same function minus the completeness flag. Task 5
+must state which of the four now share a call site and which do not.
+
 ## Global Constraints
 
 - **`RUSTUP_TOOLCHAIN=stable`** for every build/test; a failed build silently reuses a stale `target/release/` binary.
@@ -95,9 +116,12 @@ fn conjunctive_range_filler_derives_every_conjunct() {
         "{DECLS}
          SubClassOf(:X ObjectSomeValuesFrom(:r :B))
          ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))
-         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)"
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :Q)) :S)"
     );
-    assert!(entails(&body, "X", "W"), "X ⊑ W via the folded range");
+    // BOTH conjuncts, or a sabotage that pushes only the lowest-id one passes.
+    assert!(entails(&body, "X", "W"), "X ⊑ W via the P side of the folded range");
+    assert!(entails(&body, "X", "S"), "X ⊑ S via the Q side of the folded range");
 }
 
 /// CONTROL that must keep passing: the atomic filler was never broken.
@@ -196,9 +220,15 @@ Place it immediately above `collect_el_rules`:
 /// `abox_saturation_inconsistent`.
 ///
 /// `Bot` returns `false` **without** pushing: `Domain(r, ⊥)` is handled earlier
-/// by `poisoned_roles`, and a `Bot` nested inside a conjunction (`P ⊓ ⊥ ≡ ⊥`)
-/// means the whole role is poisoned — which this function does not model, so it
-/// declines and the gates route the ontology to the hybrid path.
+/// by `poisoned_roles`, so this function never sees it on the engine path;
+/// `is_processed_role_filler` re-admits it explicitly for the gates.
+///
+/// **Nested `⊥`/`⊤` are UNCONSTRUCTIBLE, so those arms are defensive, not live.**
+/// `ConceptPool::and` collapses `And([P, ⊥])` to `⊥` and drops `⊤`
+/// (`ir.rs:367-390`), `intern_raw` is private, and `convert.rs`/`normalize.rs`
+/// build conjunctions only through `.and(`. So `P ⊓ ⊥` reaches the engine as a
+/// bare `⊥` and correctly poisons the role — a STRONGER outcome than this
+/// function would give. Do not describe that path as if it executes.
 pub fn decompose_role_filler(
     c: ConceptId,
     pool: &ConceptPool,
@@ -292,17 +322,26 @@ In that file's `mod tests`, using this crate's real `ConceptPool` API
         assert_eq!(sink.len(), 1, "the atomic conjunct is still pushed");
     }
 
-    /// ORDER-INDEPENDENCE, and it is what sabotage #5 (short-circuiting the `And`
-    /// loop) is caught by: with the non-decomposable conjunct FIRST, a
-    /// short-circuiting loop would push nothing.
+    /// ORDER-INDEPENDENCE, and what sabotage #5 (short-circuiting the `And` loop)
+    /// is caught by.
+    ///
+    /// **`ConceptPool::and` SORTS its operands by `ConceptId`** (`ir.rs:385-386`,
+    /// `sort_unstable` + `dedup`), so argument order at the call site is NOT the
+    /// order the loop sees — INTERN order is. Interning `p` first therefore makes
+    /// `pool.and([or, p])` intern to the same `And([p, or])` as the previous test,
+    /// where a short-circuiting loop still pushes `p` and the test passes
+    /// VACUOUSLY. Intern the disjunction FIRST so its id is lower and it is
+    /// visited first.
     #[test]
-    fn decompose_does_not_short_circuit_when_the_bad_conjunct_comes_first() {
+    fn decompose_does_not_short_circuit_when_the_bad_conjunct_sorts_first() {
         let mut pool = ConceptPool::default();
-        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        // Intern order is what matters: `or` must get a LOWER id than `p`.
         let q = pool.atomic(owl_dl_core::ClassId::new(1));
         let r = pool.atomic(owl_dl_core::ClassId::new(2));
         let or = pool.or([q, r]);
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
         let and = pool.and([or, p]);
+        assert!(or < p, "guard: the fixture is only meaningful if `or` sorts first");
         let mut sink = Vec::new();
         assert!(!decompose_role_filler(and, &pool, &mut sink));
         assert_eq!(sink.len(), 1, "the atomic conjunct is pushed regardless of order");
@@ -466,7 +505,28 @@ cargo test -p owl-dl-reasoner --test conjunctive_domain_range_filler
 
 Expected: `test result: ok. 9 passed; 0 failed`.
 
-- [ ] **Step 5: Run the flag-default and fragment guards**
+- [ ] **Step 5: Retarget the test that PINS this bug**
+
+`crates/owl-dl-verify/tests/horn_widening_market.rs:113` —
+`a_conjunctive_domain_filler_is_horn_non_el_and_the_checker_reaches_a_verdict` asserts
+`fragment == FC::Horn` on **exactly this fixture**. After Step 3 it is `PureEl` and the test
+fails. It is not wrong; it recorded the market analysis while the defect was live, and the defect
+was its vehicle — the `tests-that-pin-the-bug` pattern (roadmap S10).
+
+Retarget it to a shape that stays Horn for a reason that is a DESIGN DECISION rather than a
+defect: keep the assertion but change the filler to `ObjectUnionOf(:P :Q)`, which is
+non-decomposable by construction and must never be admitted. Update the doc comment to say the
+conjunctive case moved to pure-EL when #110 was fixed, and why that does not weaken the market
+analysis (a `Verified` verdict there is now reachable through the fast path, which was the
+finding).
+
+```sh
+cargo test -p owl-dl-verify --test horn_widening_market
+```
+
+Expected: 3 passed, 0 failed.
+
+- [ ] **Step 6: Run the flag-default and fragment guards**
 
 ```sh
 cargo test -p owl-dl-reasoner --test flag_defaults
@@ -476,12 +536,27 @@ cargo test -p owl-dl-reasoner saturator_fragment_
 Expected: all pass — this change must not move any flag default or loosen the D10 allowlist for
 `∀` / `≤n` / `⊔` / `DisjointClasses`.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```sh
-git add crates/owl-dl-reasoner/src/classify.rs crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
+git add crates/owl-dl-reasoner/src/classify.rs crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs \
+        crates/owl-dl-verify/tests/horn_widening_market.rs
 git commit -m "fix(classify): admit a fully-decomposable Domain/Range filler to the EL fragment (#110)"
 ```
+
+- [ ] **Step 8: Wire the two PROVENANCE mirrors, or record the gap**
+
+`collect_el_rules_with_provenance` has its **own** Domain arm
+(`owl-dl-saturation/src/lib.rs:3150-3155`, `Atomic`-only, pushing `domain_axiom_refs`) and the
+mini Pass-1 range mirror at `:3218-3228` is likewise `Atomic`-only. That arm's own comment says it
+"must mirror the real Pass 1 exactly … any divergence shows up as a wrong or missing proof".
+
+After Task 1 those mirrors diverge: `rustdl prove` / `RUSTDL_PROOF=1` on a fact derived from a
+conjunctive filler gets an empty `axiom_refs` (the `.find(...)` at `:1639`/`:1860`/`:1882` returns
+`None`). **Answers are unaffected; proofs are.** Route both mirrors through
+`decompose_role_filler` in the same commit — that is the whole point of the shared function — and
+add a canary asserting `prove` attributes the conjunctive-domain subsumption to its axiom. If you
+choose not to wire them, say so explicitly in Task 5's write-up; do not leave it undiscovered.
 
 ---
 
@@ -525,10 +600,21 @@ done
 Write `docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md` with one row per
 probe × {rustdl before, rustdl after, Konclude, HermiT, KM}.
 
-**Pre-registered pass condition (S3):** all three oracles agree with post-fix rustdl on **6 of 6**.
-`dom_disj` and `dom_partial` are the DISCRIMINATING controls — the oracles must *not* report
-`X ⊑ Q` there, and `dom_atomic`/`rng_atomic` are where they *do* report, which is what makes their
-silence on the negatives meaningful (S5). Any disagreement blocks the merge until adjudicated.
+**Pre-registered pass condition (S3), stated as a defined comparison:** for each probe, the set of
+**named** subsumption pairs — excluding every row whose superclass is `owl:Thing` and every row
+mentioning `owl:Nothing`, since Konclude emits 8 `Thing` rows on `dom_conj` alone and a raw
+`<SubClassOf>` count therefore compares nothing — must be EQUAL across post-fix rustdl, Konclude,
+HermiT and KM, on **6 of 6**.
+
+`dom_disj` is the DISCRIMINATING control: the oracles must not report `X ⊑ P` or `X ⊑ Q` there,
+and `dom_atomic`/`rng_atomic` are where they DO report, which is what makes that silence
+meaningful rather than the under-reporting Konclude is documented to do (S5).
+
+**`dom_partial` as written is a vacuous negative** — it asks whether the oracles report `X ⊑ Q`,
+and `Q` does not appear in that axiom, so "no" is trivially true and no implementation could fail
+it. Replace it with a probe of the conjunct the engine did NOT process: add
+`SubClassOf(ObjectSomeValuesFrom(:s :S) :Z)` and ask whether `X ⊑ Z` is derived. That is the
+informative question, and it strengthens A3 rather than blocking it.
 
 - [ ] **Step 4: Run the sabotage battery — five, each with its predicted failure**
 
@@ -559,10 +645,18 @@ git commit -m "docs: oracle adjudication + sabotage battery for #110"
 
 - [ ] **Step 1: Pin both binaries (S2)**
 
+**`git stash` does NOT work here** — by Task 4 the change is committed, so a clean tree stashes
+nothing and BOTH builds are the AFTER code. Use a worktree at the pre-fix commit, and honour the
+toolchain constraint (a bare `cargo` is 1.75, its build FAILS, and a failed build silently reuses
+whatever is already in `target/release/`):
+
 ```sh
-git stash && cargo build --release && cp target/release/rustdl /tmp/rustdl-110-BEFORE && git stash pop
+export PATH="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH"
+BASE=$(git rev-parse HEAD~4)          # the commit before Task 1; VERIFY with `git log --oneline`
+git worktree add /tmp/wt-110-before "$BASE"
+(cd /tmp/wt-110-before && cargo build --release) && cp /tmp/wt-110-before/target/release/rustdl /tmp/rustdl-110-BEFORE
 cargo build --release && cp target/release/rustdl /tmp/rustdl-110-AFTER
-sha256sum /tmp/rustdl-110-BEFORE /tmp/rustdl-110-AFTER
+sha256sum /tmp/rustdl-110-BEFORE /tmp/rustdl-110-AFTER    # MUST differ
 ```
 
 **Verify the pin against a discriminating input before trusting it:**
@@ -589,7 +683,21 @@ here demonstrates non-regression only. The evidence is Task 3.
 
 - [ ] **Step 3: Two-arm sweep over the 14 conjunctive-filler ontologies + 20 controls**
 
-The 14: `ore_ont_{10080,10908,11064,11296,11305,11647,12107,12342,12451,15993,16372,16814,5964,714}`.
+**The frame is 27, not 14.** An earlier scan reported 14 and was WRONG: its `break` fired after
+the first axiom body matching a broad construct regex, so an ontology whose first Domain/Range
+axiom was non-conjunctive was recorded as a non-member and its later bodies never examined.
+Reproduce the correct frame with either instrument — they agree at 27:
+
+```sh
+grep -lE 'ObjectProperty(Domain|Range)\([^)]*ObjectIntersectionOf' \
+  /data/dumontier/ore-run/pool_sample/files/* | wc -l      # 27
+```
+
+The 27 = the original 14 (`10080, 10908, 11064, 11296, 11305, 11647, 12107, 12342, 12451, 15993,
+16372, 16814, 5964, 714`) plus `10109, 10517, 10807, 14272, 16371, 4796, 4827, 5764, 6923, 7828,
+8094, 8429, 9864`. Several of the additions are the documented `pt`-sensitive / slow set
+(`14272, 9864, 6923, 8429`), so budget for long walls and expect UNMEASURED members.
+
 Controls: any 20 with zero `ObjectIntersectionOf` inside a Domain/Range, where the pass provably
 cannot fire.
 
@@ -606,19 +714,40 @@ sequential re-adjudication with ≥3 runs.
 
 Admitting these axioms moves ontologies from `Horn` onto the **pure-EL fast path**, changing
 which engine answers. Enumerate the movers **by GATE, not by grep** (grep ≠ gate — the Lever 1
-precedent):
+precedent).
 
-```sh
-for f in /data/dumontier/ore-run/pool_sample/files/*; do
-  b=$(basename "$f"); 
-  before=$(timeout 120 /tmp/rustdl-110-BEFORE classify "$f" 2>/dev/null | grep -m1 '^# fragment:')
-  after=$(timeout 120 /tmp/rustdl-110-AFTER  classify "$f" 2>/dev/null | grep -m1 '^# fragment:')
-  [ "$before" != "$after" ] && echo -e "$b\t$before\t$after"
-done | tee /tmp/fragment-movers.tsv
+**Do NOT do this by diffing `# fragment:` from `classify`.** That banner is written by
+`write_classification` (`main.rs:1098`) only *after* classification completes, so the loop is a
+full two-arm classify of 1,920 ontologies — hours, not a routing probe — and any DNF yields an
+EMPTY string on that side, so a both-arm DNF reads as "not a mover" and a one-sided DNF reads as a
+false mover.
+
+`analyze_fragment` needs no reasoning (cf. `main.rs:2557`, which calls it before any engine runs).
+Add a probe binary alongside the existing `examples/clause_stats_probe`:
+
+```rust
+// crates/owl-dl-reasoner/examples/fragment_probe.rs
+// Prints `<name>\t<fragment>` for one ontology; parse+convert+gate only, no reasoning.
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: fragment_probe <ontology>");
+    let mut r = std::io::BufReader::new(std::fs::File::open(&path).expect("open"));
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut r, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+    let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
+    println!("{}\t{:?}", path, owl_dl_reasoner::analyze_fragment(&internal));
+}
 ```
 
-**Pre-registered pass condition:** every mover goes `Horn → pure-EL` or `OutOfFragment → Horn`
-(never the reverse — the gate may only widen), and each mover is triple-identical across arms.
+Run it under both binaries, and record a missing/failed result as **UNMEASURED**, never as
+"not a mover".
+
+**Pre-registered pass condition:** every mover goes `Horn → pure-EL`. **`OutOfFragment → Horn` is
+an ANOMALY, not an allowed outcome** — `Horn` is decided by `clausify_with_stats`, which this
+change does not touch, so such a transition means something unintended moved and must be
+explained before merging. Each mover must additionally be triple-identical across arms.
 
 - [ ] **Step 5: Confirm the standing DKey discriminators did not move**
 

--- a/docs/superpowers/plans/2026-09-06-conjunctive-domain-range-filler-110.md
+++ b/docs/superpowers/plans/2026-09-06-conjunctive-domain-range-filler-110.md
@@ -1,0 +1,680 @@
+# Conjunctive `ObjectPropertyDomain` / `Range` filler (#110) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the EL saturator process a conjunctive `ObjectPropertyDomain`/`Range` filler, and move both fragment gates in the same commit so the gate and the engine cannot disagree.
+
+**Architecture:** `Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)` is a **logical identity**, so decomposing the conjunction into atomic conjuncts is sound and completeness-preserving by construction. `role_domains`/`role_ranges` are already `HashMap<RoleId, Vec<ClassId>>`, so a conjunction is already representable — this pushes n entries where it used to push none. **One shared function** performs the decomposition and reports whether it was COMPLETE; the engine consumes the entries, both gates consume the boolean. They therefore cannot drift, which is the mechanism that generates D10 bugs.
+
+**Tech Stack:** Rust (edition 2024), `owl-dl-saturation`, `owl-dl-reasoner`. Build/test with `RUSTUP_TOOLCHAIN=stable cargo …` or `PATH="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH"` — a bare `cargo` on this host is 1.75 and rejects edition2024.
+
+**Spec:** `docs/superpowers/plans/2026-09-06-d10-arc-roadmap.md` § WS1, and issue #110.
+
+## Global Constraints
+
+- **`RUSTUP_TOOLCHAIN=stable`** for every build/test; a failed build silently reuses a stale `target/release/` binary.
+- **Unflagged.** A soundness/completeness fix is not opt-in. No new `RUSTDL_*` flag.
+- **Direction of risk is INVERTED:** this ADDS domain/range inferences, so the failure mode is a false POSITIVE, not a miss. Every canary needs an oracle, and the negative controls carry the weight.
+- **Partial decomposition is SOUND; partial ADMISSION is not.** The engine may push the atomic conjuncts of `P ⊓ ∃s.C` (a weaker domain is the safe direction). The gates must refuse that axiom, because a conjunct the engine never processed inside a complete-certified fragment is a fresh D10.
+- **`ore_ont_9347` = 113 and `ore_ont_5368` = 18,620,251** are the standing DKey discriminators; if either moves, something unintended changed.
+- Oracles: Konclude `/data/dumontier/reasoners/run-konclude.sh`, HermiT `/data/dumontier/reasoners/run-hermit.sh`, KM `/data/dumontier/kobayashi-marust/engine/target/release/km classify`. Judge Konclude from CONTENT (it exits 0 on junk, writing an 896-byte stub).
+- Corpus: `/data/dumontier/ore-run/pool_sample/files` (1,920).
+
+---
+
+### Task 1: Shared decomposer + engine wiring
+
+**Files:**
+- Modify: `crates/owl-dl-saturation/src/lib.rs` (new `pub fn decompose_role_filler`; the `ObjectPropertyDomain` arm at ~3457 and `ObjectPropertyRange` arm at ~3473)
+- Test: `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs` (new)
+
+**Interfaces:**
+- Produces: `pub fn owl_dl_saturation::decompose_role_filler(c: ConceptId, pool: &ConceptPool, sink: &mut Vec<ClassId>) -> bool` — pushes every atomic conjunct onto `sink`; returns `true` iff the filler decomposed COMPLETELY. Task 2's gates call it with a throwaway sink and read only the `bool`.
+
+- [ ] **Step 1: Write the failing canaries**
+
+Create `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs`:
+
+```rust
+//! Issue #110 — a CONJUNCTIVE `ObjectPropertyDomain`/`Range` filler is dropped.
+//!
+//! `collect_el_rules`' Domain/Range arms handled `Bot` (poison) and `Atomic`
+//! (push) and fell through silently on `And`, so `Domain(r, P ⊓ Q)` reached the
+//! engine as nothing at all. `is_el_axiom` correctly refused the axiom, routing
+//! the ontology to the hybrid path — where the tier walk then never compared
+//! `X` against `P`, because dropping the filler left `X` with no EL subsumer and
+//! therefore in `P`'s own tier. `classify` returned ZERO rows with
+//! `incomplete: false`; Konclude, HermiT and KM all derive the pairs.
+//!
+//! `Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)` is a logical identity, so the
+//! fix decomposes rather than approximates.
+
+use owl_dl_reasoner::classify;
+
+fn entails(body: &str, sub: &str, sup: &str) -> bool {
+    let src = format!("Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/t>\n{body}\n)\n");
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+    let c = classify(&onto).expect("classify");
+    c.is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+const DECLS: &str = "Declaration(Class(:P)) Declaration(Class(:Q)) Declaration(Class(:X))
+     Declaration(Class(:B)) Declaration(Class(:W)) Declaration(Class(:S))
+     Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))";
+
+/// #110, domain half. Both conjuncts must be derived, not just the first.
+#[test]
+fn conjunctive_domain_filler_derives_every_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))"
+    );
+    assert!(entails(&body, "X", "P"), "X ⊑ P (first conjunct)");
+    assert!(entails(&body, "X", "Q"), "X ⊑ Q (second conjunct)");
+}
+
+/// #110, range half — the LARGER population (13 of the 14 ORE candidates carry a
+/// conjunctive Range against 4 for Domain).
+///
+/// NB the existential filler is `:B`, NOT `owl:Thing`. `∃r.⊤` lowers to a
+/// deliberately subsumer-less ⊤-witness that `Range` is not folded into — the
+/// documented `topwitness.ofn` DESIGN DECISION — so a `⊤` fixture fails on the
+/// atomic control too and cannot discriminate.
+#[test]
+fn conjunctive_range_filler_derives_every_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)"
+    );
+    assert!(entails(&body, "X", "W"), "X ⊑ W via the folded range");
+}
+
+/// CONTROL that must keep passing: the atomic filler was never broken.
+#[test]
+fn atomic_domain_filler_still_derives_its_subsumption() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r :P)"
+    );
+    assert!(entails(&body, "X", "P"));
+}
+
+/// FP GUARD. Decomposition must never invent a domain the axiom does not state:
+/// `Domain(r, P)` alone must NOT yield `X ⊑ Q`.
+#[test]
+fn decomposition_does_not_invent_an_unstated_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r :P)"
+    );
+    assert!(!entails(&body, "X", "Q"), "Q is not a domain of r");
+}
+
+/// PARTIAL decomposition is SOUND: `P ⊓ ∃s.S` yields the atomic `P`, which is a
+/// WEAKER (larger) domain than the axiom states — the safe direction. Task 2
+/// pins that the GATE nonetheless refuses this axiom.
+#[test]
+fn partially_decomposable_filler_still_derives_its_atomic_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))"
+    );
+    assert!(entails(&body, "X", "P"), "the atomic conjunct is entailed");
+}
+
+/// A DISJUNCTIVE filler must NOT decompose. `Domain(r, P ⊔ Q)` does not entail
+/// `Domain(r,P)`; deriving `X ⊑ P` from it would be a false POSITIVE, which is
+/// this change's failure direction.
+#[test]
+fn a_disjunctive_filler_does_not_decompose() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectUnionOf(:P :Q))"
+    );
+    assert!(!entails(&body, "X", "P"), "FP: a disjunct is not a domain");
+    assert!(!entails(&body, "X", "Q"), "FP: a disjunct is not a domain");
+}
+```
+
+- [ ] **Step 2: Run them and confirm the two bug tests FAIL and the four others PASS**
+
+```sh
+export PATH="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH"
+cargo test -p owl-dl-reasoner --test conjunctive_domain_range_filler
+```
+
+Expected: `conjunctive_domain_filler_derives_every_conjunct` and
+`conjunctive_range_filler_derives_every_conjunct` FAIL;
+`atomic_domain_filler_still_derives_its_subsumption`,
+`decomposition_does_not_invent_an_unstated_conjunct`,
+`a_disjunctive_filler_does_not_decompose` PASS;
+`partially_decomposable_filler_still_derives_its_atomic_conjunct` FAILS (nothing is pushed today).
+
+**If a bug test PASSES here, stop** — the defect does not reproduce on this tree and the plan's premise (S1) is stale.
+
+- [ ] **Step 3: Add the shared decomposer to `owl-dl-saturation/src/lib.rs`**
+
+Place it immediately above `collect_el_rules`:
+
+```rust
+/// Decompose an `ObjectPropertyDomain` / `ObjectPropertyRange` filler into the
+/// ATOMIC classes the saturator's `role_domains` / `role_ranges` can hold,
+/// pushing each onto `sink`. Returns `true` iff the filler decomposed
+/// **completely**.
+///
+/// `Domain(r, P ⊓ Q)` is logically identical to `Domain(r,P) ∧ Domain(r,Q)`
+/// (likewise `Range`), so this is sound and completeness-preserving by
+/// construction — the same identity argument as `flatten_union_of_oneofs`
+/// (#42 item 1) and #81's range fold, not an approximation.
+///
+/// **Partial decomposition is deliberate and sound.** `P ⊓ ∃s.C` yields `P`
+/// alone: a WEAKER (larger) domain than the axiom states, which derives fewer
+/// subsumptions and never a wrong one. Contrast `DataUnionOf`, where keeping
+/// half a union NARROWS a range and manufactures clashes — there all-or-nothing
+/// is load-bearing, here it is not.
+///
+/// **The `bool` is what the fragment gates consume**, and it is why this
+/// function is `pub`. A gate that re-implemented "is this filler decomposable?"
+/// could drift from what this actually processes, and a conjunct the engine
+/// silently skipped inside a complete-certified fragment is exactly the D10 bug
+/// class. One function, no drift — the same reasoning that factored out
+/// `abox_saturation_inconsistent`.
+///
+/// `Bot` returns `false` **without** pushing: `Domain(r, ⊥)` is handled earlier
+/// by `poisoned_roles`, and a `Bot` nested inside a conjunction (`P ⊓ ⊥ ≡ ⊥`)
+/// means the whole role is poisoned — which this function does not model, so it
+/// declines and the gates route the ontology to the hybrid path.
+pub fn decompose_role_filler(
+    c: ConceptId,
+    pool: &ConceptPool,
+    sink: &mut Vec<ClassId>,
+) -> bool {
+    match pool.get(c) {
+        ConceptExpr::Atomic(id) => {
+            sink.push(*id);
+            true
+        }
+        // `Domain(r, ⊤)` states nothing; vacuously complete, nothing to push.
+        ConceptExpr::Top => true,
+        ConceptExpr::And(ops) => {
+            let mut complete = true;
+            for op in ops {
+                // Deliberately NOT short-circuiting: every atomic conjunct is
+                // entailed and worth pushing even when a sibling is not
+                // representable.
+                complete &= decompose_role_filler(*op, pool, sink);
+            }
+            complete
+        }
+        _ => false,
+    }
+}
+```
+
+- [ ] **Step 4: Wire both engine arms to it**
+
+In `collect_el_rules`, replace the `ObjectPropertyDomain` arm's final branch:
+
+```rust
+                } else if let ConceptExpr::Atomic(id) = internal.concepts.get(*domain) {
+                    rules
+                        .role_domains
+                        .entry(role.role_id())
+                        .or_default()
+                        .push(*id);
+                }
+```
+
+with:
+
+```rust
+                } else {
+                    let entry = rules.role_domains.entry(role.role_id()).or_default();
+                    decompose_role_filler(*domain, &internal.concepts, entry);
+                }
+```
+
+and the identical change in the `ObjectPropertyRange` arm, targeting `rules.role_ranges` and `*range`.
+
+- [ ] **Step 5: Run the canaries — all six must pass**
+
+```sh
+cargo test -p owl-dl-reasoner --test conjunctive_domain_range_filler
+```
+
+Expected: `test result: ok. 6 passed; 0 failed`.
+
+- [ ] **Step 6: Add decomposer unit tests in `owl-dl-saturation`**
+
+In that file's `mod tests`, using this crate's real `ConceptPool` API
+(`pool.atomic(ClassId::new(n))`, `pool.and([..])`, `pool.or([..])`, `pool.top()`, `pool.bot()`):
+
+```rust
+    #[test]
+    fn decompose_pushes_every_atomic_conjunct_and_reports_complete() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let and = pool.and([p, q]);
+        let mut sink = Vec::new();
+        assert!(decompose_role_filler(and, &pool, &mut sink), "fully decomposable");
+        assert_eq!(sink.len(), 2, "both conjuncts pushed");
+    }
+
+    /// PARTIAL: `P ⊓ (Q ⊔ R)` pushes `P` and reports INCOMPLETE. A disjunction is
+    /// used as the non-decomposable conjunct because it needs no `Role`, keeping
+    /// the unit test free of role-hierarchy setup.
+    #[test]
+    fn decompose_reports_incomplete_but_still_pushes_the_atomic_half() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let r = pool.atomic(owl_dl_core::ClassId::new(2));
+        let or = pool.or([q, r]);
+        let and = pool.and([p, or]);
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(and, &pool, &mut sink), "not complete");
+        assert_eq!(sink.len(), 1, "the atomic conjunct is still pushed");
+    }
+
+    /// ORDER-INDEPENDENCE, and it is what sabotage #5 (short-circuiting the `And`
+    /// loop) is caught by: with the non-decomposable conjunct FIRST, a
+    /// short-circuiting loop would push nothing.
+    #[test]
+    fn decompose_does_not_short_circuit_when_the_bad_conjunct_comes_first() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let r = pool.atomic(owl_dl_core::ClassId::new(2));
+        let or = pool.or([q, r]);
+        let and = pool.and([or, p]);
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(and, &pool, &mut sink));
+        assert_eq!(sink.len(), 1, "the atomic conjunct is pushed regardless of order");
+    }
+
+    /// FP GUARD: a bare disjunction decomposes to NOTHING. `Domain(r, P ⊔ Q)`
+    /// does not entail `Domain(r, P)`.
+    #[test]
+    fn decompose_declines_a_disjunction_and_pushes_nothing() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let or = pool.or([p, q]);
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(or, &pool, &mut sink));
+        assert!(sink.is_empty(), "a disjunct is not a domain — FP guard");
+    }
+
+    /// `Top` states nothing and is vacuously complete: `Domain(r, ⊤)` must be
+    /// admitted by the gate (it adds no constraint) while pushing no class.
+    #[test]
+    fn decompose_treats_top_as_complete_and_pushes_nothing() {
+        let mut pool = ConceptPool::default();
+        let top = pool.top();
+        let mut sink = Vec::new();
+        assert!(decompose_role_filler(top, &pool, &mut sink));
+        assert!(sink.is_empty());
+    }
+
+    /// `Bot` declines WITHOUT pushing — it is handled earlier by
+    /// `poisoned_roles`, and `is_processed_role_filler` re-admits it explicitly.
+    #[test]
+    fn decompose_declines_bot_without_pushing() {
+        let mut pool = ConceptPool::default();
+        let bot = pool.bot();
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(bot, &pool, &mut sink));
+        assert!(sink.is_empty());
+    }
+```
+
+- [ ] **Step 7: Run the saturation unit tests**
+
+```sh
+cargo test -p owl-dl-saturation decompose_
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 8: Commit**
+
+```sh
+git add crates/owl-dl-saturation/src/lib.rs crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
+git commit -m "fix(saturation): decompose a conjunctive Domain/Range filler (#110)"
+```
+
+---
+
+### Task 2: Move both fragment gates in lockstep
+
+**Files:**
+- Modify: `crates/owl-dl-reasoner/src/classify.rs` (`is_atomic_or_trivial_concept:2132`; `is_el_axiom`'s Domain/Range arms at 2183/2186; `is_saturator_axiom`'s at 2574/2577)
+- Test: `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs` (extend)
+
+**Interfaces:**
+- Consumes: `owl_dl_saturation::decompose_role_filler` from Task 1.
+
+- [ ] **Step 1: Write the failing gate tests**
+
+Append to `conjunctive_domain_range_filler.rs`:
+
+```rust
+use owl_dl_core::convert::convert_ontology;
+use owl_dl_reasoner::{FragmentClassification as FC, analyze_fragment};
+
+fn fragment_of(body: &str) -> FC {
+    let src = format!("Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/t>\n{body}\n)\n");
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+    analyze_fragment(&convert_ontology(&onto).expect("convert"))
+}
+
+/// The gate must move WITH the engine: a fully-decomposable filler is now
+/// processed, so the ontology belongs on the pure-EL fast path.
+#[test]
+fn a_fully_decomposable_filler_is_admitted_to_pure_el() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))"
+    );
+    assert_eq!(fragment_of(&body), FC::PureEl);
+}
+
+/// THE LOAD-BEARING NEGATIVE. A partially-decomposable filler leaves `∃s.S`
+/// unprocessed by the engine, so admitting it to a complete-certified fragment
+/// would be a FRESH D10 — the exact bug class this fix exists to close.
+#[test]
+fn a_partially_decomposable_filler_is_refused_by_the_gate() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))"
+    );
+    assert_ne!(fragment_of(&body), FC::PureEl);
+}
+
+/// A disjunctive filler is not decomposable and must stay out of the fragment.
+#[test]
+fn a_disjunctive_filler_is_refused_by_the_gate() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectUnionOf(:P :Q))"
+    );
+    assert_ne!(fragment_of(&body), FC::PureEl);
+}
+```
+
+- [ ] **Step 2: Run and confirm exactly the first one FAILS**
+
+```sh
+cargo test -p owl-dl-reasoner --test conjunctive_domain_range_filler
+```
+
+Expected: `a_fully_decomposable_filler_is_admitted_to_pure_el` FAILS (gate still refuses); the two negatives PASS.
+
+- [ ] **Step 3: Point both gates at the shared decomposer**
+
+Replace `is_atomic_or_trivial_concept` (used ONLY by the four Domain/Range arms — verify with `grep -n is_atomic_or_trivial_concept crates/owl-dl-reasoner/src/classify.rs` before editing; if it has other callers, add a new function instead of changing this one):
+
+```rust
+/// True iff a Domain/Range filler is one the saturator processes IN FULL.
+///
+/// Delegates to `owl_dl_saturation::decompose_role_filler` and reads only its
+/// completeness flag, so the gate cannot drift from what the engine actually
+/// does. Re-implementing the predicate here is how D10 bugs are born — see that
+/// function's doc.
+fn is_processed_role_filler(c: ConceptId, pool: &ConceptPool) -> bool {
+    let mut sink = Vec::new();
+    owl_dl_saturation::decompose_role_filler(c, pool, &mut sink)
+        || matches!(pool.get(c), ConceptExpr::Bot)
+}
+```
+
+`Bot` is admitted explicitly because the engine handles it via `poisoned_roles` *before* the
+decomposer is reached, so the decomposer legitimately returns `false` for it.
+
+Then rename the four call sites at 2183/2186/2574/2577 from `is_atomic_or_trivial_concept` to
+`is_processed_role_filler`.
+
+- [ ] **Step 4: Run the full canary file — all nine must pass**
+
+```sh
+cargo test -p owl-dl-reasoner --test conjunctive_domain_range_filler
+```
+
+Expected: `test result: ok. 9 passed; 0 failed`.
+
+- [ ] **Step 5: Run the flag-default and fragment guards**
+
+```sh
+cargo test -p owl-dl-reasoner --test flag_defaults
+cargo test -p owl-dl-reasoner saturator_fragment_
+```
+
+Expected: all pass — this change must not move any flag default or loosen the D10 allowlist for
+`∀` / `≤n` / `⊔` / `DisjointClasses`.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add crates/owl-dl-reasoner/src/classify.rs crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
+git commit -m "fix(classify): admit a fully-decomposable Domain/Range filler to the EL fragment (#110)"
+```
+
+---
+
+### Task 3: Oracle adjudication and the sabotage battery
+
+**Files:**
+- Create: `docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md`
+
+- [ ] **Step 1: Build the six probe files**
+
+```sh
+S=$(mktemp -d)
+mk() { printf 'Prefix(:=<http://rustdl.test/>)\nPrefix(owl:=<http://www.w3.org/2002/07/owl#>)\nOntology(\n%s\n)\n' "$2" > "$S/$1.ofn"; }
+D='Declaration(Class(:P)) Declaration(Class(:Q)) Declaration(Class(:X)) Declaration(Class(:B)) Declaration(Class(:W)) Declaration(Class(:S)) Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))'
+mk dom_conj    "$D SubClassOf(:X ObjectSomeValuesFrom(:r :B)) ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))"
+mk dom_atomic  "$D SubClassOf(:X ObjectSomeValuesFrom(:r :B)) ObjectPropertyDomain(:r :P)"
+mk rng_conj    "$D SubClassOf(:X ObjectSomeValuesFrom(:r :B)) ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q)) SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)"
+mk rng_atomic  "$D SubClassOf(:X ObjectSomeValuesFrom(:r :B)) ObjectPropertyRange(:r :P) SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)"
+mk dom_partial "$D SubClassOf(:X ObjectSomeValuesFrom(:r :B)) ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))"
+mk dom_disj    "$D SubClassOf(:X ObjectSomeValuesFrom(:r :B)) ObjectPropertyDomain(:r ObjectUnionOf(:P :Q))"
+echo "$S"
+```
+
+- [ ] **Step 2: Run all three oracles on all six**
+
+```sh
+KM=/data/dumontier/kobayashi-marust/engine/target/release/km
+for f in dom_conj dom_atomic rng_conj rng_atomic dom_partial dom_disj; do
+  echo "=== $f ==="
+  /data/dumontier/reasoners/run-konclude.sh $S/$f.ofn $S/$f.kon.owx >/dev/null 2>&1
+  echo "  konclude bytes=$(stat -c%s $S/$f.kon.owx)"   # 896 == the failure stub, NOT an answer
+  grep -o '<SubClassOf>' $S/$f.kon.owx | wc -l
+  timeout 300 /data/dumontier/reasoners/run-hermit.sh $S/$f.ofn $S/$f.hermit.out >/dev/null 2>&1
+  grep -oE 'SubClassOf\([^)]*\)' $S/$f.hermit.out | grep -v 'owl:Thing\|Nothing'
+  timeout 120 $KM classify $S/$f.ofn
+done
+```
+
+- [ ] **Step 3: Record the adjudication table**
+
+Write `docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md` with one row per
+probe × {rustdl before, rustdl after, Konclude, HermiT, KM}.
+
+**Pre-registered pass condition (S3):** all three oracles agree with post-fix rustdl on **6 of 6**.
+`dom_disj` and `dom_partial` are the DISCRIMINATING controls — the oracles must *not* report
+`X ⊑ Q` there, and `dom_atomic`/`rng_atomic` are where they *do* report, which is what makes their
+silence on the negatives meaningful (S5). Any disagreement blocks the merge until adjudicated.
+
+- [ ] **Step 4: Run the sabotage battery — five, each with its predicted failure**
+
+| # | Sabotage | Predicted |
+|---|---|---|
+| 1 | Revert both engine arms to the `Atomic`-only branch | the 2 bug canaries + the partial canary fail |
+| 2 | Make `decompose_role_filler`'s `And` arm return `true` unconditionally | `a_partially_decomposable_filler_is_refused_by_the_gate` fails |
+| 3 | Add a `ConceptExpr::Or` arm that decomposes like `And` | `a_disjunctive_filler_does_not_decompose` + `a_disjunctive_filler_is_refused_by_the_gate` fail |
+| 4 | Make `is_processed_role_filler` re-implement the check locally (`matches!(Atomic|Bot|Top|And(all atomic))`) instead of calling the decomposer | **predicted: SURVIVES** — the two agree today. Recording the survivor is the point: it shows the canaries pin behaviour, not the no-drift property, which rests on the shared call site alone. |
+| 5 | Short-circuit the `And` loop on the first `false` | `decompose_does_not_short_circuit_when_the_bad_conjunct_comes_first` fails — that unit test exists specifically because the integration canary orders the atomic conjunct FIRST and cannot see this |
+
+Run each, record caught/survived, **revert before the next**. Report every survivor in the doc
+(S4). Do not paper over #4 — an honest recorded limit is worth more than a claimed catch.
+
+- [ ] **Step 5: Commit the adjudication doc**
+
+```sh
+git add docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
+git commit -m "docs: oracle adjudication + sabotage battery for #110"
+```
+
+---
+
+### Task 4: Corpus gates
+
+**Files:**
+- Create: `docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md`
+
+- [ ] **Step 1: Pin both binaries (S2)**
+
+```sh
+git stash && cargo build --release && cp target/release/rustdl /tmp/rustdl-110-BEFORE && git stash pop
+cargo build --release && cp target/release/rustdl /tmp/rustdl-110-AFTER
+sha256sum /tmp/rustdl-110-BEFORE /tmp/rustdl-110-AFTER
+```
+
+**Verify the pin against a discriminating input before trusting it:**
+
+```sh
+for b in BEFORE AFTER; do
+  echo -n "$b: "; /tmp/rustdl-110-$b classify --json $S/dom_conj.ofn | python3 -c 'import json,sys;print(len(json.load(sys.stdin)["direct_subsumptions"]))'
+done
+```
+
+Expected `BEFORE: 0`, `AFTER: 2`. **If they read the same, the pin is wrong — stop.**
+
+- [ ] **Step 2: FP=0 net**
+
+```sh
+./scripts/run-soundness-diff.sh 2>&1 | grep '^\[fp0\]'
+```
+
+Expected: 11 VERIFIED, every closure exact (galen 28007, notgalen 32739, sio 8904, wine 653,
+ore-10908 6001, pizza 499, alehif 247, ro 158, ore-15672 142, sulo 51, bibtex 16).
+
+**Record this as INERTNESS, not correctness (S9):** corpus reach is measured zero, so a green net
+here demonstrates non-regression only. The evidence is Task 3.
+
+- [ ] **Step 3: Two-arm sweep over the 14 conjunctive-filler ontologies + 20 controls**
+
+The 14: `ore_ont_{10080,10908,11064,11296,11305,11647,12107,12342,12451,15993,16372,16814,5964,714}`.
+Controls: any 20 with zero `ObjectIntersectionOf` inside a Domain/Range, where the pass provably
+cannot fire.
+
+Run each ontology in BOTH arms, **alternating arm order by index** (S7), sequential, 240 s cap,
+comparing the TRIPLE (S6). `ore_ont_10080` DNFs symmetrically at 600 s and is expected UNMEASURED;
+`ore_ont_12451` needs ≥900 s (it is 230 s in one arm and 777 s in another — a one-sided timeout
+here is a CANDIDATE loss, not a loss; raise the cap before recording one, S8).
+
+**Pre-registered pass condition:** 0 lost entailments; any GAIN adjudicated against the three
+oracles (a gain is the expected direction and must still be confirmed); 0 `ok → dnf` surviving
+sequential re-adjudication with ≥3 runs.
+
+- [ ] **Step 4: Fragment-routing sweep — the behaviour change this fix actually ships**
+
+Admitting these axioms moves ontologies from `Horn` onto the **pure-EL fast path**, changing
+which engine answers. Enumerate the movers **by GATE, not by grep** (grep ≠ gate — the Lever 1
+precedent):
+
+```sh
+for f in /data/dumontier/ore-run/pool_sample/files/*; do
+  b=$(basename "$f"); 
+  before=$(timeout 120 /tmp/rustdl-110-BEFORE classify "$f" 2>/dev/null | grep -m1 '^# fragment:')
+  after=$(timeout 120 /tmp/rustdl-110-AFTER  classify "$f" 2>/dev/null | grep -m1 '^# fragment:')
+  [ "$before" != "$after" ] && echo -e "$b\t$before\t$after"
+done | tee /tmp/fragment-movers.tsv
+```
+
+**Pre-registered pass condition:** every mover goes `Horn → pure-EL` or `OutOfFragment → Horn`
+(never the reverse — the gate may only widen), and each mover is triple-identical across arms.
+
+- [ ] **Step 5: Confirm the standing DKey discriminators did not move**
+
+```sh
+for b in BEFORE AFTER; do
+  /tmp/rustdl-110-$b tbox-stats /data/dumontier/ore-run/pool_sample/files/ore_ont_9347.owl | grep -i 'concept.rules'
+done
+```
+
+Expected 113 in both. If it moves, something unintended changed.
+
+- [ ] **Step 6: Commit the sweep**
+
+```sh
+git add docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md
+git commit -m "docs: corpus gates for #110"
+```
+
+---
+
+### Task 5: Documentation and close-out
+
+**Files:**
+- Modify: `CLAUDE.md` (the `owl-dl-verify` §, where #110 is recorded as UNFIXED)
+- Modify: `docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md` (its closing section states the defect is open)
+
+- [ ] **Step 1: Update `CLAUDE.md`**
+
+Rewrite the "#110 UNFIXED" block to record: the fix (decomposition as a logical identity), the
+gate/engine shared-call-site design and *why* (drift is the D10 generator), the partial-vs-complete
+asymmetry, the sabotage results **including survivor #4**, and — per S9 — that the corpus evidence
+is inertness while Task 3's adjudication is the real evidence.
+
+- [ ] **Step 2: Update the widening doc's closing section**
+
+Change its "UNFIXED" framing to point at the fix, keeping the diagnosis (it is the provenance
+record for how the defect was found).
+
+- [ ] **Step 3: Full gates**
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace 2>&1 | grep -E 'test result:.*failed' | grep -v ' 0 failed'
+```
+
+Expected: fmt clean, clippy clean, no line printed by the third command.
+
+- [ ] **Step 4: Commit, PR, close #110**
+
+```sh
+git add CLAUDE.md docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md
+git commit -m "docs: record the #110 fix"
+gh pr create --base main --title "fix: decompose a conjunctive ObjectPropertyDomain/Range filler (#110)" --body-file <(...)
+```
+
+The PR body must state, in this order: the identity argument; that gate and engine moved in one
+commit through one shared function; the oracle table; the sabotage results with survivors named;
+and that **corpus reward is measured ZERO** so the sweeps are non-regression evidence only.

--- a/docs/superpowers/plans/2026-09-06-conjunctive-domain-range-filler-110.md
+++ b/docs/superpowers/plans/2026-09-06-conjunctive-domain-range-filler-110.md
@@ -46,7 +46,7 @@ must state which of the four now share a call site and which do not.
 ### Task 1: Shared decomposer + engine wiring
 
 **Files:**
-- Modify: `crates/owl-dl-saturation/src/lib.rs` (new `pub fn decompose_role_filler`; the `ObjectPropertyDomain` arm at ~3457 and `ObjectPropertyRange` arm at ~3473)
+- Modify: `crates/owl-dl-saturation/src/lib.rs` (new `pub fn decompose_role_filler`; the `ObjectPropertyDomain` arm at ~3457 and `ObjectPropertyRange` arm at ~3473; the provenance mirrors at ~3150 and ~3218)
 - Test: `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs` (new)
 
 **Interfaces:**
@@ -391,7 +391,21 @@ cargo test -p owl-dl-saturation decompose_
 
 Expected: 6 passed.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 8: Wire the two PROVENANCE mirrors, or record the gap**
+
+`collect_el_rules_with_provenance` has its **own** Domain arm
+(`owl-dl-saturation/src/lib.rs:3150-3155`, `Atomic`-only, pushing `domain_axiom_refs`) and the
+mini Pass-1 range mirror at `:3218-3228` is likewise `Atomic`-only. That arm's own comment says it
+"must mirror the real Pass 1 exactly … any divergence shows up as a wrong or missing proof".
+
+After Task 1 those mirrors diverge: `rustdl prove` / `RUSTDL_PROOF=1` on a fact derived from a
+conjunctive filler gets an empty `axiom_refs` (the `.find(...)` at `:1639`/`:1860`/`:1882` returns
+`None`). **Answers are unaffected; proofs are.** Route both mirrors through
+`decompose_role_filler` in the same commit — that is the whole point of the shared function — and
+add a canary asserting `prove` attributes the conjunctive-domain subsumption to its axiom. If you
+choose not to wire them, say so explicitly in Task 5's write-up; do not leave it undiscovered.
+
+- [ ] **Step 9: Commit**
 
 ```sh
 git add crates/owl-dl-saturation/src/lib.rs crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
@@ -405,6 +419,7 @@ git commit -m "fix(saturation): decompose a conjunctive Domain/Range filler (#11
 **Files:**
 - Modify: `crates/owl-dl-reasoner/src/classify.rs` (`is_atomic_or_trivial_concept:2132`; `is_el_axiom`'s Domain/Range arms at 2183/2186; `is_saturator_axiom`'s at 2574/2577)
 - Test: `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs` (extend)
+- Modify: `crates/owl-dl-verify/tests/horn_widening_market.rs` (Step 5 retargets a test that pins this bug)
 
 **Interfaces:**
 - Consumes: `owl_dl_saturation::decompose_role_filler` from Task 1.
@@ -544,20 +559,6 @@ git add crates/owl-dl-reasoner/src/classify.rs crates/owl-dl-reasoner/tests/conj
 git commit -m "fix(classify): admit a fully-decomposable Domain/Range filler to the EL fragment (#110)"
 ```
 
-- [ ] **Step 8: Wire the two PROVENANCE mirrors, or record the gap**
-
-`collect_el_rules_with_provenance` has its **own** Domain arm
-(`owl-dl-saturation/src/lib.rs:3150-3155`, `Atomic`-only, pushing `domain_axiom_refs`) and the
-mini Pass-1 range mirror at `:3218-3228` is likewise `Atomic`-only. That arm's own comment says it
-"must mirror the real Pass 1 exactly … any divergence shows up as a wrong or missing proof".
-
-After Task 1 those mirrors diverge: `rustdl prove` / `RUSTDL_PROOF=1` on a fact derived from a
-conjunctive filler gets an empty `axiom_refs` (the `.find(...)` at `:1639`/`:1860`/`:1882` returns
-`None`). **Answers are unaffected; proofs are.** Route both mirrors through
-`decompose_role_filler` in the same commit — that is the whole point of the shared function — and
-add a canary asserting `prove` attributes the conjunctive-domain subsumption to its axiom. If you
-choose not to wire them, say so explicitly in Task 5's write-up; do not leave it undiscovered.
-
 ---
 
 ### Task 3: Oracle adjudication and the sabotage battery
@@ -642,6 +643,7 @@ git commit -m "docs: oracle adjudication + sabotage battery for #110"
 
 **Files:**
 - Create: `docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md`
+- Create: `crates/owl-dl-reasoner/examples/fragment_probe.rs` (Step 4's gate-only routing probe)
 
 - [ ] **Step 1: Pin both binaries (S2)**
 
@@ -681,7 +683,7 @@ ore-10908 6001, pizza 499, alehif 247, ro 158, ore-15672 142, sulo 51, bibtex 16
 **Record this as INERTNESS, not correctness (S9):** corpus reach is measured zero, so a green net
 here demonstrates non-regression only. The evidence is Task 3.
 
-- [ ] **Step 3: Two-arm sweep over the 14 conjunctive-filler ontologies + 20 controls**
+- [ ] **Step 3: Two-arm sweep over the 27 conjunctive-filler ontologies + 20 controls**
 
 **The frame is 27, not 14.** An earlier scan reported 14 and was WRONG: its `break` fired after
 the first axiom body matching a broad construct regex, so an ontology whose first Domain/Range

--- a/docs/superpowers/plans/2026-09-06-d10-arc-roadmap.md
+++ b/docs/superpowers/plans/2026-09-06-d10-arc-roadmap.md
@@ -1,0 +1,150 @@
+# D10 arc — long-term roadmap with pre-registered acceptance and kill conditions
+
+**Status:** roadmap, 2026-09-06. Four INDEPENDENT workstreams. Per the writing-plans scope
+check, each gets its own plan; only WS1 is planned in detail today
+(`2026-09-06-conjunctive-domain-range-filler-110.md`) because only WS1's premise has been
+verified against current `main`.
+
+**Why a roadmap and not one plan:** WS1 is an engine fix, WS2 a bounded feasibility probe,
+WS3 a corpus acquisition, WS4 a triage. They share a theme (D10 / silent incompleteness) and
+nothing else. Bundling them would produce a plan whose tasks cannot be independently
+rejected — the failure the scope check exists to prevent.
+
+---
+
+## Standing conditions — every workstream, no exceptions
+
+These are this repo's own hard-won rules. A workstream that violates one is not done, however
+good its headline number looks.
+
+| # | Condition | Why it is here |
+|---|---|---|
+| S1 | **Re-verify the premise against current `main` before planning against it.** | The 2026-08-18 audit: five proposals targeted already-shipped work; three named targets had evaporated. This check has retired more work than it cost, every time. |
+| S2 | **Pin the binary per configuration**, named after the configuration, immediately after the build, and verify the pin against a **discriminating** input. | A 2 h scan once measured a sabotage build. `ore_ont_9347` cannot discriminate DKey; `5368` can. |
+| S3 | **Declare the numeric pass/fail criterion BEFORE running.** | A probe silently failed to fire on 4 of 6 targets and would have read as 4 confirmations. |
+| S4 | **Sabotage every guard.** Break the guarded code; confirm the test fails. Report survivors as findings. | Three sabotages of a differential test all passed 6/6. A guard that cannot be made to fail is not a guard. |
+| S5 | **Oracle-adjudicate with a DISCRIMINATING control.** Konclude under-reports (9 recorded); pair every negative probe with a case where the oracle *does* report. | The v0.4.6–v0.4.9 float/double FP. |
+| S6 | **Compare the TRIPLE** (`direct_subsumptions`, `unsatisfiable`, `equivalent_groups`), never row counts. | `direct_subsumptions` is the Hasse relation: proving a class unsat ELIDES rows, so a correct fix reads as a regression. 4 recorded instances. |
+| S7 | **Alternate arm order** in any wall comparison; a fixed order buys a ~3.4% phantom. | The #70 sweep. |
+| S8 | **Adjudicate every reported loss sequentially on an idle host, ≥3 runs**, and **raise the cap before recording a one-sided timeout as a loss**. | Contention manufactures `ok → dnf`; and `ore_ont_12451` (2026-09-05) was 3.4× slower, not lost. |
+| S9 | **State what the evidence does NOT cover.** A green FP=0 net over the curated corpus shows INERTNESS for any area the corpus does not exercise. | `datatype_value_membership.rs` says so itself. |
+| S10 | **Check whether a fixture's behaviour is a DEFECT or a documented DESIGN DECISION** before reporting it, and before pinning a test to it. | `topwitness.ofn` (2026-09-06 near-miss); `tests-that-pin-the-bug`. |
+
+---
+
+## WS1 — Close #110: conjunctive `ObjectPropertyDomain` / `Range` filler
+
+**Question.** `Domain(r, P ⊓ Q)` + `X ⊑ ∃r.B` entails `X ⊑ P`, `X ⊑ Q`. `classify` returns zero
+rows with `incomplete: false` while Konclude, HermiT and KM all derive both. Same for `Range`.
+Close it at root.
+
+**Premise, VERIFIED 2026-09-06 (S1).** `collect_el_rules`' `ObjectPropertyDomain` /
+`ObjectPropertyRange` arms (`owl-dl-saturation/src/lib.rs:3457-3487`) handle `Bot` (poison) and
+`Atomic` (push), and **silently fall through on `And`**. `role_domains` and `role_ranges` are
+already `HashMap<RoleId, Vec<ClassId>>` — a conjunction is *already representable*. Both
+fragment gates (`is_el_axiom:2183/2186`, `is_saturator_axiom:2574/2577`) refuse via one shared
+predicate `is_atomic_or_trivial_concept:2132`.
+
+**Approach.** `Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)` is a **logical identity**, so
+decomposition is sound and completeness-preserving by construction — the same argument shape as
+`flatten_union_of_oneofs` (#42 item 1) and #81's range fold.
+
+**Detailed plan:** `2026-09-06-conjunctive-domain-range-filler-110.md`.
+
+**Acceptance (all required):**
+- A1. Both reproducers (domain + range) derive the entailed pairs; both atomic controls still do.
+- A2. `# fragment:` moves `Horn` → `pure-EL` on both reproducers — the gate and engine moved together.
+- A3. A **partially**-decomposable filler (`Domain(r, P ⊓ ∃s.C)`) derives `P` **and is REFUSED by both gates** (a fresh D10 otherwise).
+- A4. Konclude ∪ HermiT ∪ KM agree on every probe, each paired with a discriminating control (S5).
+- A5. **≥5 sabotages run, every survivor reported** (S4).
+- A6. FP=0 net: 11 VERIFIED, closures exact. **Recorded as INERTNESS, not correctness** (S9) — corpus reach is measured zero.
+- A7. Two-arm sweep over the **14** conjunctive-filler ORE ontologies plus ≥20 non-bearing controls: triple-identical or adjudicated (S6, S7, S8).
+- A8. **Fragment-routing sweep** — the fix moves ontologies onto the pure-EL fast path, which is a behaviour change: 0 `ok → dnf`, 0 answer changes.
+
+**Kill condition.** If A3 cannot be satisfied without the two predicates drifting apart, stop and
+re-plan: the fix has become a gate/engine coupling problem, which is the D10 generator itself.
+
+**Expected corpus reward: ZERO.** Measured — 12 of 14 IDENTICAL under `SAME_TIER=1`, 0 gained.
+This is a correctness fix. **Do not sell it as a completeness win**, and do not let a flat sweep
+be read as the fix not working (S9).
+
+---
+
+## WS2 — `VarCap`: are any of the 39 addressable?
+
+**Question.** `RUSTDL_TRACE_BODY_VARS` census (2026-09-04) found **39 ontologies with
+`VarCap`-only refusals** — clauses silently discarded for exceeding `MAX_BODY_VARS = 8`, the same
+silent-drop shape as the `NotTree` bug that turned out to be real. Recorded, never diagnosed.
+
+**What is already measured out — do not re-run.** Raising the cap 8 → 16 recovers **nothing** and
+**destroys three completers** (`ore_ont_16461`, `7775`, `15491`; 9,773 sound pairs lost), because
+the withheld clause is **disjunctive** in each case. No fixed value works: binders need 9, 11, 12,
+16, 25 and 133.
+
+**The one unexplored shape**, named in `docs/2026-08-03-max-body-vars.md` and never built: admit
+wide **Horn** bodies while continuing to refuse wide **disjunctive** ones.
+
+**Step 1 is a measurement, not a build.** Of the 39, how many refuse a body that is **Horn**?
+
+**Acceptance:**
+- B1. Per-ontology Horn/disjunctive split of the 39 refused bodies, by the ENGINE probe, smoke-tested against a known value first (S3).
+- B2. For any Horn-bodied member, confirm the withheld clause changes an ANSWER (oracle-adjudicated), not merely that it is withheld.
+
+**Kill condition, pre-registered.** If **fewer than 3** of the 39 refuse a Horn body whose
+withheld clause changes an answer, **stop and record the negative**. The CB arc was deferred at a
+market of 16; a market under 3 does not justify a new branching-cap policy in the wedge's hot path.
+
+---
+
+## WS3 — Point `verify-el` at a corpus that is not ORE
+
+**Question.** Post-#87 the instrument is clean (0 violations over 403 checkable). It has therefore
+found **nothing** on ORE — and ORE is heavily mined by this project. Its value as an unattended
+D10 hunter is untested on fresh ground.
+
+**Prerequisite, and it is a real cost.** F1 and F3 remain live builder false-positive mechanisms,
+so every `Violated` is a LEAD requiring adjudication (~1 h each with peer oracles). Budget that
+before starting.
+
+**Acceptance:**
+- C1. Corpus obtained, licensed, and its size + provenance recorded.
+- C2. Coverage reported as the same five-bucket split used for ORE (verified / gate-refused by fragment / builder-refused by reason / timeout / error), so it is comparable.
+- C3. Every `Violated` adjudicated against Konclude ∪ HermiT ∪ KM with a discriminating control (S5), and classified as engine defect / builder FP / unresolved.
+
+**Kill condition.** If coverage is again ~20% **and** violations are 0 after adjudication,
+`verify-el` is measured out as a *hunter*. Reposition it as a **regression gate** (run it on the
+curated fixtures in CI, where a new `Violated` means a fresh engine defect) and stop investing in
+coverage.
+
+---
+
+## WS4 — The 9 builder-refusal ontologies
+
+**Question.** Of 1,920, exactly **9** pass the CLI fragment gate and are then refused by the
+builder: **6 `AxiomsDroppedAtConversion`, 3 `BoundTripped`**. The 6 are the interesting ones — a
+dropped axiom is a conversion gap, and `dropped` is *visible*, so these are cheap to characterise.
+
+**Acceptance:**
+- D1. Per-ontology, the `dropped` map by kind, from the CLI's own reporting (not a grep).
+- D2. Each distinct kind classified: known-and-deliberate (SWRL, `HasKey`) vs an unrecorded gap.
+
+**Kill condition.** If all 6 are known-and-deliberate kinds, record the fact in the `owl-dl-verify`
+section and close. This is a ~1 h triage, not a project; **do not** let it grow into a conversion
+workstream without a fresh decision.
+
+---
+
+## Ordering and rationale
+
+1. **WS1** — a real defect, root cause known, premise verified, fix sized.
+2. **WS4** — ~1 h, and it closes out the decomposition finding.
+3. **WS2** — cheap probe with a hard pre-registered kill condition.
+4. **WS3** — largest, gated on obtaining a corpus, and its value is contingent on WS2/WS4 not
+   turning up something closer to hand.
+
+**What this roadmap deliberately excludes**, each already measured out — re-propose only with new
+evidence: raising `verify-el`'s 60 s cap (5× buys +2.1 points, finds nothing); widening
+`verify-el` past `is_pure_el` to Horn (two admissible shapes; see
+`docs/benchmarks/2026-09-05-verify-el-horn-widening-market.md`); flipping
+`RUSTDL_CLASSIFY_SAME_TIER` (corpus-invisible, and measured at 3.4× wall on `ore_ont_12451` for
+identical answers).

--- a/docs/superpowers/plans/2026-09-06-d10-arc-roadmap.md
+++ b/docs/superpowers/plans/2026-09-06-d10-arc-roadmap.md
@@ -64,7 +64,20 @@ decomposition is sound and completeness-preserving by construction — the same 
 **Kill condition.** If A3 cannot be satisfied without the two predicates drifting apart, stop and
 re-plan: the fix has become a gate/engine coupling problem, which is the D10 generator itself.
 
-**Expected corpus reward: ZERO.** Measured — 12 of 14 IDENTICAL under `SAME_TIER=1`, 0 gained.
+**WS1b — the GCI sibling, #114 (NEW, found by adversarial review of the WS1 plan).**
+`SubClassOf(∃r.⊤, C)` with non-atomic `C` is the same construct in different syntax, dropped by a
+DIFFERENT decomposer (`atomic_operands_on_right`), and certified **`pure-EL`** rather than `Horn`
+— a strictly more serious D10 instance. Deliberately out of WS1's scope; sequence it immediately
+after, and treat unifying `atomic_operands_on_right` with WS1's `decompose_role_filler` as its
+first design option. There are **four** decomposers of this one construct in tree; WS1 adds the
+fourth without removing any.
+
+**Expected corpus reward: ZERO — but the frame was WRONG and is being re-measured.** The original
+scan reported 14 conjunctive-filler ontologies; the correct superset is **27** (its `break` fired
+on a broad construct regex, so an ontology whose first Domain/Range axiom was non-conjunctive was
+never fully examined). 13 of 14 were IDENTICAL under `SAME_TIER=1` with 0 gained; the remaining 13
+are in flight. **Do not quote "corpus reach zero" until the full 27 are measured** — the
+conclusion is likely unchanged, but it was measured over half the frame.
 This is a correctness fix. **Do not sell it as a completeness win**, and do not let a flat sweep
 be read as the fix not working (S9).
 


### PR DESCRIPTION
## What this is

A scoping spike with a go/no-go, plus its retraction of the recommendation that motivated it.
**Docs and one new test file; no engine change.**

`docs/benchmarks/2026-09-05-verify-el-cap-is-a-weak-lever.md` closed by naming the fragment as
the binding constraint on `verify-el` coverage — 1,392 of 1,920 (72.5%) `unresolved` against 124
lost to the cap — and recommending the gate be widened from `PureEl` to `Horn`. **That
recommendation is wrong and is retracted here.** A count of refusals is not a count of
recoverable cases.

## The go/no-go

`verify` reaches `Verified` only with **zero** unresolved axioms (`lib.rs:494-520`), so one
refused axiom sinks a whole verdict. A two-list comparison of {constructs that make an ontology
Horn-but-not-EL} against `eval.rs`'s arms finds essentially all of them refused:

- the six concept-level generators (`∃r⁻`, `∀`, `≥n`, `≤n`, nominal, `Self`) — explicit
  `Unresolved` arms
- the twelve axiom-level ones (`Functional`, `InverseFunctional`, `Reflexive`, `Irreflexive`,
  `Asymmetric`, `DisjointObjectProperties`, `DisjointUnion`, the five ABox forms) — `unhandled`
- the inverse-role role-axiom cases — their own guards
- `SymmetricRole` / `InverseObjectProperties` *look* handled but hold only when the role has **no
  edges** — exactly the bare declaration `is_pure_el` already admits

**Exactly two holes**, both the same mechanism (the EL gate demands `Atomic` where `eval.rs`
accepts any concept it can evaluate, and `CE::And` is one): a non-atomic `DisjointClasses`
member, and a conjunctive `ObjectPropertyDomain`/`Range` filler. Grep supersets ≤8 and ≤14, and
**not additive** — a verdict needs *every* departure from `is_el_axiom` to be one of the two.
`ore_ont_10908` is in the 14, is a curated fixture, and classifies at MISSED=0.

**No third hole**, printed rather than eyeballed: `eval_concept` accepts exactly
`Top`/`Bot`/`Atomic`/`And`/`Some(Named)` and `is_el_concept` exactly
`Top`/`Atomic`/`Bot`/`And`/`Some(!inverse)` — identical sets.

## The 1,392 also decomposes, and the second suspected lever is measured out

Full 1,920 scan at a 60 s cap:

| bucket | count |
|---|---:|
| `verified` | 361 |
| refused by the CLI gate | 1,351 — 662 `Horn`, 689 `OutOfFragment` |
| **past the gate, refused by the builder** | **9** |
| timeout — unmeasured | 199 |
| error | 1 |

The builder-refusal half — the population that would need no fragment work at all — is
**9 ontologies** (6 `AxiomsDroppedAtConversion`, 3 `BoundTripped`). `ChainRangeOutOfProfile`,
`LabelNotClosed` and `RunDelta` fire on **zero** ORE ontologies.

## The payoff: a live D10 defect, filed as #110

`ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B` entails `X ⊑ P` and `X ⊑ Q`. `classify` returns
**zero rows** with `incomplete: false` and `dropped: {}` under a banner certifying the fragment
complete; **Konclude and HermiT both derive both pairs** and rustdl's own `subclass` proves them.

Root-caused to the tier walk, not the calculus — no subsumption-path flag recovers it
(`TRUST_SAT=0`, `HYPERTABLEAU=0`, `CLASSIFY_VERIFY_REFUTATIONS=1`, `DOMAIN_ABSORPTION=0` all
return zero rows), while `RUSTDL_CLASSIFY_SAME_TIER=1` recovers both. The atomic-filler control
classifies correctly, which isolates the cause.

**Corpus reach measured ZERO** — two-arm run over the 14 candidates, arm order alternated, triple
(rows, unsat, equiv) compared: **13 IDENTICAL, 0 gained, 0 lost, 1 unmeasured**. So
`RUSTDL_CLASSIFY_SAME_TIER`'s corpus-invisible default-OFF justification **stands unqualified**;
this is a second *synthetic* pattern, as `sp11sub` was.

The second commit is a correction worth reading on its own. `ore_ont_12451` showed a **one-sided**
timeout at a 600 s cap (`=0` finished in 230 s, `=1` hit the cap) and was about to be recorded as
a loss. At a 1500 s cap with 2 repeats per arm it completes in **777 s / 775 s against
229 s / 228 s with all four triples identical** — 3.4× slower, same answer. `ore_ont_10080`, the
remaining unmeasured member, DNFs *symmetrically* (600 s / 601 s). **A one-sided timeout at a cap
is a candidate loss, not a loss.** The 3.4× is also the first measurement of that flag's
documented ~2× wall cost on this corpus, which is further reason the #110 fix should not be
"flip the flag".

The defect lives in `classify` and is independent of the widening — `verify-el` cannot even run
on that ontology today. The spike pointed at the shape; the instrument did not detect it.

## Method note kept in the doc

The first draft of this analysis claimed the market was **zero** and carried a `∎`. It was
written over five unread `eval.rs` arms and **two of them were holes**. Enumerate every arm a
universal quantifies over, or do not write the universal.

## Gates

`cargo fmt --all -- --check` clean; `cargo clippy -p owl-dl-verify --all-targets --all-features
-D warnings` clean; `owl-dl-verify` suite **93 passed / 0 failed**. No engine change, so no
FP=0 net or corpus sweep is implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzVE2TSVVMc3n8Wrce65Jg