### PR TITLE
fix(convert): flatten a union of enumerations in data cardinality positions (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1678,9 +1678,55 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
     integer interval set can express — bare DATATYPES (`xsd:decimal`), `DataComplementOf`,
     other-datatype enumerations — which drop WHOLE and VISIBLY (`dropped` is non-empty),
     never narrowed; interval unions over the five DENSE datatypes (see the discreteness
-    note above); `DataIntersectionOf` in these positions; and qualified data CARDINALITY
-    over a union (`≥3 p.({1} ⊔ {2})`), which takes a different path and which Konclude
-    also does not call unsat.
+    note above); and `DataIntersectionOf` in these positions.
+
+  - **Qualified data CARDINALITY over a union — CLOSED 2026-09-06 (#42).** The list above
+    said it "takes a different path", which was true and is now fixed: the three
+    `Data{Min,Max,Exact}Cardinality` arms pre-flatten with the SAME
+    `flatten_union_of_oneofs` the `∀`/range path already used, so the two cannot drift.
+    A union of enumerations IS one enumeration, so the rewrite is a logical identity —
+    sound and completeness-preserving by construction, for `≤` and `=` as much as `≥`.
+    `≥3 p.({1} ⊔ {2})` goes from satisfiable-with-the-axiom-DROPPED to UNSAT.
+  - **THE PEERS SPLIT BY OPERATOR, IN OPPOSITE DIRECTIONS — name the operator before
+    citing one.** On `≥n` over a union `HermiT` is right while Konclude and `JFact`
+    under-report. On `≤n`/`=n` it REVERSES: Konclude and `JFact` are right and **`HermiT`
+    answers satisfiable — the first `HermiT` under-report recorded in this project.** The
+    discriminating control is that `HermiT` decides the identical hand-written
+    `DataOneOf` correctly, so it can do the reasoning and simply does not see through
+    `DataUnionOf` in a `≤`/`=` position. The first draft of this fix asserted "HermiT
+    agrees" in all three arms; that was true only for `Min`. (This also RETIRES the old
+    residual line's "which Konclude also does not call unsat" — true, but it was stated
+    as if it justified the drop, and Konclude is on the WRONG side for `≥`.)
+  - **KNOWN PRE-EXISTING SILENT MISS, surfaced by this work and NOT fixed by it:**
+    `≤1 p.DataOneOf(1 2)` with two `DataHasValue` witnesses is SATISFIABLE with
+    `incomplete: false` and `dropped: {}`, while `HermiT`, Konclude and `JFact` all say
+    unsat. `DataHasValue` lowers to the RANGE bucket `[v,v]` while `≤n`-over-enumeration
+    lands in the `io:` bucket, and `concrete_domain_clash` checks buckets independently.
+    D10 shape — wrong AND reported complete. **Practical consequence: a `≤`/`=` canary
+    MUST use `DataSomeValuesFrom(p, DataOneOf(v))` witnesses**, or it fails against a
+    CORRECT engine and invites "fixing" the implementation to match.
+  - **CORPUS REACH IS PROVABLY ZERO, verified independently.** All 1,920 ORE files are
+    OFN, so a `DataUnionOf` grep is a genuine superset (no RDF/XML `owl:unionOf` route);
+    exactly ONE ontology authors one (`ore_ont_5964`); and it appears in **zero**
+    cardinality positions, so the changed arms are never entered. Evidence is 11 canaries
+    plus the per-operator peer adjudication, never a sweep.
+  - **SABOTAGE: 4 run, 4 caught — but TWO survived the FIRST suite.** Reverting the
+    flatten in the `Max`+`Exact` arms only, and a `members.len() != 2` guard, each left
+    all 21 tests across three files green: every canary was `DataMinCardinality`, and
+    EVERY union in all three files plus the `convert.rs` unit pin has exactly two
+    top-level members. A third (integer-only `collect`) was caught only by a NEIGHBOURING
+    file for an unrelated reason — so this file's coverage was incidental and would have
+    vanished silently had that neighbour been retargeted. **Instantiating one arbitrary
+    shape is not pinning the general case.** Closed by 5 canaries; the re-run catches all
+    4, each by exactly one named test.
+  - **TWO STALE-BINARY FALSE ALARMS IN ONE SESSION, both nearly published.** "The fix
+    does not work for `Max`" and "flat 3-member unions drop" were BOTH artifacts of a
+    stale `target/release/rustdl` — the gotcha this file opens with. The second was
+    settled by instrumenting the arm: the flatten fired identically in both cases
+    (`lits=3`, `parse_integer_oneof=Some(3)`), which makes differing outcomes impossible
+    and points at the binary rather than the code. **When two runs of "the same" source
+    disagree, print what the code DID before theorising about why.** The build-to-build
+    discrepancy itself is UNEXPLAINED and recorded as such rather than given a cause.
 
   Synthetic test harness: `crates/owl-dl-reasoner/tests/datatype_completeness.rs`
   (6 fixtures under `tests/fixtures/datatype/`; all 6 pass post-D5).

