### PR TITLE
fix(saturation): a non-atomic GCI domain head must not be discarded (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1858,6 +1858,52 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   paths can label one logical nested-existential witness differently and get deduped into two
   separate elements — not shown unsound, but untested against a future concept-level check).
 
+> **A NON-ATOMIC GCI DOMAIN HEAD WAS DISCARDED, NOT DROPPED (2026-09-06, #114, unflagged) — THE
+> SAME D10 FAMILY AS #110, ONE SPELLING OVER.** `SubClassOf(ObjectSomeValuesFrom(:r owl:Thing), C)`
+> is the GCI spelling of `ObjectPropertyDomain(r, C)`. Its arm pushed
+> `atomic_operands_on_right(sup, pool)` into `role_domains`, and that helper keeps only `Atomic`
+> operands and returns `Vec::new()` for anything else — so `∃r.⊤ ⊑ ∃s.S` pushed **nothing** and the
+> axiom vanished, while `is_el_concept` admits `∃s.S`, so the gate certified the ontology
+> **pure-EL**, the fragment where the saturator runs alone and no tableau follows. `classify`
+> returned ZERO rows with `incomplete: false` and `dropped: {}` where **both Konclude and HermiT**
+> derive `X ⊑ Z`. The mixed head `P ⊓ ∃s.S` was subtler: the atomic conjunct survived, so the answer
+> looked partially right. Fixed by routing the head through
+> `atomic_or_tseitin_body_with_extras` — the same lowering every other RHS site uses, which for an
+> `∃` body mints the EQUIVALENT (two-way) marker, so a downstream `∃s.S ⊑ Z` trigger fires on it.
+> Splitting `⊑ C₁ ⊓ … ⊓ Cₙ` is a logical identity, hence unflagged.
+>
+> **THREE SABOTAGES SURVIVED AND THE FIX WAS THE ANSWER, NOT MORE TESTS.** Round 1: dropping the
+> helper's own `And` split, and a `Top` conjunct pushing `ClassId::new(0)`, both left all six
+> canaries green. Round 2: dropping the `Atomic` fast path did too. All three were **equivalent
+> mutations of branches nothing needed** — `atomic_or_tseitin_body_with_extras` already lowers a
+> conjunctive head and already returns the bare id for an atomic one. **The branches were DELETED
+> rather than pinned**, reducing the helper to one path and making those three mutations
+> unconstructible. Writing a canary for a branch that is provably redundant records coverage you do
+> not have. What remains is caught: reverting to `atomic_operands_on_right` fails 3 tests, and a
+> non-atomic arm returning nothing fails 3.
+>
+> **CORPUS REACH IS PROVABLY ZERO, AND THE FIRST INSTRUMENT SAID 91.** A census over the **157** ORE
+> ontologies carrying a GCI-domain axiom finds **0 of 157** with a non-atomic head, across **8,585**
+> such axioms — the changed arm cannot fire on ORE. The first pass reported **91** because the
+> regex truncated heads at 50 characters and read a bare `<http://…>` IRI as non-atomic; the
+> corrected extractor balances parens. Two-arm sweep over those 157, pinned binaries: **154
+> IDENTICAL / 3 BOTH_DNF / 0 DIFFER**. So the sweep is non-regression evidence only and the real
+> evidence is 6 canaries plus the Konclude/HermiT adjudication — the same verdict as #110, #84 and
+> #42 item 2, where the axioms exist but the CONSUMER pattern does not.
+>
+> **A SIBLING GAP THE ISSUE DOES NOT REPORT, MEASURED AND LEFT OPEN.** The AXIOM spelling
+> `ObjectPropertyDomain(r, ∃s.S)` still misses, confirmed by both oracles. Its Pass-1 arm runs
+> during axiom collection, **before `effective_ranges` is built**, so the marker machinery this fix
+> uses is not available there; closing it means moving the arm or deferring it to Pass 2, which is a
+> larger change than #114 asks for. Pinned by
+> `a_nonatomic_domain_on_the_axiom_spelling_is_a_known_sibling_miss`, which asserts the CURRENT
+> (missing) behaviour and instructs a future fix to FLIP it rather than delete it — see
+> [[tests-that-pin-the-bug]].
+>
+> Canaries `crates/owl-dl-reasoner/tests/gci_domain_nonatomic_head.rs` (6, incl. an atomic-head
+> discriminating control and an FP guard on a source with no `r`-successor). Gates: suite 1970/0;
+> FP=0 net 12 VERIFIED, every closure exact; clippy `--all-targets --all-features` exit 0.
+
 > **CHAIN-INDUCED RANGE FOLDING (2026-09-05, #84, unflagged) — THE SIBLING OF #81, KEYED ON A
 > ROLE PAIR.** `Chain(t,u) ⊑ r` + `Range(r,F)` + `C ⊑ ∃t.∃u.A` + `∃t.∃u.F ⊑ D` entails `C ⊑ D`,
 > and `classify` reported only `F ⊑ G` with **`incomplete: false`** — the D10 shape. `HermiT`

--- a/crates/owl-dl-reasoner/tests/gci_domain_nonatomic_head.rs
+++ b/crates/owl-dl-reasoner/tests/gci_domain_nonatomic_head.rs
@@ -1,0 +1,138 @@
+//! #114 — `SubClassOf(ObjectSomeValuesFrom(r, owl:Thing), C)` with a NON-ATOMIC `C`.
+//!
+//! That GCI is the spelling of `ObjectPropertyDomain(r, C)`. The saturator routed its
+//! head through `atomic_operands_on_right`, which keeps only `Atomic` operands and
+//! returns nothing for anything else — so `∃r.⊤ ⊑ ∃s.S` pushed NO domain entry and the
+//! axiom vanished.
+//!
+//! # Why this was the worst shape in the D10 family
+//!
+//! `is_el_concept` admits `∃s.S`, so the ontology is certified **`pure-EL`** — the
+//! fragment where the saturator is claimed complete on its own and **no tableau runs at
+//! all**. `classify` returned zero rows with `incomplete: false` and `dropped: {}` while
+//! Konclude v0.7.0-1138 and `HermiT` 1.4.3 both derive `X ⊑ Z` (measured). A wrong
+//! answer under the strongest completeness banner the project makes.
+//!
+//! The mixed head `P ⊓ ∃s.S` was subtler and is canaried separately: the atomic conjunct
+//! survived, so the output looked partially right rather than empty.
+//!
+//! # Known sibling, deliberately NOT fixed here
+//!
+//! The `ObjectPropertyDomain(r, ∃s.S)` AXIOM spelling has the same gap and still misses
+//! (`a_nonatomic_domain_on_the_axiom_spelling_is_a_known_sibling_miss` pins it). Its arm
+//! runs in Pass 1, BEFORE `effective_ranges` is built, so the marker machinery this fix
+//! uses is not yet available there; closing it needs a pass restructure, not a shared
+//! helper. Recorded rather than silently left.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use std::io::Cursor;
+use std::time::Duration;
+
+fn holds(body: &str, sub: &str, sup: &str) -> bool {
+    let ofn = format!(
+        "Prefix(:=<http://ex.org/>)\n\
+         Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n\
+         Ontology(<http://ex.org/g>\n\
+         Declaration(Class(:X)) Declaration(Class(:B)) Declaration(Class(:S))\n\
+         Declaration(Class(:Z)) Declaration(Class(:P)) Declaration(Class(:W))\n\
+         Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))\n\
+         {body}\n)\n"
+    );
+    let mut reader = Cursor::new(ofn);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    let result = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+    result.is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+/// `X` has an `r`-successor, so it is in `r`'s domain.
+const SRC: &str = "SubClassOf(:X ObjectSomeValuesFrom(:r :B))";
+/// Consumes the domain's existential conclusion.
+const SINK: &str = "SubClassOf(ObjectSomeValuesFrom(:s :S) :Z)";
+
+#[test]
+fn an_existential_gci_domain_head_reaches_the_source() {
+    // The issue's reproducer. Konclude and HermiT both derive `X ⊑ Z`.
+    let body = format!(
+        "SubClassOf(ObjectSomeValuesFrom(:r owl:Thing) ObjectSomeValuesFrom(:s :S))\n{SRC}\n{SINK}"
+    );
+    assert!(holds(&body, "X", "Z"), "X ⊑ ∃r.⊤ ⊑ ∃s.S ⊑ Z");
+}
+
+#[test]
+fn a_mixed_gci_domain_head_yields_both_conjuncts() {
+    // The subtler variant: before the fix this returned `[X ⊑ P]` — the ATOMIC conjunct
+    // survived while the existential one was discarded, so the answer looked partially
+    // right instead of empty. Both must now hold.
+    let body = format!(
+        "SubClassOf(ObjectSomeValuesFrom(:r owl:Thing) \
+         ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))\n{SRC}\n{SINK}"
+    );
+    assert!(
+        holds(&body, "X", "P"),
+        "the atomic conjunct (worked before)"
+    );
+    assert!(
+        holds(&body, "X", "Z"),
+        "the existential conjunct (was dropped)"
+    );
+}
+
+#[test]
+fn an_atomic_gci_domain_head_still_works() {
+    // The discriminating control: this derived correctly BEFORE the fix, which is what
+    // isolates the non-atomic head as the cause rather than the GCI-domain mechanism.
+    let body = format!("SubClassOf(ObjectSomeValuesFrom(:r owl:Thing) :P)\n{SRC}");
+    assert!(holds(&body, "X", "P"));
+}
+
+#[test]
+fn a_nested_existential_domain_head_reaches_the_source() {
+    // Two levels deep, so the head needs the recursive marker lowering rather than a
+    // one-level special case.
+    let body = format!(
+        "SubClassOf(ObjectSomeValuesFrom(:r owl:Thing) \
+         ObjectSomeValuesFrom(:s ObjectSomeValuesFrom(:s :S)))\n{SRC}\n\
+         SubClassOf(ObjectSomeValuesFrom(:s ObjectSomeValuesFrom(:s :S)) :W)"
+    );
+    assert!(holds(&body, "X", "W"));
+}
+
+#[test]
+fn a_source_without_an_r_successor_gains_nothing() {
+    // THE FP GUARD. The domain fires on `r`-SOURCES only: a class with no `r`-successor
+    // must not inherit the head. Without this, "the head reaches the source" would be
+    // satisfied by an implementation that asserts the head of everything.
+    let body = format!(
+        "SubClassOf(ObjectSomeValuesFrom(:r owl:Thing) ObjectSomeValuesFrom(:s :S))\n\
+         Declaration(Class(:Unrelated))\n{SINK}"
+    );
+    assert!(
+        !holds(&body, "Unrelated", "Z"),
+        "a class with no r-successor is not in r's domain — FALSE POSITIVE if this trips"
+    );
+}
+
+#[test]
+fn a_nonatomic_domain_on_the_axiom_spelling_is_a_known_sibling_miss() {
+    // `ObjectPropertyDomain(r, ∃s.S)` is the SAME semantics as the fixed GCI above and
+    // still misses: its arm runs in Pass 1, before `effective_ranges` exists, so the
+    // marker machinery is unavailable there and closing it needs a pass restructure.
+    //
+    // Konclude and HermiT both derive `X ⊑ Z` here, so this pins a REAL gap, not a
+    // design choice. A future fix should FLIP this assertion, never delete it.
+    let body = format!("ObjectPropertyDomain(:r ObjectSomeValuesFrom(:s :S))\n{SRC}\n{SINK}");
+    assert!(
+        !holds(&body, "X", "Z"),
+        "if this now HOLDS the sibling gap is closed — flip this test and update #114"
+    );
+}

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -4214,13 +4214,17 @@ fn lower_sub_class_of(
                     rules.poisoned_roles.insert(role.role_id());
                     return;
                 }
-                for head in atomic_operands_on_right(sup, pool) {
-                    rules
-                        .role_domains
-                        .entry(role.role_id())
-                        .or_default()
-                        .push(head);
-                }
+                // #114: was `atomic_operands_on_right`, which DISCARDED every
+                // non-atomic conjunct — so `∃r.⊤ ⊑ ∃s.S` pushed nothing and the
+                // axiom vanished under a pure-EL completeness banner. See
+                // `domain_heads_el`.
+                let heads =
+                    domain_heads_el(sup, pool, rules, tseitin, effective_ranges, chain_ranges);
+                rules
+                    .role_domains
+                    .entry(role.role_id())
+                    .or_default()
+                    .extend(heads);
                 return;
             }
             // Task 2b Bug 2: `∃r.A ⊑ ⊥`. `atomic_operands_on_right(Bot, _)` returns
@@ -4463,6 +4467,72 @@ fn nested_extras(
     out.sort_unstable_by_key(|c| c.index());
     out.dedup();
     out
+}
+
+/// The domain subsumers of a GCI head `C` in `∃r.⊤ ⊑ C`, lowering NON-ATOMIC
+/// conjuncts to markers instead of discarding them (#114).
+///
+/// `∃r.⊤ ⊑ C` is the GCI spelling of `ObjectPropertyDomain(r, C)`, and
+/// `⊑ C₁ ⊓ … ⊓ Cₙ` is exactly `⊑ C₁` and … and `⊑ Cₙ`, so splitting the head is a
+/// logical identity. Each conjunct then becomes a `role_domains` entry.
+///
+/// **The bug this closes was the worst shape in this file's D10 family.**
+/// `atomic_operands_on_right` keeps only `Atomic` operands and returns
+/// `Vec::new()` for anything else, so `∃r.⊤ ⊑ ∃s.S` pushed NOTHING and the axiom
+/// vanished — while `is_el_concept` admits `∃s.S`, so the gate certified the
+/// ontology **pure-EL**, the fragment where the saturator is claimed complete on
+/// its own and no tableau runs at all. `classify` returned zero rows with
+/// `incomplete: false` and `dropped: {}` where both Konclude and `HermiT` derive
+/// `X ⊑ Z`. The mixed head `P ⊓ ∃s.S` was subtler still: the atomic conjunct
+/// survived, so the answer looked partially right.
+///
+/// A non-atomic conjunct is lowered by the same
+/// `atomic_or_tseitin_body_with_extras` every other RHS site uses, which for an
+/// `∃` body mints the EQUIVALENT (two-way) marker — that is what makes the head's
+/// own consequences reachable, so a downstream `∃s.S ⊑ Z` trigger fires on the
+/// marker and the domain carries `Z` through to every `r`-source.
+///
+/// **The gate and this decomposer are aligned by construction, which is the point.**
+/// `is_el_concept` admits exactly `Top` / `Atomic` / `Bot` / `And` of those /
+/// `Some(non-inverse, …)`; `Bot` and `Top` heads are handled by their own arms
+/// before this is reached, and the marker machinery covers `Atomic`, `And` and
+/// `Some`. So on any head the gate is willing to certify pure-EL, the lowering
+/// succeeds. A head that does NOT lower is by that token outside the certified
+/// fragment, and returning nothing for it is the pre-existing sound
+/// under-approximation — never a silent miss under a completeness claim.
+///
+/// **ONE PATH, BY DELIBERATE SUBTRACTION.** Earlier versions split the top-level
+/// `And` themselves and short-circuited an `Atomic` head. Sabotage showed BOTH
+/// branches were equivalent-not-load-bearing: removing either left all six canaries
+/// green, because `atomic_or_tseitin_body_with_extras` already lowers a conjunctive
+/// head (through `atomic_classes_with_existential_markers`) and already returns the
+/// bare id for an atomic one. Rather than add tests pinning branches nothing needs,
+/// the branches are gone — the two mutations that survived are now unconstructible.
+/// If profiling ever wants the atomic short-circuit back, note that it is a pure
+/// optimisation whose absence no canary can detect.
+///
+/// Sound in the FP direction regardless: every id returned is a genuine subsumer of
+/// the head, so a domain entry can only add entailed consequences.
+fn domain_heads_el(
+    sup: ConceptId,
+    pool: &ConceptPool,
+    rules: &mut ElRules,
+    tseitin: &mut TseitinAllocator,
+    effective_ranges: &HashMap<RoleId, Vec<ClassId>>,
+    chain_ranges: &HashMap<(RoleId, RoleId), Vec<ClassId>>,
+) -> Vec<ClassId> {
+    atomic_or_tseitin_body_with_extras(
+        sup,
+        &[],
+        pool,
+        rules,
+        tseitin,
+        effective_ranges,
+        chain_ranges,
+        None,
+    )
+    .into_iter()
+    .collect()
 }
 
 /// The atomic conjuncts of a domain/range filler, or `None` if any part is not


### PR DESCRIPTION
`SubClassOf(ObjectSomeValuesFrom(:r owl:Thing), C)` is the GCI spelling of `ObjectPropertyDomain(r, C)`.

That arm pushed `atomic_operands_on_right(sup, pool)` into `role_domains`, and that helper keeps only `Atomic` operands and returns `Vec::new()` for anything else. So `∃r.⊤ ⊑ ∃s.S` pushed **nothing** and the axiom vanished — while `is_el_concept` admits `∃s.S`, so the gate certified the ontology **pure-EL**, the fragment where the saturator runs alone and no tableau follows. `classify` returned **zero rows with `incomplete: false` and `dropped: {}`** where both Konclude v0.7.0-1138 and HermiT 1.4.3 derive `X ⊑ Z`. The D10 shape: the answer is wrong *and* reported complete. Same family as #110, one spelling over.

The mixed head `P ⊓ ∃s.S` was subtler — the atomic conjunct survived, so the answer looked partially right rather than empty.

## The fix

The head now routes through `atomic_or_tseitin_body_with_extras`, the same lowering every other RHS site uses, which for an `∃` body mints the **equivalent (two-way)** marker — that is what makes a downstream `∃s.S ⊑ Z` trigger fire on it and carry `Z` to every `r`-source.

Splitting `⊑ C₁ ⊓ … ⊓ Cₙ` is a **logical identity**, hence sound and completeness-preserving by construction, hence unflagged. Gate and decomposer stay aligned by construction: `is_el_concept` admits exactly `Top` / `Atomic` / `Bot` / `And` of those / `Some(non-inverse)`; `Bot` and `Top` have their own arms upstream; the marker machinery covers the rest. Any head the gate will certify, the lowering handles.

| probe | before | after |
|---|---|---|
| `∃r.⊤ ⊑ ∃s.S` + `∃s.S ⊑ Z` | `[]` | `[('X','Z')]` |
| `∃r.⊤ ⊑ P ⊓ ∃s.S` | `[('X','P')]` | `[('X','P'), ('X','Z')]` |
| `ObjectPropertyDomain(r, ∃s.S)` (sibling, out of scope) | `[]` | `[]` |

## Three sabotages survived, and the fix was deletion, not more tests

| round | mutation | result |
|---|---|---|
| 1 | drop the helper's own `And` split | **survived** |
| 1 | a `Top` conjunct pushing `ClassId::new(0)` | **survived** |
| 2 | drop the `Atomic` fast path | **survived** |

All three were **equivalent mutations of branches nothing needed**: `atomic_or_tseitin_body_with_extras` already lowers a conjunctive head (through `atomic_classes_with_existential_markers`) and already returns the bare id for an atomic one. Writing canaries to pin provably-redundant branches would record coverage that does not exist, so **the branches are gone** and the helper is one path — those three mutations are now unconstructible.

What remains *is* caught: reverting to `atomic_operands_on_right` fails 3 tests; a non-atomic arm returning nothing fails 3.

## Corpus reach is provably zero — and the first instrument said 91

Census over the **157** ORE ontologies carrying a GCI-domain axiom: **0 of 157** have a non-atomic head, across **8,585** such axioms. The changed arm cannot fire on ORE.

The first pass reported **91** because the regex truncated heads at 50 characters and read a bare `<http://…>` IRI as non-atomic; the corrected extractor balances parens.

Two-arm sweep over those 157 with pinned binaries: **154 IDENTICAL / 3 BOTH_DNF / 0 DIFFER**.

So the sweep is **non-regression evidence only**; the evidence is the 6 canaries plus the Konclude/HermiT adjudication — the same verdict as #110, #84 and #42 item 2, where the axioms are present but the *consumer* pattern is not.

## A sibling gap the issue does not report, measured and left open

The **axiom** spelling `ObjectPropertyDomain(r, ∃s.S)` also misses, confirmed by both oracles. Its arm runs in **Pass 1**, during axiom collection, *before* `effective_ranges` is built, so the marker machinery this fix uses is not available there. Closing it means moving that arm or deferring it to Pass 2 — a larger change than #114 asks for.

Pinned by `a_nonatomic_domain_on_the_axiom_spelling_is_a_known_sibling_miss`, which asserts the **current (missing)** behaviour and instructs a future fix to **flip** it rather than delete it.

## Gates

- suite **1970 passed / 0 failed** (`CARGO_EXIT=0`)
- FP=0 net **12 VERIFIED**, every closure exact, zero mismatches
- clippy `--all-targets --all-features` exit 0; `cargo fmt --check` clean

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)