### PR TITLE
fix(saturation): a conjunctive domain/range filler must not be dropped (#110)

### DIFF
--- a/crates/owl-dl-reasoner/tests/conjunctive_domain_range.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_domain_range.rs
@@ -1,0 +1,113 @@
+//! #110 — a conjunctive `ObjectPropertyDomain` / `ObjectPropertyRange` filler must
+//! not be dropped.
+//!
+//! `ObjectPropertyDomain(r, P ⊓ Q)` is `∃r.⊤ ⊑ P ⊓ Q`, which is exactly
+//! `∃r.⊤ ⊑ P` and `∃r.⊤ ⊑ Q` — a logical identity, so splitting it is sound and
+//! completeness-preserving by construction. The same holds on the range side.
+//!
+//! Before this, the saturator accepted only an ATOMIC filler and silently dropped a
+//! conjunctive one: `classify` returned zero rows with **`incomplete: false`** and
+//! `dropped: {}`, under a banner certifying the fragment complete — the D10 shape,
+//! where the answer is wrong *and* reported complete. Both peers derive the pairs
+//! (`Konclude` v0.7.0-1138 and `HermiT` 1.4.3, measured), and rustdl's own
+//! `subclass` proved them, so only `classify` was affected.
+//!
+//! The atomic controls are what show the cause is the CONJUNCTIVE filler rather
+//! than the domain/range mechanism: they derived their pair correctly throughout.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use std::io::Cursor;
+use std::time::Duration;
+
+fn holds(body: &str, sub: &str, sup: &str) -> bool {
+    let ofn = format!(
+        "Prefix(:=<http://rustdl.test/>)\nOntology(\n\
+         Declaration(Class(:P)) Declaration(Class(:Q)) Declaration(Class(:X))\n\
+         Declaration(Class(:B)) Declaration(Class(:D)) Declaration(Class(:Z))\n\
+         Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))\n\
+         {body}\n)\n"
+    );
+    let mut reader = Cursor::new(ofn);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    let result = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+    result.is_subclass(
+        &format!("http://rustdl.test/{sub}"),
+        &format!("http://rustdl.test/{sup}"),
+    )
+}
+
+const EXISTS: &str = "SubClassOf(:X ObjectSomeValuesFrom(:r :B))";
+
+#[test]
+fn a_conjunctive_domain_yields_every_conjunct() {
+    let body = format!("{EXISTS}\nObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))");
+    assert!(holds(&body, "X", "P"), "X ⊑ P (Konclude and HermiT agree)");
+    assert!(holds(&body, "X", "Q"), "X ⊑ Q (Konclude and HermiT agree)");
+}
+
+#[test]
+fn an_atomic_domain_still_works() {
+    // The discriminating control: this derived correctly even before #110, which is
+    // what isolates the conjunctive filler as the cause.
+    let body = format!("{EXISTS}\nObjectPropertyDomain(:r :P)");
+    assert!(holds(&body, "X", "P"));
+}
+
+#[test]
+fn a_conjunctive_range_yields_every_conjunct() {
+    // Measured to have the identical defect: `HermiT` derives `X ⊑ D`, rustdl
+    // reported `[]` with `incomplete: false`.
+    let body = format!(
+        "{EXISTS}\nObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))\n\
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)"
+    );
+    assert!(holds(&body, "X", "D"), "X ⊑ D (HermiT agrees)");
+}
+
+#[test]
+fn an_atomic_range_still_works() {
+    let body = format!(
+        "{EXISTS}\nObjectPropertyRange(:r :P)\n\
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)"
+    );
+    assert!(holds(&body, "X", "D"));
+}
+
+#[test]
+fn a_nested_conjunction_is_flattened() {
+    // `P ⊓ (Q ⊓ Z)` — the recursion, not just one level.
+    let body = format!(
+        "{EXISTS}\n\
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectIntersectionOf(:Q :Z)))"
+    );
+    assert!(holds(&body, "X", "P"));
+    assert!(holds(&body, "X", "Q"));
+    assert!(holds(&body, "X", "Z"));
+}
+
+#[test]
+fn a_filler_mixing_atomic_and_non_atomic_parts_still_drops_whole() {
+    // ALL-OR-NOTHING, on purpose. Taking the atomic half would be sound in
+    // isolation (`⊑ P ⊓ Z` entails `⊑ P`) but would put the ENGINE ahead of the
+    // fragment GATE, which decides membership separately — the gate would keep
+    // calling this out-of-fragment while the engine acted on part of it. That is
+    // the D10 shape this fix exists to close, so it must not be re-created here.
+    //
+    // If a future change teaches the gate about conjunctive fillers, this becomes
+    // the wrong assertion and should be FLIPPED rather than deleted.
+    let body = format!(
+        "{EXISTS}\n\
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :Z)))"
+    );
+    assert!(
+        !holds(&body, "X", "P"),
+        "a mixed filler must drop WHOLE, keeping engine and fragment gate in agreement"
+    );
+}

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -3462,12 +3462,16 @@ fn collect_el_rules(
                     // no individual may be an r-source. Poison the role so that
                     // any class deriving `∃r.X` is marked unsatisfiable.
                     rules.poisoned_roles.insert(role.role_id());
-                } else if let ConceptExpr::Atomic(id) = internal.concepts.get(*domain) {
+                } else if let Some(ids) = all_atomic_conjuncts(&internal.concepts, *domain) {
+                    // `ObjectPropertyDomain(r, P ⊓ Q)` ≡ `∃r.⊤ ⊑ P ⊓ Q` ≡
+                    // `∃r.⊤ ⊑ P` AND `∃r.⊤ ⊑ Q` — a logical identity, so splitting
+                    // is sound and completeness-preserving by construction (#110).
+                    // The atomic case is the one-element instance of it.
                     rules
                         .role_domains
                         .entry(role.role_id())
                         .or_default()
-                        .push(*id);
+                        .extend(ids);
                 }
             }
             Axiom::ObjectPropertyRange { role, range } => {
@@ -3478,12 +3482,16 @@ fn collect_el_rules(
                     // r-edge can exist in any model. Poison the role so that any
                     // class deriving `∃r.X` is marked unsatisfiable.
                     rules.poisoned_roles.insert(role.role_id());
-                } else if let ConceptExpr::Atomic(id) = internal.concepts.get(*range) {
+                } else if let Some(ids) = all_atomic_conjuncts(&internal.concepts, *range) {
+                    // Same identity on the range side: `Range(r, P ⊓ Q)` ≡
+                    // `Range(r, P)` AND `Range(r, Q)`. Measured to have the same
+                    // defect as the domain arm — HermiT derives the pair, rustdl
+                    // reported `[]` with `incomplete: false` (#110).
                     rules
                         .role_ranges
                         .entry(role.role_id())
                         .or_default()
-                        .push(*id);
+                        .extend(ids);
                 }
             }
             Axiom::SubObjectPropertyOf {
@@ -4455,6 +4463,39 @@ fn nested_extras(
     out.sort_unstable_by_key(|c| c.index());
     out.dedup();
     out
+}
+
+/// The atomic conjuncts of a domain/range filler, or `None` if any part is not
+/// atomic.
+///
+/// `C` alone when `C` is atomic; each operand when `C` is an `And` of atomics,
+/// recursively. `ObjectPropertyDomain(r, P ⊓ Q)` is `∃r.⊤ ⊑ P ⊓ Q`, which is
+/// exactly `∃r.⊤ ⊑ P` and `∃r.⊤ ⊑ Q` — a logical identity, hence sound and
+/// completeness-preserving by construction (#110). Before this, only the atomic
+/// case was accepted and a conjunctive filler was silently DROPPED: `classify`
+/// returned zero rows with `incomplete: false` under a banner certifying the
+/// fragment complete, while both peer reasoners derived the pairs and rustdl's own
+/// `subclass` proved them.
+///
+/// ALL-OR-NOTHING on purpose. A filler mixing atomic and non-atomic parts (say
+/// `P ⊓ ∃s.Z`) still drops WHOLE, exactly as before, rather than contributing its
+/// atomic half. Taking the half would be sound in isolation — `⊑ P ⊓ Z` entails
+/// `⊑ P` — but it would put the ENGINE ahead of the fragment GATE, which decides
+/// membership separately: the gate would keep calling the axiom out-of-fragment
+/// while the engine quietly acted on part of it. Keeping the two in agreement is
+/// what avoids re-creating the D10 shape this fix exists to close.
+fn all_atomic_conjuncts(pool: &ConceptPool, c: ConceptId) -> Option<Vec<ClassId>> {
+    match pool.get(c) {
+        ConceptExpr::Atomic(id) => Some(vec![*id]),
+        ConceptExpr::And(ops) => {
+            let mut out = Vec::with_capacity(ops.len());
+            for op in ops {
+                out.extend(all_atomic_conjuncts(pool, *op)?);
+            }
+            Some(out)
+        }
+        _ => None,
+    }
 }
 
 /// `effective_ranges[r]`, or an empty slice for a role with no range.


### PR DESCRIPTION
Closes #110.

```
ObjectPropertyDomain(r, P ⊓ Q)  ≡  ∃r.⊤ ⊑ P ⊓ Q  ≡  ∃r.⊤ ⊑ P  and  ∃r.⊤ ⊑ Q
```

The saturator accepted only an **atomic** filler and silently dropped a conjunctive one.
`classify` returned zero rows with **`incomplete: false`** and `dropped: {}`, under a banner
certifying the fragment complete — the D10 shape, where the answer is wrong *and* reported
complete. Both peers derive the pairs and rustdl's own `subclass` proved them, so only `classify`
was affected.

Splitting is a **logical identity**, hence sound and completeness-preserving by construction; the
atomic case is its one-element instance. Unflagged for that reason.

## The issue understated it: range has the same defect

#110 documents only the domain side. Measured before assuming — `ObjectPropertyRange(r, P ⊓ Q)`
with `∃r.(B ⊓ P) ⊑ D`:

| | result |
|---|---|
| rustdl, before | `[]`, `incomplete: false` |
| HermiT 1.4.3 | `X ⊑ D` |

Fixing only what the issue named would have left half of it live. Both arms now split, both
canaried.

## Verified

| fixture | after | oracles |
|---|---|---|
| conjunctive domain | `X ⊑ P`, `X ⊑ Q` | **Konclude and HermiT both confirm** |
| conjunctive range | `X ⊑ D` | HermiT confirms |
| atomic domain / range (controls) | unchanged | — |
| nested `P ⊓ (Q ⊓ Z)` | all three conjuncts | — |

## All-or-nothing, deliberately

A filler mixing atomic and non-atomic parts (`P ⊓ ∃s.Z`) still drops **whole**. Taking the atomic
half would be sound in isolation — `⊑ P ⊓ Z` entails `⊑ P` — but it would put the **engine ahead of
the fragment gate**, which decides membership separately: the gate would keep calling the axiom
out-of-fragment while the engine quietly acted on part of it. That is exactly the D10 shape this
fix closes. The canary says to **flip** rather than delete it if the gate ever learns conjunctive
fillers.

The issue's predicted mechanism was right: teaching `role_domains` the conjunctive filler gives `X`
its EL subsumers and fixes the tier walk as a **side effect**. No tier-walk change was needed, and
`RUSTDL_CLASSIFY_SAME_TIER` stays default-OFF with its corpus-invisible justification intact.

## Sabotage: 3 run, 3 caught

| # | sabotage | caught by |
|---|---|---|
| S1 | revert to atomic-only | 3 tests |
| S2 | drop the `?` — take the atomic half of a mixed filler | the boundary canary, alone |
| S3 | fix domain only, leave range dropping | the range canary, alone |

## Corpus: 0 regressions, 0 answer changes

Two-arm sweep over the **27** ontologies carrying a conjunctive domain/range filler — a wider frame
than the issue's 14, since range is matched too — arm order alternated:

**12 IDENTICAL / 2 BOTH_DNF / 13 DIFFER**, and all 13 adjudicate clean. Twelve are
`gained=0 lost=0`. The one with movement, `ore_ont_10517` (674 gained / 385 lost, both arms
`incomplete: true`), is settled by the control: the **unchanged** binary swings **861/254** and
**804/221** against *itself* — larger than the arms differ from each other.

**So the fix is corpus-invisible**, stated plainly rather than dressed up: it derives entailments
both peers confirm on the reproducers and changes nothing on the 27 ORE ontologies carrying the
construct. Same verdict as #84 and #42 item 2 — the axioms are present, the *consumer* pattern is
not. The canaries and the oracle adjudication are the evidence; the sweep is non-regression
evidence only.

## Gates

- suite **1953 passed / 0 failed** (`CARGO_EXIT=0`)
- FP=0 net **11 VERIFIED, every closure exact**, no mismatches
- `cargo clippy --workspace --all-targets --all-features` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