--- a/crates/owl-dl-core/src/convert.rs
+++ b/crates/owl-dl-core/src/convert.rs
@@ -844,6 +844,33 @@ pub(crate) fn bucket_to_dkey_iri(b: RangeBucket) -> String {
 /// subsumption (and, for ∀, the `DisjointClasses` seeding). Returns `None`
 /// for any range the datatype machinery doesn't recognize, so the caller
 /// emits `UnsupportedDataRange` and the whole axiom drops (sound).
+/// Why the three `Data{Min,Max,Exact}Cardinality` arms pre-flatten their range.
+///
+/// A union of ENUMERATIONS is one enumeration — `{1} ⊔ {2}` IS `{1,2}` — and none
+/// of the per-datatype `lower_*_data_cardinality` parsers recognises a
+/// `DataUnionOf`, so without the flatten the whole axiom DROPPED (visibly, via
+/// `dropped`). OWL 2 Direct Semantics:
+///
+/// ```text
+/// DataMinCardinality( n DPE DR ) = { x | #{ y | (x,y) ∈ (DPE)^DP and y ∈ (DR)^DT } ≥ n }
+/// DataOneOf( lt1 ... ltn )       = { (lt1)^LT , ... , (ltn)^LT }
+/// ```
+///
+/// `#` counts DISTINCT values, so the flattened form denotes exactly the same set
+/// and the rewrite is a logical identity — sound and completeness-preserving by
+/// construction, for `≤` and `=` as much as for `≥`.
+///
+/// **NAME THE OPERATOR BEFORE CITING A PEER — they split, and in opposite
+/// directions.** On `≥n` over a union, `HermiT` is right while Konclude and `JFact`
+/// under-report. On `≤n`/`=n` it REVERSES: Konclude and `JFact` are right and
+/// `HermiT` answers satisfiable, the first `HermiT` under-report recorded here.
+/// The control that makes that a finding rather than noise is that `HermiT`
+/// decides the identical hand-written `DataOneOf` correctly.
+///
+/// ALL-OR-NOTHING is inherited from [`flatten_union_of_oneofs`] and is
+/// FP-critical: a partial flatten would yield a strictly NARROWER range, which in
+/// a `≤n` position manufactures a clash.
+///
 /// Flatten `DataUnionOf` whose members are ALL enumerations into one `DataOneOf`
 /// (#42 item 1).
 ///
@@ -1350,6 +1377,11 @@ pub fn convert_class_expression<A: ForIRI>(
         // so this never materialises successors (it would otherwise blow up on
         // a large `≥n` over a tiny range).
         ClassExpression::DataMinCardinality { n, dp, dr } => {
+            // #42: flatten a union of enumerations before the per-datatype chain —
+            // see `flatten_union_of_oneofs_for_cardinality` for the identity, the
+            // per-operator oracle split, and why this must not be a partial flatten.
+            let flat = flatten_union_of_oneofs(dr);
+            let dr = flat.as_ref().unwrap_or(dr);
             lower_int_data_cardinality(*n, dp, dr, vocab, pool, true, false)
                 .or_else(|_| lower_str_data_cardinality(*n, dp, dr, vocab, pool, true, false))
                 .or_else(|_| lower_float_data_cardinality(*n, dp, dr, vocab, pool, true, false))
@@ -1375,6 +1407,11 @@ pub fn convert_class_expression<A: ForIRI>(
                 })
         }
         ClassExpression::DataMaxCardinality { n, dp, dr } => {
+            // #42: flatten a union of enumerations before the per-datatype chain —
+            // see `flatten_union_of_oneofs_for_cardinality` for the identity, the
+            // per-operator oracle split, and why this must not be a partial flatten.
+            let flat = flatten_union_of_oneofs(dr);
+            let dr = flat.as_ref().unwrap_or(dr);
             lower_int_data_cardinality(*n, dp, dr, vocab, pool, false, true)
                 .or_else(|_| lower_str_data_cardinality(*n, dp, dr, vocab, pool, false, true))
                 .or_else(|_| lower_float_data_cardinality(*n, dp, dr, vocab, pool, false, true))
@@ -1400,6 +1437,11 @@ pub fn convert_class_expression<A: ForIRI>(
                 })
         }
         ClassExpression::DataExactCardinality { n, dp, dr } => {
+            // #42: flatten a union of enumerations before the per-datatype chain —
+            // see `flatten_union_of_oneofs_for_cardinality` for the identity, the
+            // per-operator oracle split, and why this must not be a partial flatten.
+            let flat = flatten_union_of_oneofs(dr);
+            let dr = flat.as_ref().unwrap_or(dr);
             lower_int_data_cardinality(*n, dp, dr, vocab, pool, true, true)
                 .or_else(|_| lower_str_data_cardinality(*n, dp, dr, vocab, pool, true, true))
                 .or_else(|_| lower_float_data_cardinality(*n, dp, dr, vocab, pool, true, true))

--- a/crates/owl-dl-reasoner/tests/data_cardinality_over_union.rs
+++ b/crates/owl-dl-reasoner/tests/data_cardinality_over_union.rs
@@ -1,0 +1,233 @@
+//! #42 — qualified data cardinality over a UNION of enumerations.
+//!
+//! `≥3 p.({1} ⊔ {2})` is unsatisfiable, and rustdl used to report the class
+//! satisfiable while dropping the axiom (visibly, via `dropped`). OWL 2 Direct
+//! Semantics:
+//!
+//! ```text
+//! DataMinCardinality( n DPE DR ) = { x | #{ y | (x,y) ∈ (DPE)^DP and y ∈ (DR)^DT } ≥ n }
+//! DataOneOf( lt1 ... ltn )       = { (lt1)^LT , ... , (ltn)^LT }
+//! ```
+//!
+//! `#` counts DISTINCT values and `{1} ⊔ {2}` denotes the 2-element set `{1,2}`, so
+//! `≥ 3` cannot be met and the class is empty.
+//!
+//! # The peers split, and the majority is on the wrong side
+//!
+//! **The peers split DIFFERENTLY for `≥` than for `≤`/`=`, so name the operator
+//! before citing one.** On `≥n` over a union `HermiT` is right and Konclude and
+//! `JFact` under-report (Konclude's ninth recorded instance, `JFact`'s first). On
+//! `≤n`/`=n` it REVERSES: Konclude and `JFact` are right and **`HermiT` answers
+//! satisfiable** — the first `HermiT` under-report recorded in this project.
+//! The discriminating control is that `HermiT` decides the identical
+//! hand-written `DataOneOf` correctly, so it can do the reasoning and simply
+//! does not see through `DataUnionOf` in a `≤`/`=` position. Kobayashi-MaRust
+//! v1.3.0 also says satisfiable, but its answer carries no weight in that direction:
+//! it misses an unsat that all four other reasoners agree on
+//! (`∀p.(≥1 ⊓ ≤10)` with `∃p.{50}`), so its `satisfiable` is uninformative while its
+//! `unsat` is not. **Do not resolve this by counting reasoners** — the semantics
+//! decide it, and the boundary pair below is what shows `HermiT` is reasoning about
+//! the set SIZE rather than refusing the construct.
+//!
+//! The fix reuses `flatten_union_of_oneofs`, the same helper (and the same
+//! all-or-drop discipline) the `∀`/range path already uses, so the two cannot drift.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use std::io::Cursor;
+use std::time::Duration;
+
+fn unsat(body: &str) -> bool {
+    let ofn = format!(
+        "Prefix(:=<http://ex.org/>)\n\
+         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n\
+         Ontology(<http://ex.org/c>\n\
+         Declaration(Class(:A)) Declaration(DataProperty(:p))\n\
+         {body}\n)\n"
+    );
+    let mut reader = Cursor::new(ofn);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    let result = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+    result
+        .unsatisfiable_classes()
+        .iter()
+        .any(|c| c.ends_with("/A"))
+}
+
+/// Two DISTINCT witnesses, as `DataSomeValuesFrom(p, DataOneOf(v))` — see
+/// `max_cardinality_below_the_union_size_is_unsatisfiable` for why `DataHasValue`
+/// cannot be used here.
+const WITNESSES: &str = "SubClassOf(:A DataSomeValuesFrom(:p DataOneOf(\"1\"^^xsd:integer)))\n\
+     SubClassOf(:A DataSomeValuesFrom(:p DataOneOf(\"2\"^^xsd:integer)))";
+
+const UNION2: &str = "DataUnionOf(DataOneOf(\"1\"^^xsd:integer) DataOneOf(\"2\"^^xsd:integer))";
+
+#[test]
+fn min_cardinality_above_the_union_size_is_unsatisfiable() {
+    assert!(
+        unsat(&format!("SubClassOf(:A DataMinCardinality(3 :p {UNION2}))")),
+        "≥3 over a 2-value union is unsatisfiable by the OWL 2 semantics (HermiT agrees)"
+    );
+}
+
+#[test]
+fn min_cardinality_at_the_union_size_stays_satisfiable() {
+    // THE BOUNDARY CONTROL, one integer from its twin above. Without it, "≥n is
+    // unsat" would be satisfied by an implementation that calls every qualified
+    // min-cardinality unsatisfiable. HermiT gives the same discriminating pair,
+    // which is what shows it reasons about the set SIZE.
+    assert!(
+        !unsat(&format!("SubClassOf(:A DataMinCardinality(2 :p {UNION2}))")),
+        "≥2 over a 2-value union is satisfiable — FALSE POSITIVE if this trips"
+    );
+}
+
+#[test]
+fn the_plain_enumeration_form_still_works() {
+    // Worked before the union flattening reached the cardinality path; pins that it
+    // was not disturbed.
+    assert!(unsat(
+        "SubClassOf(:A DataMinCardinality(3 :p DataOneOf(\"1\"^^xsd:integer \"2\"^^xsd:integer)))"
+    ));
+}
+
+#[test]
+fn a_nested_union_flattens_too() {
+    // `⊔` is associative; the helper recurses.
+    let nested = "DataUnionOf(DataOneOf(\"1\"^^xsd:integer) \
+                  DataUnionOf(DataOneOf(\"2\"^^xsd:integer) DataOneOf(\"3\"^^xsd:integer)))";
+    assert!(
+        unsat(&format!("SubClassOf(:A DataMinCardinality(4 :p {nested}))")),
+        "≥4 over a 3-value nested union is unsatisfiable"
+    );
+    assert!(
+        !unsat(&format!("SubClassOf(:A DataMinCardinality(3 :p {nested}))")),
+        "≥3 over a 3-value nested union is satisfiable"
+    );
+}
+
+#[test]
+fn duplicate_values_across_the_union_are_counted_once() {
+    // `{1,2} ⊔ {2,3}` has THREE distinct values, not four — dedup is by VALUE.
+    // Over-counting here would make `≥4` satisfiable (a MISS); under-counting would
+    // make `≥3` unsatisfiable (a FALSE POSITIVE). Both directions are pinned.
+    let overlap = "DataUnionOf(DataOneOf(\"1\"^^xsd:integer \"2\"^^xsd:integer) \
+                   DataOneOf(\"2\"^^xsd:integer \"3\"^^xsd:integer))";
+    assert!(
+        unsat(&format!(
+            "SubClassOf(:A DataMinCardinality(4 :p {overlap}))"
+        )),
+        "the union holds 3 distinct values, so ≥4 is unsatisfiable"
+    );
+    assert!(
+        !unsat(&format!(
+            "SubClassOf(:A DataMinCardinality(3 :p {overlap}))"
+        )),
+        "≥3 is satisfiable over 3 distinct values — FALSE POSITIVE if this trips"
+    );
+}
+
+#[test]
+fn max_cardinality_below_the_union_size_is_unsatisfiable() {
+    // CLOSES SABOTAGE SURVIVOR 1: reverting the flatten in the `Max`+`Exact` arms
+    // ONLY left all 21 tests across three files green, because every canary here
+    // was `DataMinCardinality`.
+    //
+    // WITNESSES MUST BE `DataSomeValuesFrom(p, DataOneOf(v))`, NOT `DataHasValue`.
+    // `DataHasValue` lowers to the RANGE bucket `[v,v]` while `≤n`-over-enumeration
+    // lands in the `io:` bucket, and `concrete_domain_clash` checks buckets
+    // independently — so the `DataHasValue` spelling is SATISFIABLE on correct code
+    // (a pre-existing SILENT miss: `incomplete: false`, `dropped: {}`, while all
+    // three peers say unsat). Writing this canary the obvious way would fail against
+    // a correct engine and invite "fixing" the implementation to match.
+    //
+    // Oracle: Konclude and JFact. `HermiT` says SATISFIABLE here — see the header.
+    assert!(
+        unsat(&format!(
+            "SubClassOf(:A DataMaxCardinality(1 :p {UNION2}))\n{WITNESSES}"
+        )),
+        "two distinct values both in a 2-value union cannot satisfy ≤1"
+    );
+}
+
+#[test]
+fn max_cardinality_at_the_union_size_stays_satisfiable() {
+    // The boundary twin, one integer away — without it the test above is satisfied
+    // by an implementation that calls every `≤n` unsatisfiable.
+    assert!(
+        !unsat(&format!(
+            "SubClassOf(:A DataMaxCardinality(2 :p {UNION2}))\n{WITNESSES}"
+        )),
+        "≤2 with two witnesses is satisfiable — FALSE POSITIVE if this trips"
+    );
+}
+
+#[test]
+fn exact_cardinality_over_a_union_is_flattened_in_both_directions() {
+    // `=n` is `≥n ⊓ ≤n`, so it must fail for BOTH reasons. `=1` with two distinct
+    // witnesses violates the `≤` half; `=3` over a 2-value union violates the `≥`
+    // half; `=2` satisfies both and pins that the arm is not simply always-unsat.
+    assert!(unsat(&format!(
+        "SubClassOf(:A DataExactCardinality(1 :p {UNION2}))\n{WITNESSES}"
+    )));
+    assert!(unsat(&format!(
+        "SubClassOf(:A DataExactCardinality(3 :p {UNION2}))"
+    )));
+    assert!(!unsat(&format!(
+        "SubClassOf(:A DataExactCardinality(2 :p {UNION2}))"
+    )));
+}
+
+#[test]
+fn a_flat_three_member_union_flattens() {
+    // CLOSES SABOTAGE SURVIVOR 2: a `members.len() != 2 => None` guard survived the
+    // entire suite, because EVERY union in all three test files — and the unit pin
+    // in `convert.rs` — has exactly two top-level members. `a_nested_union_flattens_too`
+    // does not cover this: it is 2-member at the top and nests.
+    let u3 = "DataUnionOf(DataOneOf(\"1\"^^xsd:integer) DataOneOf(\"2\"^^xsd:integer) \
+              DataOneOf(\"3\"^^xsd:integer))";
+    assert!(
+        unsat(&format!("SubClassOf(:A DataMinCardinality(4 :p {u3}))")),
+        "≥4 over a flat 3-value union is unsatisfiable"
+    );
+    assert!(
+        !unsat(&format!("SubClassOf(:A DataMinCardinality(3 :p {u3}))")),
+        "≥3 over a flat 3-value union is satisfiable"
+    );
+}
+
+#[test]
+fn the_identity_is_not_integer_specific() {
+    // Makes this file SELF-SUFFICIENT. Filtering `collect` to `xsd:integer` literals
+    // survived every test here and was caught only by a neighbouring file, for an
+    // unrelated reason — so the coverage was incidental and would vanish silently if
+    // that neighbour were ever retargeted.
+    let us = "DataUnionOf(DataOneOf(\"a\"^^xsd:string) DataOneOf(\"b\"^^xsd:string))";
+    assert!(
+        unsat(&format!("SubClassOf(:A DataMinCardinality(3 :p {us}))")),
+        "≥3 over a 2-value STRING union is unsatisfiable"
+    );
+    assert!(
+        !unsat(&format!("SubClassOf(:A DataMinCardinality(2 :p {us}))")),
+        "≥2 over a 2-value STRING union is satisfiable"
+    );
+}
+
+#[test]
+fn a_union_carrying_a_non_enumeration_member_still_drops() {
+    // ALL-OR-DROP, inherited from `flatten_union_of_oneofs`. A partial flatten would
+    // be a strictly weaker range, which is unsound in the sufficient direction. The
+    // class stays satisfiable (a sound MISS, and a VISIBLE one — `dropped` is set).
+    let mixed = "DataUnionOf(DataOneOf(\"1\"^^xsd:integer) \
+                 DatatypeRestriction(xsd:integer xsd:minInclusive \"100\"^^xsd:integer))";
+    assert!(
+        !unsat(&format!("SubClassOf(:A DataMinCardinality(3 :p {mixed}))")),
+        "a union with a non-enumeration member must drop whole, not flatten partially"
+    );
+}


### PR DESCRIPTION
Refs #42 — the last item on the residual list.

`≥3 p.({1} ⊔ {2})` reported the class **satisfiable while dropping the axiom**. OWL 2 Direct
Semantics:

```
DataMinCardinality( n DPE DR ) = { x | #{ y | (x,y) ∈ (DPE)^DP and y ∈ (DR)^DT } ≥ n }
DataOneOf( lt1 ... ltn )       = { (lt1)^LT , ... , (ltn)^LT }
```

`#` counts **distinct** values and `{1} ⊔ {2}` denotes the 2-element set `{1,2}`, so `≥3` is
unmeetable.

The three `Data{Min,Max,Exact}Cardinality` arms now pre-flatten with the **same**
`flatten_union_of_oneofs` the `∀`/range path already used — one helper, one all-or-drop
discipline, so the two cannot drift. A union of enumerations *is* one enumeration, so this is a
logical identity: sound and completeness-preserving by construction, for `≤` and `=` as much as
`≥`. Unflagged for that reason.

## The peers split by operator, in opposite directions

| probe | rustdl | HermiT | JFact | Konclude | **spec** |
|---|---|---|---|---|---|
| `≥3` over a 2-value union | UNSAT | UNSAT | sat | sat | **UNSAT** |
| `≤1` over a 2-value union, 2 witnesses | UNSAT | **sat** | UNSAT | UNSAT | **UNSAT** |
| `≤1` plain `DataOneOf` (control) | UNSAT | UNSAT | UNSAT | UNSAT | **UNSAT** |

On `≥n` HermiT is right; on `≤n`/`=n` it **reverses** and HermiT answers satisfiable — the
**first HermiT under-report recorded in this project**. Row 3 is what makes that a finding
rather than noise: HermiT decides the identical hand-written `DataOneOf` correctly, so it can do
the reasoning and simply does not see through `DataUnionOf` in a `≤`/`=` position.

My first draft asserted "HermiT agrees" in all three arms — true only for `Min`. The comment now
lives in one doc home and names the operator before citing a peer.

## Sabotage: 4 run, 4 caught — but two survived the first suite

| mutation | first suite | now |
|---|---|---|
| revert flatten in `Max`+`Exact` only | **survived all 21 tests** | 2 tests fail |
| `members.len() != 2 → None` | **survived all 21 tests** | flat-3 test, alone |
| `collect` keeps only `xsd:integer` | caught only by a *neighbouring file* | string test, alone |
| loosen all-or-nothing (`_ => false → true`) | caught | mixed-member test, alone |

Every canary was `DataMinCardinality`, and every union in all three files — plus the `convert.rs`
unit pin — had exactly **two** top-level members. The third case is the subtler one: this file's
coverage was *incidental*, and would have vanished silently had that neighbour ever been
retargeted. **Instantiating one arbitrary shape is not pinning the general case.**

## A trap in writing the `≤` canary

It **must** use `DataSomeValuesFrom(p, DataOneOf(v))` witnesses. `DataHasValue` lowers to the
range bucket while `≤n`-over-enumeration lands in the `io:` bucket, and `concrete_domain_clash`
checks buckets independently — so the obvious spelling is **satisfiable on correct code**, a
pre-existing *silent* miss (`incomplete: false`, `dropped: {}`) that all three peers call unsat.
Surfaced by this work, **not fixed by it**, and recorded: written the obvious way, the canary
fails against a correct engine and invites "fixing" the implementation to match.

## Corpus reach is provably zero

Verified independently: all 1,920 ORE files are OFN (so a `DataUnionOf` grep is a genuine
superset — no RDF/XML `owl:unionOf` route), exactly **one** ontology authors one, and it appears
in **zero** cardinality positions, so the changed arms are never entered. The evidence here is
the 11 canaries plus the per-operator peer adjudication — not a sweep.

## Gates

- suite **1958 passed / 0 failed** (`CARGO_EXIT=0`, captured directly)
- FP=0 net **12 VERIFIED, every closure exact**, zero mismatches
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
