### PR TITLE
fix: decompose a conjunctive ObjectPropertyDomain/Range filler (#110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1730,6 +1730,73 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   *increased* unresolved by 31 — several slow ontologies were off-fragment all along, so part of
   the timeout bucket was never checkable. See
   `docs/benchmarks/2026-09-05-verify-el-cap-is-a-weak-lever.md`.
+  **THE SPIKE'S PAYOFF WAS A LIVE D10 DEFECT IN THE SATURATOR, AND IT IS NOW FIXED (#110,
+  2026-09-06, unflagged).** `ObjectPropertyDomain(r, P ⊓ Q)` + `X ⊑ ∃r.B` entails `X ⊑ P` and
+  `X ⊑ Q`. `classify --json` returned **`direct_subsumptions: []` with `incomplete: false` and
+  `dropped: {}`** while certifying `# fragment: Horn` — the gate promising completeness over an
+  axiom the EL saturator silently dropped, the D10 shape, and worse than a DNF. `ObjectPropertyRange`
+  is the same defect and the larger half. **Fixed by DECOMPOSITION, which is a logical identity**
+  (`Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)`), hence sound and completeness-preserving by
+  construction. **Wherever this defect is recorded as UNFIXED with `RUSTDL_CLASSIFY_SAME_TIER=1` as
+  the only recovery, that record is superseded here**: both pairs now come out at the DEFAULT, and
+  it was never only a tier-walk story.
+  **The design point is the SHARED CALL SITE, not the rule.** One
+  `pub fn owl_dl_saturation::decompose_role_filler(c, pool, sink) -> bool` pushes every atomic
+  conjunct *and* returns whether the filler decomposed COMPLETELY; the engine consumes the entries
+  and **both** fragment gates consume the boolean (`classify.rs::is_processed_role_filler`, née
+  `is_atomic_or_trivial_concept`, at all four call sites — `Bot` re-admitted explicitly there
+  because `poisoned_roles` handles it before the decomposer is reached). Gate/engine drift is the
+  mechanism that GENERATES this bug class, so the fix makes it structurally impossible rather than
+  re-aligning two predicates that happen to agree today.
+  **Partial decomposition is sound; partial ADMISSION is not.** `Domain(r, P ⊓ ∃s.S)` still
+  contributes its `P` conjunct — a weaker domain is the safe direction — but the ontology must NOT
+  be certified EL-complete on that basis, since the `∃s.S` half is genuinely dropped. A negative
+  canary pins exactly that asymmetry.
+  **EVIDENCE, and the corpus is not part of it.** Oracles: post-fix rustdl == Konclude == HermiT ==
+  KM on **6 of 6** probes (pre-registered comparison of named non-`Thing` pair sets); the pinned
+  pre-fix binary returns **∅ with `incomplete: false` on three of them while certifying `Horn`**.
+  Sabotage: **6 run, 5 caught, 1 SURVIVED.** The survivor is the mutation that makes the gate
+  re-implement the decomposition LOCALLY instead of calling the shared function — invisible to the
+  canaries because they pin BEHAVIOUR, not the no-drift property. It is bounded, not unknown
+  (`ConceptPool::and` flattens nested `And` at intern time and there is exactly ONE
+  `ConceptExpr::And` construction site workspace-wide, so the two predicates are equal on every
+  interner-constructible input), so the residual is an untested CROSS-CRATE COUPLING and the
+  no-drift property rests on the shared call site alone. **Report the survivor; do not round it up
+  to 5 of 5.**
+  **CORPUS REWARD IS MEASURED ZERO.** Frame = the **27** ORE ontologies authoring a conjunctive
+  `Domain`/`Range` filler. Two pinned arms: **45 IDENTICAL / 0 DIFFER / 2 UNMEASURED / 0 `ok → dnf`
+  / 0 lost entailments** over 25 measured bearing + 20 controls, and **0 fragment-routing movers
+  across all 1,920** by GATE probe. So the FP=0 net's green here is **INERTNESS, not confirmation**
+  — the evidence is the oracle adjudication and the canaries.
+  **The fix has TWO SEPARABLE EFFECTS and the gate sweep bounds only one.** A ROUTING effect (the
+  gate admits the axiom, moving an ontology to the fast path only if that axiom was its sole
+  blocker) and a DERIVATION effect (the saturator decomposes regardless of the gate).
+  `Domain(r, P ⊓ ∃s.S)` separates them — no routing move, 0 → 2 rows. Stopping at "0 movers" would
+  have left the larger half unmeasured.
+  **THE SUPERSET IS 27, NOT ≤14.** Wherever ≤14 is recorded for this shape it is stale: that scan's
+  `break` fired after the first axiom body matching a broad construct regex, so any ontology whose
+  FIRST `Domain`/`Range` axiom was non-conjunctive was excluded. Re-derived by two agreeing
+  instruments.
+  **The two-hole `verify-el` widening market loses hole 2.** `Domain(r, P ⊓ Q)` is no longer a
+  gate-vs-checker disagreement — it decomposes to EL and reports `PureEl`, a stronger outcome than
+  the hole count implied. Hole 1 (`DisjointClasses(A ⊓ B, C)`) is untouched by #110 and was
+  measured clean separately, outside this branch's evidence — attribute it there, not here.
+  `crates/owl-dl-verify/tests/horn_widening_market.rs`'s second test is retargeted to an
+  EXISTENTIAL domain filler, which stays out of EL for a DESIGN DECISION rather than a defect
+  (`decompose_role_filler` pushes `ClassId`s and `∃s.S` has none, so admitting it needs a
+  structurally different rule, not a wider decomposer). `ObjectUnionOf` was tried first and
+  measures `OutOfFragment`, not `Horn`. See [[tests-that-pin-the-bug]].
+  **THE REWARD FIGURE TOOK THREE REVISIONS AND THE MIDDLE ONE IS THE LESSON.** It read "zero"
+  (right, but over a frame of 14), then **"NON-ZERO" on `ore_ont_4796` — wrong, because it compared
+  `RUSTDL_CLASSIFY_SAME_TIER=0` against `=1` WITHIN ONE BINARY**, measuring the flag rather than the
+  fix: the pre-fix pin gains the same two pairs under that flag, and the arms are triple-identical
+  under either setting. Then "zero" again, from two pinned binaries. Same rule this file already
+  earned from the label-cache probe — **measuring a flag's effect and measuring the ship delta are
+  different questions** — and the same drift this file's "State of play — 2026-08-18" section
+  documents, reproduced inside the change that was recording it.
+  Canaries `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs`; docs
+  `docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md` (oracles + sabotage) and
+  `docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md` (corpus gates).
   **A trap worth carrying beyond this crate**, from F4: any oracle comparison that counts `Thing`
   rows reports spurious MISSED on any ontology asserting `⊤ ⊑ C`. This project has been bitten
   once already — 73% of an apparent ~1,795-row gap against Kobayashi-MaRust was the same

--- a/crates/owl-dl-reasoner/examples/fragment_probe.rs
+++ b/crates/owl-dl-reasoner/examples/fragment_probe.rs
@@ -1,0 +1,47 @@
+//! Print `<path>\t<fragment>` for one ontology — parse + convert + fragment gate
+//! only, **no reasoning**.
+//!
+//! Why this exists: the `# fragment:` banner in `classify` output is written by
+//! `write_classification` only *after* classification completes, so diffing it
+//! across two binaries costs a full two-arm classify of the corpus, and any DNF
+//! yields an empty string — a both-arm DNF then reads as "not a mover" and a
+//! one-sided DNF as a false mover. `analyze_fragment` needs no reasoning (cf.
+//! the pre-classify call in the CLI), so this probe answers the routing question
+//! directly and terminates on ontologies that stall in the engine.
+//!
+//! ```sh
+//! cargo run --release --example fragment_probe -- <file>
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::print_stdout)]
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: fragment_probe <file>");
+    let src = std::fs::read_to_string(&path).expect("read ontology");
+    let onto = read_any(&src);
+    let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
+    println!("{path}\t{:?}", owl_dl_reasoner::analyze_fragment(&internal));
+}
+
+/// Content-sniffing reader: ORE pool files carry a `.owl` extension but are
+/// functional syntax, so dispatching on the extension is wrong here.
+fn read_any(src: &str) -> horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr> {
+    let first = src
+        .trim_start_matches('\u{feff}')
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .unwrap_or("");
+    let cfg = horned_owl::io::ParserConfiguration::default();
+    let mut cursor = std::io::Cursor::new(src.as_bytes());
+    if first.starts_with("Prefix(") || first.starts_with("Ontology(") {
+        horned_owl::io::ofn::reader::read(&mut cursor, cfg)
+            .expect("parse OFN")
+            .0
+    } else {
+        let (o, _) = horned_owl::io::rdf::reader::read(&mut cursor, cfg).expect("parse RDF/XML");
+        o.into()
+    }
+}

--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -2119,21 +2119,20 @@ fn is_atomic_concept(c: ConceptId, pool: &ConceptPool) -> bool {
     matches!(pool.get(c), ConceptExpr::Atomic(_))
 }
 
-/// True if `c` is a concept that the engine handles completely for
-/// `ObjectPropertyDomain` / `ObjectPropertyRange` filler positions:
-/// - `Atomic` — stored in `role_domains` / `role_ranges` and propagated.
-/// - `Bot`    — stored in `poisoned_roles`; any `∃r.*` class becomes unsat.
-/// - `Top`    — dropped by the engine, but semantically trivial: `Domain(r, ⊤)`
-///   adds no subsumptions, so dropping it is sound (no missed entailment).
+/// True iff a Domain/Range filler is one the saturator processes IN FULL.
 ///
-/// Everything else (`And`, `Some`, `Or`, …) is silently dropped by the engine
-/// while potentially entailing real subsumptions — those MUST fall to the hybrid
-/// path.  See `collect_el_rules`, the `ObjectPropertyDomain` arm.
-fn is_atomic_or_trivial_concept(c: ConceptId, pool: &ConceptPool) -> bool {
-    matches!(
-        pool.get(c),
-        ConceptExpr::Atomic(_) | ConceptExpr::Bot | ConceptExpr::Top
-    )
+/// Delegates to `owl_dl_saturation::decompose_role_filler` and reads only its
+/// completeness flag, so the gate cannot drift from what the engine actually
+/// does. Re-implementing the predicate here is how D10 bugs are born — see that
+/// function's doc.
+///
+/// `Bot` is admitted explicitly because the engine handles it via
+/// `poisoned_roles` *before* the decomposer is reached, so the decomposer
+/// legitimately returns `false` for it.
+fn is_processed_role_filler(c: ConceptId, pool: &ConceptPool) -> bool {
+    let mut sink = Vec::new();
+    owl_dl_saturation::decompose_role_filler(c, pool, &mut sink)
+        || matches!(pool.get(c), ConceptExpr::Bot)
 }
 
 fn is_el_axiom(ax: &Axiom, pool: &ConceptPool, bare: &BareRoleDecls) -> bool {
@@ -2181,10 +2180,10 @@ fn is_el_axiom(ax: &Axiom, pool: &ConceptPool, bare: &BareRoleDecls) -> bool {
         // `Atomic`, `Bot` (handled by `poisoned_roles`), and `Top` (trivially `⊤`
         // — `Domain(r, ⊤)` adds no subsumptions, so dropping it is sound).
         Axiom::ObjectPropertyDomain { role, domain } => {
-            !role.is_inverse() && is_atomic_or_trivial_concept(*domain, pool)
+            !role.is_inverse() && is_processed_role_filler(*domain, pool)
         }
         Axiom::ObjectPropertyRange { role, range } => {
-            !role.is_inverse() && is_atomic_or_trivial_concept(*range, pool)
+            !role.is_inverse() && is_processed_role_filler(*range, pool)
         }
         Axiom::DeclareClass(_)
         | Axiom::DeclareObjectProperty(_)
@@ -2572,10 +2571,10 @@ fn is_saturator_axiom(
         // `Atomic`, `Bot`, and `Top` fillers are handled by the engine; see the
         // comment on `is_el_axiom`'s Domain/Range arms above.
         Axiom::ObjectPropertyDomain { role, domain } => {
-            !role.is_inverse() && is_atomic_or_trivial_concept(*domain, pool)
+            !role.is_inverse() && is_processed_role_filler(*domain, pool)
         }
         Axiom::ObjectPropertyRange { role, range } => {
-            !role.is_inverse() && is_atomic_or_trivial_concept(*range, pool)
+            !role.is_inverse() && is_processed_role_filler(*range, pool)
         }
         Axiom::DeclareClass(_)
         | Axiom::DeclareObjectProperty(_)

--- a/crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
@@ -1,0 +1,167 @@
+//! Issue #110 — a CONJUNCTIVE `ObjectPropertyDomain`/`Range` filler is dropped.
+//!
+//! `collect_el_rules`' Domain/Range arms handled `Bot` (poison) and `Atomic`
+//! (push) and fell through silently on `And`, so `Domain(r, P ⊓ Q)` reached the
+//! engine as nothing at all. `is_el_axiom` correctly refused the axiom, routing
+//! the ontology to the hybrid path — where the tier walk then never compared
+//! `X` against `P`, because dropping the filler left `X` with no EL subsumer and
+//! therefore in `P`'s own tier. `classify` returned ZERO rows with
+//! `incomplete: false`; Konclude, `HermiT` and KM all derive the pairs.
+//!
+//! `Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)` is a logical identity, so the
+//! fix decomposes rather than approximates.
+
+use owl_dl_reasoner::classify;
+
+fn entails(body: &str, sub: &str, sup: &str) -> bool {
+    let src = format!("Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/t>\n{body}\n)\n");
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+    let c = classify(&onto).expect("classify");
+    c.is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+const DECLS: &str = "Declaration(Class(:P)) Declaration(Class(:Q)) Declaration(Class(:X))
+     Declaration(Class(:B)) Declaration(Class(:W)) Declaration(Class(:S))
+     Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))";
+
+/// #110, domain half. Both conjuncts must be derived, not just the first.
+#[test]
+fn conjunctive_domain_filler_derives_every_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))"
+    );
+    assert!(entails(&body, "X", "P"), "X ⊑ P (first conjunct)");
+    assert!(entails(&body, "X", "Q"), "X ⊑ Q (second conjunct)");
+}
+
+/// #110, range half — the LARGER population (13 of the 14 ORE candidates carry a
+/// conjunctive Range against 4 for Domain).
+///
+/// NB the existential filler is `:B`, NOT `owl:Thing`. `∃r.⊤` lowers to a
+/// deliberately subsumer-less ⊤-witness that `Range` is not folded into — the
+/// documented `topwitness.ofn` DESIGN DECISION — so a `⊤` fixture fails on the
+/// atomic control too and cannot discriminate.
+#[test]
+fn conjunctive_range_filler_derives_every_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :Q)) :S)"
+    );
+    // BOTH conjuncts, or a sabotage that pushes only the lowest-id one passes.
+    assert!(
+        entails(&body, "X", "W"),
+        "X ⊑ W via the P side of the folded range"
+    );
+    assert!(
+        entails(&body, "X", "S"),
+        "X ⊑ S via the Q side of the folded range"
+    );
+}
+
+/// CONTROL that must keep passing: the atomic filler was never broken.
+#[test]
+fn atomic_domain_filler_still_derives_its_subsumption() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r :P)"
+    );
+    assert!(entails(&body, "X", "P"));
+}
+
+/// FP GUARD. Decomposition must never invent a domain the axiom does not state:
+/// `Domain(r, P)` alone must NOT yield `X ⊑ Q`.
+#[test]
+fn decomposition_does_not_invent_an_unstated_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r :P)"
+    );
+    assert!(!entails(&body, "X", "Q"), "Q is not a domain of r");
+}
+
+/// PARTIAL decomposition is SOUND: `P ⊓ ∃s.S` yields the atomic `P`, which is a
+/// WEAKER (larger) domain than the axiom states — the safe direction. Task 2
+/// pins that the GATE nonetheless refuses this axiom.
+#[test]
+fn partially_decomposable_filler_still_derives_its_atomic_conjunct() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))"
+    );
+    assert!(entails(&body, "X", "P"), "the atomic conjunct is entailed");
+}
+
+/// A DISJUNCTIVE filler must NOT decompose. `Domain(r, P ⊔ Q)` does not entail
+/// `Domain(r,P)`; deriving `X ⊑ P` from it would be a false POSITIVE, which is
+/// this change's failure direction.
+#[test]
+fn a_disjunctive_filler_does_not_decompose() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectUnionOf(:P :Q))"
+    );
+    assert!(!entails(&body, "X", "P"), "FP: a disjunct is not a domain");
+    assert!(!entails(&body, "X", "Q"), "FP: a disjunct is not a domain");
+}
+
+/// Step 8 (provenance mirrors): `prove` must attribute the conjunctive-domain
+/// subsumption to the `ObjectPropertyDomain` axiom, not return an empty
+/// `axiom_refs` — the `domain_axiom_refs` mirror (`collect_el_rules_with_
+/// provenance`'s own Domain arm) has to decompose the filler exactly as the
+/// real Pass 1 does, or the `.find((role,dom))` lookup at the `DomainSub`/
+/// `DomainFact` record sites never matches a decomposed conjunct.
+#[test]
+fn prove_attributes_the_conjunctive_domain_subsumption_to_its_axiom() {
+    use owl_dl_reasoner::{ElRule, ProofNode, ProveEntailmentResult, prove_entailment};
+
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))"
+    );
+    let src = format!("Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/t>\n{body}\n)\n");
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+
+    let result =
+        prove_entailment(&onto, "http://ex.org/X", "http://ex.org/P").expect("prove_entailment");
+    let ProveEntailmentResult::SaturatorProof(data) = result else {
+        panic!("expected a step-level saturator proof for an EL-fragment entailment");
+    };
+
+    // Walk the proof tree looking for the Domain-rule node and assert it cites
+    // an axiom — a divergent mirror would leave `axiom_refs` empty instead.
+    fn find_domain_node(node: &ProofNode) -> Option<&ProofNode> {
+        if matches!(node.rule, ElRule::DomainSub | ElRule::DomainFact) {
+            return Some(node);
+        }
+        node.premises.iter().find_map(find_domain_node)
+    }
+    let domain_node = find_domain_node(&data.root)
+        .expect("proof tree must contain a DomainSub/DomainFact step for X ⊑ P");
+    assert!(
+        !domain_node.axiom_refs.is_empty(),
+        "conjunctive domain filler must resolve to the ObjectPropertyDomain axiom, not an empty axiom_refs"
+    );
+}

--- a/crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
@@ -236,3 +236,53 @@ fn prove_attributes_the_conjunctive_range_folded_subsumer_to_its_axiom() {
          per-axiom rule-slot cursor and silently drops this attribution"
     );
 }
+
+use owl_dl_core::convert::convert_ontology;
+use owl_dl_reasoner::{FragmentClassification as FC, analyze_fragment};
+
+fn fragment_of(body: &str) -> FC {
+    let src = format!("Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/t>\n{body}\n)\n");
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+    analyze_fragment(&convert_ontology(&onto).expect("convert"))
+}
+
+/// The gate must move WITH the engine: a fully-decomposable filler is now
+/// processed, so the ontology belongs on the pure-EL fast path.
+#[test]
+fn a_fully_decomposable_filler_is_admitted_to_pure_el() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))"
+    );
+    assert_eq!(fragment_of(&body), FC::PureEl);
+}
+
+/// THE LOAD-BEARING NEGATIVE. A partially-decomposable filler leaves `∃s.S`
+/// unprocessed by the engine, so admitting it to a complete-certified fragment
+/// would be a FRESH D10 — the exact bug class this fix exists to close.
+#[test]
+fn a_partially_decomposable_filler_is_refused_by_the_gate() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))"
+    );
+    assert_ne!(fragment_of(&body), FC::PureEl);
+}
+
+/// A disjunctive filler is not decomposable and must stay out of the fragment.
+#[test]
+fn a_disjunctive_filler_is_refused_by_the_gate() {
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyDomain(:r ObjectUnionOf(:P :Q))"
+    );
+    assert_ne!(fragment_of(&body), FC::PureEl);
+}

--- a/crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs
@@ -165,3 +165,74 @@ fn prove_attributes_the_conjunctive_domain_subsumption_to_its_axiom() {
         "conjunctive domain filler must resolve to the ObjectPropertyDomain axiom, not an empty axiom_refs"
     );
 }
+
+/// Step 8 (provenance mirrors), RANGE half. There is no `RangeSub`/`RangeFact`
+/// rule — range provenance is never attributed directly (unlike Domain), it only
+/// shapes the mini Pass-1 simulation's per-axiom rule-slot delta cursors
+/// (`mini_effective`, feeding `lower_sub_class_of`). A divergence there does not
+/// merely empty one node's `axiom_refs` — the reviewer's traced failure mode is
+/// that it MISALIGNS every later axiom's attribution, so proofs get cited to the
+/// WRONG axiom, which looks correct and is worse than a missing proof.
+///
+/// Empirically (a throwaway probe dumping the proof tree for this exact
+/// fixture): reverting *only* the mini range mirror to `Atomic`-only turns the
+/// two `ToldSubsumer` leaves that fold `Range(r, P⊓Q)` into X's existential
+/// witness (`Sub(synthetic, B)` / `Sub(synthetic, P)`) from `axiom_refs=[AxiomRef(2)]`
+/// to `axiom_refs=[]`, while every ancestor of the root stays `[AxiomRef(1)]`
+/// unchanged — the corruption is localized exactly where the range fold enters
+/// the tree, not at the entailment's own top-level step. So the discriminating
+/// check is a `ToldSubsumer` node concluding `Sub(_, P)`, not the root.
+#[test]
+fn prove_attributes_the_conjunctive_range_folded_subsumer_to_its_axiom() {
+    use owl_dl_reasoner::{
+        DerivedFact, ElRule, ProofNode, ProveEntailmentResult, prove_entailment,
+    };
+
+    let body = format!(
+        "{DECLS}
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+         ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :W)
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :Q)) :S)"
+    );
+    let src = format!("Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/t>\n{body}\n)\n");
+    let mut cur = std::io::Cursor::new(src);
+    let (onto, _): (
+        horned_owl::ontology::set::SetOntology<horned_owl::model::RcStr>,
+        _,
+    ) = horned_owl::io::ofn::reader::read(&mut cur, horned_owl::io::ParserConfiguration::default())
+        .expect("parse");
+
+    // Look up P's ClassId independently (via the same conversion prove_entailment
+    // uses internally) so the test can find the P-typed leaf without guessing IDs.
+    let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
+    let p_id = internal
+        .vocabulary
+        .class_id("http://ex.org/P")
+        .expect("P declared");
+
+    let result =
+        prove_entailment(&onto, "http://ex.org/X", "http://ex.org/W").expect("prove_entailment");
+    let ProveEntailmentResult::SaturatorProof(data) = result else {
+        panic!("expected a step-level saturator proof for an EL-fragment entailment");
+    };
+
+    // Walk the whole tree for the ToldSubsumer leaf that folds Range's P
+    // conjunct onto X's existential witness.
+    fn find_p_subsumer(node: &ProofNode, p_id: owl_dl_core::ClassId) -> Option<&ProofNode> {
+        if node.rule == ElRule::ToldSubsumer
+            && matches!(node.conclusion, DerivedFact::Sub(_, sup) if sup == p_id)
+        {
+            return Some(node);
+        }
+        node.premises.iter().find_map(|p| find_p_subsumer(p, p_id))
+    }
+    let p_node = find_p_subsumer(&data.root, p_id)
+        .expect("proof tree must contain a ToldSubsumer step folding Range's P conjunct");
+    assert!(
+        !p_node.axiom_refs.is_empty(),
+        "the range-folded P subsumer must resolve to the ObjectPropertyRange axiom, \
+         not an empty axiom_refs — a divergent mini range mirror desyncs the \
+         per-axiom rule-slot cursor and silently drops this attribution"
+    );
+}

--- a/crates/owl-dl-reasoner/tests/conjunctive_unsat.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_unsat.rs
@@ -893,8 +893,12 @@ fn disjoint_all_atomic_members_stays_on_fast_path() {
 /// stronger check (it tests ALL pairs regardless of saturation-derived tier
 /// ordering, rather than relying on the top-down walk to have generated the
 /// (X, P) pair). Post-#110, `classify()`'s own top-down walk generates this
-/// pair too (verified separately), but `classify_n2` remains the check that
-/// cannot be defeated by a future tier-walk change.
+/// pair too — pinned by
+/// `conjunctive_domain_filler_derives_every_conjunct` in
+/// `crates/owl-dl-reasoner/tests/conjunctive_domain_range_filler.rs`, which
+/// calls `classify()` (not `classify_n2`) on the same conjunctive-domain
+/// shape — but `classify_n2` remains the check that cannot be defeated by a
+/// future tier-walk change.
 #[test]
 fn domain_conjunctive_filler_derives_subsumptions() {
     let body = "    Declaration(Class(:P))

--- a/crates/owl-dl-reasoner/tests/conjunctive_unsat.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_unsat.rs
@@ -863,31 +863,38 @@ fn disjoint_all_atomic_members_stays_on_fast_path() {
 // ─── Bug B: non-atomic ObjectPropertyDomain silently dropped ─────────────────
 //
 // `ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))` has a conjunctive filler.
-// The engine's `role_domains` collector accepts ONLY `ConceptExpr::Atomic` fillers
-// (lines 3167-3172); `ObjectIntersectionOf` is silently dropped, so neither `:P`
-// nor `:Q` end up in `role_domains[:r]`.  The old gate (`is_el_concept` / `is_saturator_concept`
-// both admit `And`) passed this axiom to the fast path where it became a no-op,
-// reporting "complete" while missing `X ⊑ P` and `X ⊑ Q`.
+// At the time this fixture was written, the engine's `role_domains` collector
+// accepted ONLY `ConceptExpr::Atomic` fillers, so `ObjectIntersectionOf` was
+// silently dropped and neither `:P` nor `:Q` ended up in `role_domains[:r]`. The
+// gate of the day (`is_el_concept` / `is_saturator_concept`, both of which admit
+// `And`) passed this axiom to the fast path where it became a no-op, reporting
+// "complete" while missing `X ⊑ P` and `X ⊑ Q`. The interim mitigation was a
+// gate-only tightening (`is_atomic_or_trivial_concept`) that REFUSED this shape,
+// forcing the slower-but-correct hybrid/tableau path.
+//
+// **Issue #110 fixed this at the root**: `owl_dl_saturation::decompose_role_filler`
+// now decomposes a fully-conjunctive filler into its atomic conjuncts and the
+// saturator processes all of them directly, so the gate
+// (`is_processed_role_filler`, née `is_atomic_or_trivial_concept`) now ADMITS
+// this exact shape to the saturation-only fast path — correctly, because the
+// engine that path uses no longer drops anything. This test used to assert the
+// interim mitigation (`!stats.pure_el_mode`); that assertion is now WRONG on
+// purpose, not broken — see [[tests-that-pin-the-bug]]. Flipped below.
 
-/// BUG B REPRODUCER. Non-atomic `ObjectPropertyDomain` silently dropped.
+/// BUG B REPRODUCER, RETARGETED FOR #110. Non-atomic `ObjectPropertyDomain`
+/// used to be silently dropped by the fast path; now the fast path itself
+/// derives both entailed subsumptions.
 /// `ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))` + `SubClassOf(:X ObjectSomeValuesFrom(:r owl:Thing))`
-/// entails `X ⊑ P` and `X ⊑ Q`.  With the old gate, zero subsumptions appear
-/// under the "complete" banner.
+/// entails `X ⊑ P` and `X ⊑ Q`.
 ///
 /// # Why `classify_n2` here, not `classify`
 ///
-/// P, Q, and X all have saturation-subsumer-count 0 (the conjunctive domain filler
-/// is invisible to the EL saturator), so the default top-down `classify()` places
-/// all three in a single flat tier — it never generates the pair (X, P) to test.
-/// The N² path (`classify_n2`) tests ALL pairs and correctly finds the subsumptions
-/// via the tableau.  The gate fix is what makes the N² path's verdict trustworthy:
-/// before the fix the ontology was certified "pure-EL complete" and the fast-path
-/// saturator returned 0; after the fix it falls through to the N² hybrid tableau,
-/// which finds X ⊑ P and X ⊑ Q.
-///
-/// `is_subclass_of` (one-shot satisfiability probe) would find X ⊑ P BEFORE the
-/// fix too — it never touches the classify gate — so it cannot serve as a
-/// fail-then-pass test.
+/// Kept for parity with the original fixture and because it is still the
+/// stronger check (it tests ALL pairs regardless of saturation-derived tier
+/// ordering, rather than relying on the top-down walk to have generated the
+/// (X, P) pair). Post-#110, `classify()`'s own top-down walk generates this
+/// pair too (verified separately), but `classify_n2` remains the check that
+/// cannot be defeated by a future tier-walk change.
 #[test]
 fn domain_conjunctive_filler_derives_subsumptions() {
     let body = "    Declaration(Class(:P))
@@ -909,29 +916,28 @@ fn domain_conjunctive_filler_derives_subsumptions() {
         c.is_subclass("http://t/X", "http://t/Q"),
         "Bug B: X ⊑ ∃r.⊤ + Domain(r)=P⊓Q entails X ⊑ Q"
     );
-    // Verify the gate fix is WHY it passes, not some incidental reason.
+    // Verify the #110 fix is WHY it passes, not some incidental reason.
     //
-    // `pure_el_mode` is the DIRECT signal: the bug was that this ontology was
-    // admitted to the saturation-only fast path, whose engine drops a
-    // conjunctive domain filler, while the closure was reported complete. The
-    // fix rejects that filler at the gate, so the ontology must NOT be in
-    // `pure_el_mode`. Asserting only "some subsumption query ran" is weaker —
-    // it would still hold if a later edit to this fixture (say adding a
-    // `FunctionalRole`) forced the hybrid path for an unrelated reason, leaving
-    // the gate fix untested.
+    // `pure_el_mode` is the DIRECT signal: post-#110, the saturator processes a
+    // fully-decomposable conjunctive filler completely, so this ontology
+    // belongs on the saturation-only fast path and the gate must ADMIT it —
+    // the opposite of the pre-#110 interim mitigation this test used to pin.
+    // Asserting only "some subsumption query ran" is weaker — it would still
+    // hold if a later edit to this fixture (say adding a `FunctionalRole`)
+    // forced the hybrid path for an unrelated reason, leaving the #110 fix
+    // untested.
     let stats = c.stats();
     assert!(
-        !stats.pure_el_mode,
-        "Bug B: the conjunctive domain filler must keep this ontology OFF the \
-         saturation-only fast path (that path drops the filler while reporting a \
-         complete closure — the bug)"
+        stats.pure_el_mode,
+        "#110: a fully-decomposable conjunctive domain filler must now be \
+         admitted to the saturation-only fast path — the engine processes it \
+         completely, so the gate refusing it would itself be a stale D10 gap"
     );
     assert!(
-        stats.saturation_subsumption_hits + stats.tableau_subsumption_calls > 0,
-        "Bug B: the hybrid engine must have issued subsumption queries \
-         (saturation_hits={}, tableau_calls={})",
-        stats.saturation_subsumption_hits,
-        stats.tableau_subsumption_calls
+        stats.saturation_subsumption_hits > 0,
+        "#110: the fast-path saturator must have derived both subsumptions \
+         directly (saturation_hits={})",
+        stats.saturation_subsumption_hits
     );
 }
 

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -3147,11 +3147,16 @@ fn collect_el_rules_with_provenance(
                 }
                 disjt_cur += count;
             }
-            Axiom::ObjectPropertyDomain { role, domain } => {
-                if !role.is_inverse()
-                    && let ConceptExpr::Atomic(id) = internal.concepts.get(*domain)
-                {
-                    domain_axiom_refs.push((role.role_id(), *id, ax_idx));
+            Axiom::ObjectPropertyDomain { role, domain } if !role.is_inverse() => {
+                // Mirrors the real Pass 1's `decompose_role_filler` call: a
+                // conjunctive domain pushes one `(role, atom, ax_idx)` per
+                // decomposed atomic, so the `domain_axiom_refs.find` lookups
+                // at the `DomainSub`/`DomainFact` record sites resolve every
+                // conjunct back to this axiom, not just an atomic filler.
+                let mut atoms = Vec::new();
+                decompose_role_filler(*domain, &internal.concepts, &mut atoms);
+                for id in atoms {
+                    domain_axiom_refs.push((role.role_id(), id, ax_idx));
                 }
             }
             Axiom::SubObjectPropertyOf {
@@ -3215,17 +3220,9 @@ fn collect_el_rules_with_provenance(
         // up as a wrong or missing proof rather than a wrong answer.
         for ax in &internal.axioms {
             match ax {
-                Axiom::ObjectPropertyRange { role, range }
-                    if !role.is_inverse()
-                        && matches!(internal.concepts.get(*range), ConceptExpr::Atomic(_)) =>
-                {
-                    if let ConceptExpr::Atomic(id) = internal.concepts.get(*range) {
-                        mini_rules
-                            .role_ranges
-                            .entry(role.role_id())
-                            .or_default()
-                            .push(*id);
-                    }
+                Axiom::ObjectPropertyRange { role, range } if !role.is_inverse() => {
+                    let entry = mini_rules.role_ranges.entry(role.role_id()).or_default();
+                    decompose_role_filler(*range, &internal.concepts, entry);
                 }
                 Axiom::SubObjectPropertyOf {
                     sub: SubRolePath::Chain(parts),
@@ -3429,6 +3426,61 @@ fn collect_el_rules_with_provenance(
     (rules, tseitin, total_classes, Some(trace))
 }
 
+/// Decompose an `ObjectPropertyDomain` / `ObjectPropertyRange` filler into the
+/// ATOMIC classes the saturator's `role_domains` / `role_ranges` can hold,
+/// pushing each onto `sink`. Returns `true` iff the filler decomposed
+/// **completely**.
+///
+/// `Domain(r, P ⊓ Q)` is logically identical to `Domain(r,P) ∧ Domain(r,Q)`
+/// (likewise `Range`), so this is sound and completeness-preserving by
+/// construction — the same identity argument as `flatten_union_of_oneofs`
+/// (#42 item 1) and #81's range fold, not an approximation.
+///
+/// **Partial decomposition is deliberate and sound.** `P ⊓ ∃s.C` yields `P`
+/// alone: a WEAKER (larger) domain than the axiom states, which derives fewer
+/// subsumptions and never a wrong one. Contrast `DataUnionOf`, where keeping
+/// half a union NARROWS a range and manufactures clashes — there all-or-nothing
+/// is load-bearing, here it is not.
+///
+/// **The `bool` is what the fragment gates consume**, and it is why this
+/// function is `pub`. A gate that re-implemented "is this filler decomposable?"
+/// could drift from what this actually processes, and a conjunct the engine
+/// silently skipped inside a complete-certified fragment is exactly the D10 bug
+/// class. One function, no drift — the same reasoning that factored out
+/// `abox_saturation_inconsistent`.
+///
+/// `Bot` returns `false` **without** pushing: `Domain(r, ⊥)` is handled earlier
+/// by `poisoned_roles`, so this function never sees it on the engine path;
+/// `is_processed_role_filler` re-admits it explicitly for the gates.
+///
+/// **Nested `⊥`/`⊤` are UNCONSTRUCTIBLE, so those arms are defensive, not live.**
+/// `ConceptPool::and` collapses `And([P, ⊥])` to `⊥` and drops `⊤`
+/// (`ir.rs:367-390`), `intern_raw` is private, and `convert.rs`/`normalize.rs`
+/// build conjunctions only through `.and(`. So `P ⊓ ⊥` reaches the engine as a
+/// bare `⊥` and correctly poisons the role — a STRONGER outcome than this
+/// function would give. Do not describe that path as if it executes.
+pub fn decompose_role_filler(c: ConceptId, pool: &ConceptPool, sink: &mut Vec<ClassId>) -> bool {
+    match pool.get(c) {
+        ConceptExpr::Atomic(id) => {
+            sink.push(*id);
+            true
+        }
+        // `Domain(r, ⊤)` states nothing; vacuously complete, nothing to push.
+        ConceptExpr::Top => true,
+        ConceptExpr::And(ops) => {
+            let mut complete = true;
+            for op in ops {
+                // Deliberately NOT short-circuiting: every atomic conjunct is
+                // entailed and worth pushing even when a sibling is not
+                // representable.
+                complete &= decompose_role_filler(*op, pool, sink);
+            }
+            complete
+        }
+        _ => false,
+    }
+}
+
 fn collect_el_rules(
     internal: &InternalOntology,
     role_super: &HashMap<RoleId, HashSet<RoleId>>,
@@ -3462,12 +3514,9 @@ fn collect_el_rules(
                     // no individual may be an r-source. Poison the role so that
                     // any class deriving `∃r.X` is marked unsatisfiable.
                     rules.poisoned_roles.insert(role.role_id());
-                } else if let ConceptExpr::Atomic(id) = internal.concepts.get(*domain) {
-                    rules
-                        .role_domains
-                        .entry(role.role_id())
-                        .or_default()
-                        .push(*id);
+                } else {
+                    let entry = rules.role_domains.entry(role.role_id()).or_default();
+                    decompose_role_filler(*domain, &internal.concepts, entry);
                 }
             }
             Axiom::ObjectPropertyRange { role, range } => {
@@ -3478,12 +3527,9 @@ fn collect_el_rules(
                     // r-edge can exist in any model. Poison the role so that any
                     // class deriving `∃r.X` is marked unsatisfiable.
                     rules.poisoned_roles.insert(role.role_id());
-                } else if let ConceptExpr::Atomic(id) = internal.concepts.get(*range) {
-                    rules
-                        .role_ranges
-                        .entry(role.role_id())
-                        .or_default()
-                        .push(*id);
+                } else {
+                    let entry = rules.role_ranges.entry(role.role_id()).or_default();
+                    decompose_role_filler(*range, &internal.concepts, entry);
                 }
             }
             Axiom::SubObjectPropertyOf {
@@ -5095,6 +5141,106 @@ fn build_role_super(internal: &InternalOntology) -> HashMap<RoleId, HashSet<Role
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decompose_pushes_every_atomic_conjunct_and_reports_complete() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let and = pool.and([p, q]);
+        let mut sink = Vec::new();
+        assert!(
+            decompose_role_filler(and, &pool, &mut sink),
+            "fully decomposable"
+        );
+        assert_eq!(sink.len(), 2, "both conjuncts pushed");
+    }
+
+    /// PARTIAL: `P ⊓ (Q ⊔ R)` pushes `P` and reports INCOMPLETE. A disjunction is
+    /// used as the non-decomposable conjunct because it needs no `Role`, keeping
+    /// the unit test free of role-hierarchy setup.
+    #[test]
+    fn decompose_reports_incomplete_but_still_pushes_the_atomic_half() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let r = pool.atomic(owl_dl_core::ClassId::new(2));
+        let or = pool.or([q, r]);
+        let and = pool.and([p, or]);
+        let mut sink = Vec::new();
+        assert!(
+            !decompose_role_filler(and, &pool, &mut sink),
+            "not complete"
+        );
+        assert_eq!(sink.len(), 1, "the atomic conjunct is still pushed");
+    }
+
+    /// ORDER-INDEPENDENCE, and what sabotage #5 (short-circuiting the `And` loop)
+    /// is caught by.
+    ///
+    /// **`ConceptPool::and` SORTS its operands by `ConceptId`** (`ir.rs:385-386`,
+    /// `sort_unstable` + `dedup`), so argument order at the call site is NOT the
+    /// order the loop sees — INTERN order is. Interning `p` first therefore makes
+    /// `pool.and([or, p])` intern to the same `And([p, or])` as the previous test,
+    /// where a short-circuiting loop still pushes `p` and the test passes
+    /// VACUOUSLY. Intern the disjunction FIRST so its id is lower and it is
+    /// visited first.
+    #[test]
+    fn decompose_does_not_short_circuit_when_the_bad_conjunct_sorts_first() {
+        let mut pool = ConceptPool::default();
+        // Intern order is what matters: `or` must get a LOWER id than `p`.
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let r = pool.atomic(owl_dl_core::ClassId::new(2));
+        let or = pool.or([q, r]);
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let and = pool.and([or, p]);
+        assert!(
+            or < p,
+            "guard: the fixture is only meaningful if `or` sorts first"
+        );
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(and, &pool, &mut sink));
+        assert_eq!(
+            sink.len(),
+            1,
+            "the atomic conjunct is pushed regardless of order"
+        );
+    }
+
+    /// FP GUARD: a bare disjunction decomposes to NOTHING. `Domain(r, P ⊔ Q)`
+    /// does not entail `Domain(r, P)`.
+    #[test]
+    fn decompose_declines_a_disjunction_and_pushes_nothing() {
+        let mut pool = ConceptPool::default();
+        let p = pool.atomic(owl_dl_core::ClassId::new(0));
+        let q = pool.atomic(owl_dl_core::ClassId::new(1));
+        let or = pool.or([p, q]);
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(or, &pool, &mut sink));
+        assert!(sink.is_empty(), "a disjunct is not a domain — FP guard");
+    }
+
+    /// `Top` states nothing and is vacuously complete: `Domain(r, ⊤)` must be
+    /// admitted by the gate (it adds no constraint) while pushing no class.
+    #[test]
+    fn decompose_treats_top_as_complete_and_pushes_nothing() {
+        let mut pool = ConceptPool::default();
+        let top = pool.top();
+        let mut sink = Vec::new();
+        assert!(decompose_role_filler(top, &pool, &mut sink));
+        assert!(sink.is_empty());
+    }
+
+    /// `Bot` declines WITHOUT pushing — it is handled earlier by
+    /// `poisoned_roles`, and `is_processed_role_filler` re-admits it explicitly.
+    #[test]
+    fn decompose_declines_bot_without_pushing() {
+        let mut pool = ConceptPool::default();
+        let bot = pool.bot();
+        let mut sink = Vec::new();
+        assert!(!decompose_role_filler(bot, &pool, &mut sink));
+        assert!(sink.is_empty());
+    }
 
     #[test]
     fn id_matrix_dense_and_sparse_are_semantically_identical() {

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -2673,13 +2673,24 @@ struct ElRules {
     /// Per-role domain classes: `role_domains[r]` holds the atomic
     /// classes `C` such that any `r`-source belongs to `C`. Lowered
     /// from `ObjectPropertyDomain(r, C)` with named `r` and atomic
-    /// `C`. Equivalent to `∃r.⊤ ⊑ C`.
+    /// `C` — or, since #110, from the atomic *conjuncts* of a
+    /// conjunctive `C` (`Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)`,
+    /// decomposed via `decompose_role_filler`). Equivalent to
+    /// `∃r.⊤ ⊑ C`. This map was already multi-valued before #110 (two
+    /// `ObjectPropertyDomain` axioms on one role, or the `Bug 2b-3`
+    /// `∃r.⊤ ⊑ sup` arm above, both push more than one head via
+    /// `atomic_operands_on_right`), and every consumer already iterates
+    /// the whole `Vec` — so admitting the decomposed shape reaches an
+    /// engine state that was already reachable and already handled.
     role_domains: HashMap<RoleId, Vec<ClassId>>,
     /// Per-role range classes: `role_ranges[r]` holds the atomic
     /// classes `C` such that any `r`-target belongs to `C`. Lowered
     /// from `ObjectPropertyRange(r, C)` with named `r` and atomic
-    /// `C`. Equivalent to `⊤ ⊑ ∀r.C`; in EL we only consult it on
-    /// edges that actually appear (the existential-fact targets).
+    /// `C` — or, since #110, from the atomic *conjuncts* of a
+    /// conjunctive `C` (same `decompose_role_filler` decomposition as
+    /// `role_domains`, see the note there). Equivalent to `⊤ ⊑ ∀r.C`;
+    /// in EL we only consult it on edges that actually appear (the
+    /// existential-fact targets).
     role_ranges: HashMap<RoleId, Vec<ClassId>>,
     /// Role chain axioms `r₁ ∘ r₂ ⊑ sup`. Lowered from
     /// `SubObjectPropertyOf(ObjectPropertyChain(r₁ r₂), sup)` with

--- a/crates/owl-dl-verify/tests/horn_widening_market.rs
+++ b/crates/owl-dl-verify/tests/horn_widening_market.rs
@@ -80,8 +80,12 @@ fn a_conjunctive_disjointclasses_member_is_the_one_admissible_shape() {
   SubClassOf(:A :B)\n\
   DisjointClasses(ObjectIntersectionOf(:A :B) :C)\n)\n"
     ));
-    eprintln!("fragment = {fragment:?}\nverdict  = {verdict:?}");
     assert_ne!(fragment, FC::PureEl, "the CLI gate must refuse this today");
+    assert!(
+        matches!(verdict, Verdict::Verified { .. }),
+        "this is the shape the doc comment claims makes the market non-empty — \
+         if it is not Verified, that claim is false, got {verdict:?}"
+    );
 }
 
 /// THE SECOND HOLE — RETARGETED (#110). This test used to pin a live defect:

--- a/crates/owl-dl-verify/tests/horn_widening_market.rs
+++ b/crates/owl-dl-verify/tests/horn_widening_market.rs
@@ -1,0 +1,136 @@
+//! Is there ANY ontology the `verify-el` CLI gate refuses as non-`PureEl`,
+//! that is nonetheless `Horn` AND that this crate can actually check?
+//!
+//! The market analysis behind this file found the gate refuses almost every
+//! Horn-but-not-EL construct outright (`eval.rs` returns `Unresolved` for it),
+//! and `verify` reaches `Verified` only with ZERO unresolved axioms. It found
+//! exactly two holes where the gate and the checker disagreed: a non-atomic
+//! `DisjointClasses` member, and a conjunctive `ObjectPropertyDomain`/`Range`
+//! filler. **The second hole is now CLOSED by #110** — the fix moved the gate
+//! and the engine in lockstep, so that fixture reports `PureEl` (see the
+//! retargeted test below). These tests are the discriminating probes for the
+//! wider claim — they call `build_model`/`verify` DIRECTLY, which bypasses
+//! `main.rs`'s `analyze_fragment != PureEl` early exit, so they can observe
+//! what the checker would say if the gate were widened.
+//!
+//! They exist because the claim was nearly shipped over four unread
+//! `eval.rs` arms.
+
+use owl_dl_reasoner::FragmentClassification as FC;
+use owl_dl_verify::{Bounds, Verdict};
+
+mod common;
+use common::load;
+
+const HEADER: &str = "Prefix(:=<http://rustdl.test/>)\n\
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n";
+
+fn verdict_of(ofn: &str) -> (FC, Verdict) {
+    let internal = load(ofn);
+    let fragment = owl_dl_reasoner::analyze_fragment(&internal);
+    let verdict = match owl_dl_verify::build_model(&internal, &Bounds::default()) {
+        Err(reason) => Verdict::Unresolved {
+            domain_size: 0,
+            reasons: vec![reason],
+        },
+        Ok((model, build_reasons)) => {
+            let (v, _) = owl_dl_verify::verify(model, &internal, None);
+            assert!(
+                build_reasons.is_empty(),
+                "unexpected build-time refusal: {build_reasons:?}"
+            );
+            v
+        }
+    };
+    (fragment, verdict)
+}
+
+/// A `∀` is the canonical Horn-∖-EL generator, and `eval.rs:87` refuses it.
+/// The verdict must therefore be `Unresolved` — widening the gate to admit
+/// this ontology would buy no coverage.
+#[test]
+fn a_forall_is_horn_but_not_el_and_the_evaluator_refuses_it() {
+    let (fragment, verdict) = verdict_of(&format!(
+        "{HEADER}Ontology(\n\
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(ObjectProperty(:r))\n\
+  SubClassOf(:A ObjectSomeValuesFrom(:r :B))\n\
+  SubClassOf(:A ObjectAllValuesFrom(:r :B))\n)\n"
+    ));
+    assert_ne!(fragment, FC::PureEl, "the CLI gate must refuse this today");
+    assert!(
+        matches!(verdict, Verdict::Unresolved { .. }),
+        "a widened gate must not reach a verdict here, got {verdict:?}"
+    );
+}
+
+/// THE COUNTEREXAMPLE TO "ZERO". `is_el_axiom` requires every
+/// `DisjointClasses` member to be ATOMIC, so a conjunctive member leaves the
+/// EL fragment — but `eval.rs`'s `DisjointClasses` arm has no atomicity check
+/// and `eval_concept` handles `CE::And` without complaint.
+///
+/// If this reports `Verified`, the admissible market is non-empty and the
+/// analytical claim must be stated as "these shapes only", not "zero".
+#[test]
+fn a_conjunctive_disjointclasses_member_is_the_one_admissible_shape() {
+    let (fragment, verdict) = verdict_of(&format!(
+        "{HEADER}Ontology(\n\
+  Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:C))\n\
+  Declaration(Class(:X)) Declaration(ObjectProperty(:r))\n\
+  SubClassOf(:X ObjectSomeValuesFrom(:r :A))\n\
+  SubClassOf(:A :B)\n\
+  DisjointClasses(ObjectIntersectionOf(:A :B) :C)\n)\n"
+    ));
+    eprintln!("fragment = {fragment:?}\nverdict  = {verdict:?}");
+    assert_ne!(fragment, FC::PureEl, "the CLI gate must refuse this today");
+}
+
+/// THE SECOND HOLE — RETARGETED (#110). This test used to pin a live defect:
+/// a conjunctive `ObjectPropertyDomain` filler (`Domain(r, P ⊓ Q)`) was
+/// silently dropped by the saturator while `is_el_axiom` certified the
+/// ontology `PureEl` (via `is_el_concept`, which has no atomicity check) —
+/// D10-shaped, and it cost `classify` two real subsumptions
+/// (`X ⊑ P`, `X ⊑ Q`) that Konclude, `HermiT` and rustdl's own `subclass` all
+/// confirmed. #110 fixed it at the engine: `decompose_role_filler` now
+/// processes every atomic conjunct of a fully-decomposable filler, and the
+/// gate (`is_processed_role_filler`, née `is_atomic_or_trivial_concept`) moved
+/// in lockstep, so this exact fixture now correctly reports `PureEl` — the gate
+/// and the engine agree, and there is no hole here anymore.
+///
+/// That does NOT shrink the market-analysis finding to zero holes: it moves
+/// this shape out of "Horn-non-EL-and-checkable" and into "now decomposes to
+/// EL", which is a stronger result than the original two-hole count implied.
+/// A `Verified` verdict on this fixture (reachable through the fast path) was
+/// itself the finding this widening spike was chasing.
+///
+/// So the fixture is retargeted to a shape that stays out-of-EL for a reason
+/// that is a DESIGN DECISION, not a defect: an **existential**
+/// `ObjectPropertyDomain` filler, `Domain(r, ∃s.S)`. Unlike a conjunction,
+/// this is not a case of "the decomposition exists but the engine forgot to
+/// apply it" — `decompose_role_filler`'s contract only ever pushes ATOMIC
+/// conjuncts into `role_domains`/`role_ranges: HashMap<RoleId, Vec<ClassId>>`,
+/// so an existential filler has no `ClassId` to push at all; admitting it
+/// would need a structurally different rule (materializing `x ⊑ ∃s.S` at
+/// every `r`-edge source), not a wider decomposer. (`ObjectUnionOf` was tried
+/// first, per the original plan; it measures `OutOfFragment`, not `Horn` — a
+/// disjunctive head is non-Horn by definition, so it cannot serve this test's
+/// purpose of exhibiting a Horn-but-non-EL shape. Measure before asserting.)
+/// See [[tests-that-pin-the-bug]].
+#[test]
+fn an_existential_domain_filler_is_horn_non_el_and_the_checker_reaches_a_verdict() {
+    let (fragment, verdict) = verdict_of(&format!(
+        "{HEADER}Ontology(\n\
+  Declaration(Class(:X)) Declaration(Class(:B)) Declaration(Class(:S))\n\
+  Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))\n\
+  SubClassOf(:X ObjectSomeValuesFrom(:r :B))\n\
+  ObjectPropertyDomain(:r ObjectSomeValuesFrom(:s :S))\n)\n"
+    ));
+    assert_eq!(
+        fragment,
+        FC::Horn,
+        "this shape must sit in the widening's candidate population"
+    );
+    assert!(
+        !matches!(verdict, Verdict::Unresolved { .. }),
+        "the checker must REACH a verdict here — that is what makes this a hole, got {verdict:?}"
+    );
+}

--- a/docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
+++ b/docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
@@ -250,9 +250,10 @@ untested, which is exactly [[sabotage-your-own-guard-tests]].
 
 ## 5. What this evidence does and does not license
 
-### 5.1 Corpus reach is NON-ZERO, and the published superset figure was wrong
+### 5.1 The published superset figure was wrong, and the corpus REWARD is ZERO
 
-**The superset is 27 ORE ontologies, not the ≤14 recorded in CLAUDE.md.** That smaller figure
+**The superset is 27 ORE ontologies, not the ≤14 recorded for this shape elsewhere in the
+design record.** That smaller figure
 came from a scan whose `break` fired after the first axiom body matching a broad construct
 regex, so any ontology whose *first* `Domain`/`Range` axiom happened to be non-conjunctive was
 wrongly excluded. Two independent instruments now agree at 27 — a corrected balanced-paren
@@ -274,7 +275,8 @@ re-derived here. **Prefer 27; the ≤14 is stale wherever it still appears.**
 > the same flag. Corpus reward for #110 is measured **zero**. The analysis below is otherwise
 > unchanged.
 
-**Reach is measured and non-zero.** On `ore_ont_4796` (DOLCE-Lite), `RUSTDL_CLASSIFY_SAME_TIER=1`
+**The shape occurs in the wild, but the observation below is FLAG-ATTRIBUTABLE — see the box
+above before reading it as reward.** On `ore_ont_4796` (DOLCE-Lite), `RUSTDL_CLASSIFY_SAME_TIER=1`
 gains exactly `DOLCE-Lite#agent ⊑ DOLCE-Lite#endurant` and `DOLCE-Lite#agent ⊑
 DOLCE-Lite#particular` — **transitive closure 1,224 → 1,226, lost 0** — stable at both the 5 ms
 default and `--pair-timeout-ms 1000`, and **KM derives both**. Since the flag is the documented
@@ -286,10 +288,13 @@ only `gained=1`: the second pair is transitively implied and therefore has no di
 row-count comparison understates the gain — the fifth recorded instance of the direct-vs-closure
 trap in this repository.
 
-**The bound that survives: no full ORE sweep was run for this task.** `ore_ont_4796`
-*corroborates* that the shape occurs in the wild; it does not measure the population. Task 4 is
-the sweep. Until it lands, the evidence for #110 is **the canaries, this three-oracle
-adjudication, and one corroborating real ontology** — not a population measurement.
+**The bound that survived this task — no full ORE sweep was run here — is now CLOSED by Task 4,
+and it closed against the expectation.** `ore_ont_4796` corroborates that the shape occurs in the
+wild; it never measured the population, and the population measurement came back **zero**: 45
+IDENTICAL / 0 DIFFER / 2 UNMEASURED / 0 lost entailments over 25 measured bearing + 20 controls,
+and 0 fragment-routing movers across all 1,920 (§3 of
+`docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md`). So the evidence for #110 is **the
+canaries and this three-oracle adjudication** — the corpus shows inertness, not confirmation.
 
 ### 5.2 What is established
 

--- a/docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
+++ b/docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
@@ -265,6 +265,15 @@ grep -lE 'ObjectProperty(Domain|Range)\([^)]*ObjectIntersectionOf' \
 
 re-derived here. **Prefer 27; the ≤14 is stale wherever it still appears.**
 
+> **SUPERSEDED 2026-09-06 by Task 4 — see §3 of
+> `docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md` for the corrected attribution.**
+> The `ore_ont_4796` gain below is real and KM-confirmed, but it is **not attributable to
+> #110**: the pre-fix binary gains the same two pairs under `RUSTDL_CLASSIFY_SAME_TIER=1`, and
+> BEFORE and AFTER are triple-identical under *either* flag setting. The comparison here crossed
+> a flag boundary (default vs `SAME_TIER`) within one binary rather than comparing arms under
+> the same flag. Corpus reward for #110 is measured **zero**. The analysis below is otherwise
+> unchanged.
+
 **Reach is measured and non-zero.** On `ore_ont_4796` (DOLCE-Lite), `RUSTDL_CLASSIFY_SAME_TIER=1`
 gains exactly `DOLCE-Lite#agent ⊑ DOLCE-Lite#endurant` and `DOLCE-Lite#agent ⊑
 DOLCE-Lite#particular` — **transitive closure 1,224 → 1,226, lost 0** — stable at both the 5 ms

--- a/docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
+++ b/docs/benchmarks/2026-09-06-conjunctive-domain-range-adjudication.md
@@ -1,0 +1,291 @@
+# Conjunctive `ObjectPropertyDomain`/`Range` filler (#110) — three-oracle adjudication and sabotage battery
+
+Date: 2026-09-06. Branch `fix/conjunctive-domain-range-filler-110`, Task 3.
+Binaries pinned per configuration:
+
+| arm | commit | sha256 (prefix) |
+|---|---|---|
+| BEFORE | `0abc21b` (pre-#110) | `ac6477fc` |
+| AFTER | `2fa8d0f` (Tasks 1+2) | `e9f11f43` |
+
+The AFTER binary was **rebuilt from the tree after the last sabotage revert and is
+byte-identical to the pin** (`e9f11f43…` both times). That identity is the evidence that
+all five sabotages are fully reverted, not an assertion that they are.
+
+---
+
+## 1. What was wrong, stated precisely
+
+`collect_el_rules`' `ObjectPropertyDomain`/`Range` arms handled `Bot` (poison) and `Atomic`
+(push) and **fell through silently on `And`**. `Domain(r, P ⊓ Q)` therefore reached the EL
+saturator as *nothing at all*.
+
+The EL gate was not the liar — `is_el_axiom` correctly refused the axiom, so the ontology
+routed to the hybrid path. **The false certification is the `Horn` banner plus the tier
+walk**: dropping the filler leaves `X` with no EL subsumer, so the tier walk (which groups
+by EL/told subsumer count and never compares same-tier classes) never compares `X` against
+`P`, and `classify` returns **zero rows with `incomplete: false` and `dropped: {}`** under
+`# fragment: Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)`.
+
+That is the D10 shape: a gate certifying complete over an engine that dropped the axiom.
+
+**This closes a defect the design record already carries as live and UNFIXED.** CLAUDE.md's
+`owl-dl-verify` section records exactly this shape — *"`ObjectPropertyDomain(r, P ⊓ Q)` …
+`direct_subsumptions: []` with `incomplete: false`"*, recovered only by
+`RUSTDL_CLASSIFY_SAME_TIER=1`. It now closes **at the default, with no flag**.
+
+---
+
+## 2. Oracle adjudication — 6 of 6
+
+**Comparison, as defined:** the set of **named** subsumption pairs, excluding every row whose
+superclass is `owl:Thing` and every row mentioning `owl:Nothing`. This exclusion is not
+cosmetic — Konclude emits **6 `Thing` rows on `dom_conj`, of 8 `<SubClassOf>` blocks total**,
+so a raw `<SubClassOf>` count compares nothing. Konclude was judged from **content, never exit
+code** (it exits 0 on a missing file, writing an ~896-byte `Thing`/`Nothing` stub); every
+output here is 2414–2537 bytes, so every run genuinely classified.
+
+The Konclude parser was validated independently rather than trusted: a raw
+`grep -c '<SubClassOf>'` reproduces the parsed block totals exactly (8/7/7/7/8/7), and the
+files contain **zero** `abbreviatedIRI` attributes, so the IRI regex dropped nothing.
+
+| probe | rustdl BEFORE | rustdl AFTER | Konclude | HermiT | KM | agree? |
+|---|---|---|---|---|---|---|
+| `dom_conj` | **∅** | `X⊑P`, `X⊑Q` | `X⊑P`, `X⊑Q` | `X⊑P`, `X⊑Q` | `X⊑P`, `X⊑Q` | ✅ |
+| `dom_atomic` | `X⊑P` | `X⊑P` | `X⊑P` | `X⊑P` | `X⊑P` | ✅ |
+| `rng_conj` | **∅** | `X⊑W` | `X⊑W` | `X⊑W` | `X⊑W` | ✅ |
+| `rng_atomic` | `X⊑W` | `X⊑W` | `X⊑W` | `X⊑W` | `X⊑W` | ✅ |
+| `dom_partial` | **∅** | `X⊑P`, `X⊑Z` | `X⊑P`, `X⊑Z` | `X⊑P`, `X⊑Z` | `X⊑P`, `X⊑Z` | ✅ |
+| `dom_disj` | ∅ | ∅ | ∅ | ∅ | ∅ | ✅ |
+
+**Post-fix rustdl, Konclude, HermiT and KM produce the identical named set on 6 of 6.**
+Every AFTER row carries `consistent: true`, `incomplete: false`, `dropped: {}`, `unsat: []`.
+
+Fragment banner, BEFORE → AFTER:
+
+| probe | BEFORE | AFTER |
+|---|---|---|
+| `dom_conj` | `Horn` (mode hybrid) | **`pure-EL`** |
+| `rng_conj` | `Horn` (mode hybrid) | **`pure-EL`** |
+| `dom_atomic` / `rng_atomic` | `pure-EL` | `pure-EL` (unchanged control) |
+| `dom_partial` | `Horn` | `Horn` (gate correctly refuses; hybrid recovers) |
+| `dom_disj` | `out-of-EL` | `out-of-EL` (unchanged) |
+
+### 2.1 `dom_partial` — the brief's replacement probe, and why it strengthens the fix
+
+The brief's original `dom_partial` asked whether the oracles report `X ⊑ Q` where `Q` does not
+occur in the axiom — trivially "no", so no implementation could fail it. The version used here
+is `Domain(r, P ⊓ ∃s.S)` plus `SubClassOf(∃s.S, Z)`, asking whether **`X ⊑ Z`** is derived —
+i.e. whether the conjunct the *engine did not process* still reaches an answer.
+
+It does, and that is the point of Task 2. `decompose_role_filler` returns `false` on this
+filler, `is_processed_role_filler` therefore **refuses the fragment**, and the ontology routes
+to the complete hybrid path, which derives both `X ⊑ P` and `X ⊑ Z`. Partial decomposition is
+sound to *derive from* but must not be *certified complete* — and the probe shows the refusal
+is not a loss.
+
+### 2.2 `dom_disj` is a discriminating control, not an ambiguous silence
+
+Konclude is documented to under-report, so its silence needs licensing. It is licensed
+affirmatively here: on `dom_disj` Konclude places `X` in the **`Thing` list** (7 `Thing` rows,
+0 named) — an explicit "no named parent" — while on `dom_atomic` it emits `X ⊑ P` and `X` is
+*absent* from the `Thing` list. Same for HermiT: its `dom_disj` output is 1 byte while
+`dom_atomic`, through the same wrapper on the same file family, is 61 bytes containing the
+domain-derived row. Both oracles are demonstrably reasoning about `ObjectPropertyDomain` on
+these files and declining `dom_disj` on the merits.
+
+`Domain(r, P ⊔ Q)` entails `X ⊑ P ⊔ Q` and **neither disjunct**, so a reasoner reporting
+`X ⊑ P` here has a false positive. The fix is **provably inert** on `dom_disj`: BEFORE and
+AFTER produce identical output. That inertness is what shows the fix is not over-broad in the
+FP direction.
+
+### 2.3 Two probe limits, stated rather than implied
+
+- **`rng_conj` observes only the `P` conjunct.** Its consuming axiom is `∃r.(B ⊓ P) ⊑ W`;
+  nothing in the probe consumes `Q`. So the oracle set does **not** demonstrate that both
+  range conjuncts reach a witness — only `dom_conj` does that, via two separate rows. The
+  canary `conjunctive_range_filler_derives_every_conjunct` is what covers the range half.
+- **No integration probe can observe sabotage 5** (see §3.5).
+
+---
+
+## 3. Sabotage battery — 6 run, 5 caught, 1 survived
+
+Each sabotage was applied to source, evaluated with `cargo test` (a *pinned binary cannot see
+a source sabotage*), then reverted and the tree confirmed clean with `git diff --exit-code`
+before the next. Failures are reported **by test name**; the granularity is the finding.
+
+Baseline, unsabotaged: `conjunctive_domain_range_filler` 11/11, `owl-dl-saturation --lib
+decompose` 7/7, `horn_widening_market` 3/3.
+
+**Direction of risk differs and is not uniform.** #3 is the only sabotage whose survival would
+mean **unsoundness** (a real FP); #1/#2/#4/#5 are completeness-direction.
+
+### 3.1 Sabotage 1 — revert both engine arms to the `Atomic`-only branch → **CAUGHT**
+
+Predicted: the 2 bug canaries + the partial canary. **Observed 5 failures** — the 3 predicted
+plus both provenance canaries:
+
+```
+conjunctive_domain_filler_derives_every_conjunct                  FAILED
+conjunctive_range_filler_derives_every_conjunct                   FAILED
+partially_decomposable_filler_still_derives_its_atomic_conjunct   FAILED
+prove_attributes_the_conjunctive_domain_subsumption_to_its_axiom  FAILED
+prove_attributes_the_conjunctive_range_folded_subsumer_to_its_axiom FAILED
+```
+
+**The first reading of this was wrong, and the correction is the useful part.** The patch
+asserted a unique match on each pattern, so it hit only the *real* Pass-1 arms
+(`lib.rs` ~3519/~3532); the two provenance mirrors in `collect_el_rules_with_provenance`
+(~3157/~3225) were left decomposing. The two `prove` canaries therefore failed only because
+the underlying subsumption had vanished — **nothing to do with the mirrors**. Calling that an
+"over-catch" would have recorded coverage this sabotage does not provide, leaving those
+canaries' *stated purpose* (guarding the mirror against drift from the real pass) unverified.
+See §3.6, which runs the sabotage that actually tests it.
+
+### 3.2 Sabotage 2 — `decompose_role_filler`'s `And` arm returns `true` unconditionally → **CAUGHT**
+
+Predicted `a_partially_decomposable_filler_is_refused_by_the_gate`; that failed, plus two unit
+tests:
+
+```
+a_partially_decomposable_filler_is_refused_by_the_gate            FAILED
+decompose_reports_incomplete_but_still_pushes_the_atomic_half     FAILED
+decompose_does_not_short_circuit_when_the_bad_conjunct_sorts_first FAILED
+```
+
+### 3.3 Sabotage 3 — add a `ConceptExpr::Or` arm that decomposes like `And` → **CAUGHT**
+
+The unsoundness-direction sabotage. Both predicted canaries failed, plus three unit tests:
+
+```
+a_disjunctive_filler_does_not_decompose      FAILED  (panic: "FP: a disjunct is not a domain")
+a_disjunctive_filler_is_refused_by_the_gate  FAILED
+decompose_declines_a_disjunction_and_pushes_nothing FAILED
+decompose_reports_incomplete_but_still_pushes_the_atomic_half FAILED
+decompose_does_not_short_circuit_when_the_bad_conjunct_sorts_first FAILED
+```
+
+The panic message is the finding: under this sabotage `Domain(r, P ⊔ Q)` yields `X ⊑ P` — a
+genuine false positive, caught with a control (`dom_atomic`/`rng_atomic`) that shows the
+oracles *do* report in the entailed case.
+
+### 3.4 Sabotage 4 — re-implement `is_processed_role_filler` locally → **SURVIVED (predicted)**
+
+Replacing the delegation with a local `matches!(Atomic | Bot | Top | And(all atomic))` leaves
+**the entire workspace green — 1960 passed, 0 failed, 85 ignored**, not merely the 21 tests of
+the three targeted binaries. The frame matters here and only here: catches can only accumulate
+as the frame grows, so #1/#1b/#2/#3/#5 are frame-insensitive, but #4 is the one sabotage whose
+*headline could flip*, and two files that reference the gate by name
+(`conjunctive_unsat.rs:878`, `flag_defaults.rs`) sit outside the narrow frame. They do not
+catch it either. This was predicted; recording it is the point.
+
+**But the survivor statement is stronger than "they agree today", and the extra probe is what
+established that.** The obvious distinguisher is a *nested* conjunction —
+`Domain(r, P ⊓ (Q ⊓ W))`, where the recursive decomposer returns `true` and pushes all three
+while `And(all atomic)` returns `false`. Built as `dom_nested.ofn` and run under a
+**sabotage-4 build**: it still reports `# fragment: pure-EL` and derives `X⊑P`, `X⊑Q`, `X⊑W`,
+identical to the correct binary.
+
+The reason is structural, not luck: **`ConceptPool::and` flattens nested `And` at intern time**
+(`crates/owl-dl-core/src/ir.rs:374`, `ConceptExpr::And(inner) => v.extend_from_slice(inner)`),
+also dropping `Top` operands and short-circuiting `Bot`. So an `And` operand can never itself
+be an `And`, `Top`, or `Bot`, and on **every concept the interner can construct** the two
+predicates are extensionally equal on the boolean the gate reads.
+
+That "every constructible input" is enforced at a **single chokepoint, by privacy**, which was
+checked rather than assumed: `intern_raw` is private to `ir.rs`, and a workspace-wide grep for
+`ConceptExpr::And(` finds exactly one **construction** site — `ir.rs:389`, inside
+`ConceptPool::and` — every other hit being a destructuring pattern.
+
+So the honest limit is not "the canaries missed a divergence" but: **these canaries pin
+behaviour, not the no-drift property.** No-drift rests on the shared call site plus an
+invariant maintained in a *different crate*. If `ConceptPool::and` ever stopped flattening,
+the local and delegated forms would silently diverge and nothing here would notice. That
+coupling is untested.
+
+### 3.5 Sabotage 5 — short-circuit the `And` loop on the first `false` → **CAUGHT, by exactly one test**
+
+```
+decompose_does_not_short_circuit_when_the_bad_conjunct_sorts_first  FAILED
+```
+
+The integration suite is **completely blind**: 11/11 pass. This is the honest limit the brief
+predicted, and it is structural — `ConceptPool::and` **sorts operands by `ConceptId`**
+(`v.sort_unstable()`), so an integration fixture cannot choose which conjunct comes first;
+that ordering is an interning artefact. The unit test, which builds the `And` directly with
+the non-decomposable conjunct sorting first, is the **entire net** for this mutation — the
+same shape of limit CLAUDE.md records for the `IntSet::disjoint` relaxation.
+
+### 3.6 Sabotage 1b — revert **only** the provenance mirrors → **CAUGHT**
+
+Added after §3.1's misreading was caught. The real Pass-1 arms are left intact and only
+`collect_el_rules_with_provenance`'s two mirrors are reverted to `Atomic`-only, so the
+derivations survive and *only* the attribution can break. Predicted: the two `prove` canaries
+fail, the three derivation canaries pass. Observed exactly that:
+
+```
+prove_attributes_the_conjunctive_domain_subsumption_to_its_axiom    FAILED
+prove_attributes_the_conjunctive_range_folded_subsumer_to_its_axiom FAILED
+9 passed (incl. all three derivation canaries); saturation 7/7; horn_widening_market 3/3
+```
+
+So the mirrors **are** guarded, and by the canaries written for them — verified, not assumed.
+Without this run the branch would have shipped two guard tests whose stated purpose was
+untested, which is exactly [[sabotage-your-own-guard-tests]].
+
+---
+
+## 4. Gates
+
+- **Full workspace suite: 1960 passed, 0 failed, 85 ignored**, run after the final revert.
+  `owl-dl-py` is excluded: its *lib test* fails to **link** in this environment with undefined
+  CPython symbols (`PyExc_Exception`, `PyErr_Fetch`, …) — a missing libpython for the pyo3
+  extension, environmental and untouched by #110, which changes no Python surface.
+- **Tree clean** (`git diff --exit-code`) after each of the **six** reverts, and the rebuilt
+  release binary is **byte-identical** to the pre-sabotage pin (`e9f11f43…`), re-confirmed
+  after the final revert of the second sabotage-4 run.
+
+---
+
+## 5. What this evidence does and does not license
+
+### 5.1 Corpus reach is NON-ZERO, and the published superset figure was wrong
+
+**The superset is 27 ORE ontologies, not the ≤14 recorded in CLAUDE.md.** That smaller figure
+came from a scan whose `break` fired after the first axiom body matching a broad construct
+regex, so any ontology whose *first* `Domain`/`Range` axiom happened to be non-conjunctive was
+wrongly excluded. Two independent instruments now agree at 27 — a corrected balanced-paren
+scan, and
+
+```sh
+grep -lE 'ObjectProperty(Domain|Range)\([^)]*ObjectIntersectionOf' \
+  /data/dumontier/ore-run/pool_sample/files/* | wc -l   # 27
+```
+
+re-derived here. **Prefer 27; the ≤14 is stale wherever it still appears.**
+
+**Reach is measured and non-zero.** On `ore_ont_4796` (DOLCE-Lite), `RUSTDL_CLASSIFY_SAME_TIER=1`
+gains exactly `DOLCE-Lite#agent ⊑ DOLCE-Lite#endurant` and `DOLCE-Lite#agent ⊑
+DOLCE-Lite#particular` — **transitive closure 1,224 → 1,226, lost 0** — stable at both the 5 ms
+default and `--pair-timeout-ms 1000`, and **KM derives both**. Since the flag is the documented
+workaround for precisely the tier-walk half of this defect, that is the shape biting a real
+ontology rather than only a synthetic.
+
+**Measure this on the CLOSURE, not the Hasse relation.** The `direct_subsumptions` diff shows
+only `gained=1`: the second pair is transitively implied and therefore has no direct row. A
+row-count comparison understates the gain — the fifth recorded instance of the direct-vs-closure
+trap in this repository.
+
+**The bound that survives: no full ORE sweep was run for this task.** `ore_ont_4796`
+*corroborates* that the shape occurs in the wild; it does not measure the population. Task 4 is
+the sweep. Until it lands, the evidence for #110 is **the canaries, this three-oracle
+adjudication, and one corroborating real ontology** — not a population measurement.
+
+### 5.2 What is established
+
+On six probes spanning the fixed shape, its atomic control, the partially-decomposable fallback
+and the disjunctive FP guard, **four independent reasoners agree exactly**; the pre-fix binary
+silently returned nothing on three of them while certifying `Horn`; and **five of six mutations
+to the fix are caught by name**, the sixth being a survivor provably unobservable through the
+gate's own interface — bounded over the full 1960-test workspace, not a narrow frame.

--- a/docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md
+++ b/docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md
@@ -1,0 +1,374 @@
+# Corpus gates for #110 — conjunctive `ObjectPropertyDomain`/`Range` filler
+
+Date: 2026-09-06. Task 4 of the #110 arc (Tasks 1–3: engine fix, fragment gates, oracle
+adjudication). This document answers one question: **does the fix change answers or outcomes
+across ORE?**
+
+**Headline: no — and the pre-registered corpus expectation was wrong.** The change is **inert on
+ORE by two independent instruments covering its two separable effects** (§2b): zero
+fragment-routing movers across all 1,920 ontologies, and zero answer changes across the
+27-ontology bearing frame plus 20 controls. Two frame members are UNMEASURED — one a symmetric
+DNF, one truncating in both arms — so the zero-loss result covers **25 measured bearing
+ontologies plus 20 controls**. **`ore_ont_4796` did NOT gain, and the reason is a confound in
+the Task-3 measurement, not a broken fix** (§3).
+
+---
+
+## 0. Pins
+
+| arm | commit | `rustdl` sha256 | `fragment_probe` sha256 |
+|---|---|---|---|
+| BEFORE | `0abc21b` (parent of Task 1), built in `/tmp/wt-110-before` | `41099bfe…` | `de5e7f80…` |
+| AFTER | `0dc4b61` (worktree HEAD) | `e9f11f43…` | `339cb292…` |
+
+All four hashes differ. The AFTER `rustdl` hash `e9f11f43…` reproduces Task 3's recorded AFTER
+pin exactly. The BEFORE hash differs from Task 3's `ac6477fc…` because release builds here embed
+debuginfo paths and Task 3 built at a different throwaway path — which is why a hash is not the
+pin verification. **The pin verification is behavioural**, and both binaries were checked against
+a discriminating input before any sweep ran:
+
+| input | BEFORE | AFTER |
+|---|---|---|
+| `dom_conj.ofn` `classify --json` rows | **0** | **2** |
+| `dom_conj.ofn` fragment | **Horn** | **PureEl** |
+| `rng_conj.ofn` fragment | **Horn** | **PureEl** |
+
+**The probe binary carries its own pin check, and it needs one.** A mis-pinned `fragment_probe`
+reports "0 movers", which is indistinguishable from a clean sweep — the same failure shape as a
+guard test that cannot fail. It was re-verified *after* the corpus sweep returned zero movers,
+and still discriminated.
+
+Toolchain: `stable-x86_64-unknown-linux-gnu` on `PATH` for every build. A bare `cargo` here is
+1.75, fails on edition2024, and **a failed build silently reuses a stale binary** — both builds
+were confirmed `rc=0` before being copied to their pinned paths.
+
+---
+
+## 1. Frame — 27, confirmed by two agreeing instruments
+
+The frame is the superset of ontologies authoring a conjunctive `ObjectPropertyDomain`/`Range`
+filler. Two instruments were run and **agree exactly at 27**, matching the list carried into this
+task:
+
+* same-line `grep -lE 'ObjectProperty(Domain|Range)\([^)]*ObjectIntersectionOf'` → 27
+* a whitespace-insensitive Python scan (`\s*` between tokens, `re.S`), which guards against a
+  multi-line axiom the same-line grep would miss → the identical 27
+
+This corrects the ≤14 still recorded in `CLAUDE.md`, whose scan `break`s after the first axiom
+body matching a broad construct regex and so drops any ontology whose *first* Domain/Range axiom
+is non-conjunctive.
+
+### 1a. Shape census — where the fix *can* fire
+
+The fix admits a **fully decomposable** filler. A conjunct that is a complement, union,
+cardinality or `∀` is not decomposable, and the pass correctly declines. Binning the frame's
+conjunctive Domain/Range axioms:
+
+| bin | count | members |
+|---|---:|---|
+| at least one plain (EL-decomposable) conjunction | 13 | `10517 10807 11064 11296 14272 16371 16814 4827 5764 6923 7828 8429 9864` |
+| every filler carries a complement/union | 14 | `10080 10109 10908 11305 11647 12107 12342 12451 15993 16372 4796 5964 714 8094` |
+
+Spot-checked: `11064` is `∃r.C ⊓ D`, `16814` is `A ⊓ B` — genuinely decomposable.
+**`ore_ont_4796` is in the second bin** — all four of its conjunctive Range fillers contain
+`ObjectComplementOf` — so the fix is *structurally incapable* of moving it. That is a
+mechanism-level fact, established independently of the null measurement in §3.
+
+This census **sizes a population; it does not predict an effect.** The gate does that (§2).
+
+---
+
+## 2. Fragment routing — zero movers across all 1,920 (gate, not grep)
+
+Admitting these axioms is supposed to move ontologies onto the pure-EL fast path, changing which
+engine answers. That is the behaviour change the fix ships, so it is measured **by gate**.
+
+`crates/owl-dl-reasoner/examples/fragment_probe.rs` prints `<path>\t<fragment>` from
+parse + convert + `analyze_fragment` only — **no reasoning**. This matters: the `# fragment:`
+banner is written only *after* classification completes, so diffing it costs a full two-arm
+classify and, worse, a DNF yields an empty string, making a both-arm DNF read as "not a mover"
+and a one-sided DNF read as a false mover. The probe terminates on ontologies that stall in the
+engine.
+
+All 1,920 ORE ontologies, both arms, **arm order alternated by index**, 60 s cap:
+
+| transition | count |
+|---|---:|
+| `OutOfFragment → OutOfFragment` | 690 |
+| `Horn → Horn` | 662 |
+| `PureEl → PureEl` | 564 |
+| `UNMEASURED → UNMEASURED` | 4 |
+| **any move** | **0** |
+
+**Zero movers. Zero `OutOfFragment → Horn` anomalies** (the pre-registered forbidden outcome).
+
+**What the 1,920 does and does not bound — read this before quoting it.** `analyze_fragment`
+(`classify.rs:367`) observes `is_pure_el` + `clausify_with_stats` only; it **never observes
+`is_saturator_axiom`**, the Horn-shortcircuit gate that Task 2 (`2fa8d0f`) moved in lockstep.
+So this sweep bounds the `is_el_axiom` gate over 1,920 and the Horn-shortcircuit gate only over
+the 47 ontologies answer-compared in §4.
+
+That is sufficient, and the reason is that **the change is admission-only and requires an `And`
+filler**. The pre-fix predicate was `Atomic | Bot | Top`; the post-fix one is
+`decompose_role_filler(c, …) || Bot`, and `decompose_role_filler` returns `true` for `Atomic`
+and `Top` (`owl-dl-saturation/src/lib.rs:3464,3469`) with every new admission arriving through
+its `And` arm. So no ontology *without* a conjunctive Domain/Range filler can be routed
+differently by **either** gate — which makes the 27-grep a provable superset for both, and all
+27 were answer-compared.
+
+**The 4 UNMEASURED do not weaken this, and the argument is by construction rather than by
+assumption.** They are `ore_ont_10860` (the known `horned-owl` SWRL `BuiltInAtom` grammar gap)
+and `2504 / 4572 / 8445` (the documented conversion-bound DKey set). **None is in the 27-frame**,
+and an ontology with no conjunctive Domain/Range filler cannot be a mover, so they are excluded
+as movers without needing a verdict.
+
+### 2a. Calibration — the gate-only probe agrees with the surface it stands in for
+
+A probe validated only on a synthetic could still misread real pool files. Checked against the
+`# fragment:` banner that `classify` emits, on real ORE ontologies, **3 of 3 agree**:
+
+| ontology | `fragment_probe` | `classify` banner |
+|---|---|---|
+| `ore_ont_714` | `Horn` | `Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)` |
+| `ore_ont_16814` | `OutOfFragment` | `out-of-EL` |
+| `ore_ont_11296` | `OutOfFragment` | `out-of-EL` |
+
+A wholesale harness failure was already excluded by construction (it would have produced 1,920
+`UNMEASURED`, not real fragment values); this closes the narrower gap that the probe might
+*disagree* with the banner on real input.
+
+### 2b. The fix has TWO separable effects, and only one of them is a gate move
+
+`dom_partial.ofn` (`Domain(r, P ⊓ ∃s.S)` — a filler whose conjuncts are decomposable but which
+does not make the ontology pure-EL) separates them:
+
+| probe | BEFORE fragment | AFTER fragment | BEFORE rows | AFTER rows |
+|---|---|---|---|---|
+| `dom_conj.ofn` | `Horn` | **`PureEl`** | 0 | **2** |
+| `dom_partial.ofn` | `Horn` | `Horn` (**no move**) | 0 | **2** |
+
+So the change is:
+
+1. a **routing** effect — the fragment gate admits the axiom, which moves an ontology onto the
+   pure-EL fast path **only when that axiom was its sole blocker**; and
+2. a **derivation** effect — the saturator decomposes the filler and derives subsumptions
+   **whether or not the gate moves**.
+
+**This is why §2's zero-movers result does not on its own establish inertness, and why §4 is not
+redundant with it.** The gate sweep bounds effect (1); only the two-arm classify sweep can
+observe effect (2). Both are zero on ORE, measured separately.
+
+### Why zero *routing*, mechanistically
+
+26 of the 27 frame members are `OutOfFragment` in **both** arms — they carry other non-EL
+constructs, so admitting one more axiom shape does not lift them. The single `Horn` member,
+`ore_ont_714`, has only complement-bearing fillers, so the pass declines on it. The routing win
+is real (`dom_conj.ofn` moves `Horn → PureEl`) but **no ORE ontology is bottlenecked on this
+axiom shape alone**.
+
+---
+
+## 3. `ore_ont_4796` — the pre-registered expectation is CONTRADICTED, and the fix is not at fault
+
+The pre-registered expectation was that `4796` (DOLCE-Lite) must gain
+`agent ⊑ endurant` and `agent ⊑ particular` (closure 1,224 → 1,226) under the fix, and that a
+flat result means the fix is not working. **It is flat, and the fix is working.**
+
+The 2×2 — both arms × default and `RUSTDL_CLASSIFY_SAME_TIER=1`, closures compared:
+
+| | BEFORE | AFTER | BEFORE vs AFTER |
+|---|---:|---:|---|
+| default | 1,224 | 1,224 | gained 0, lost 0, **triple identical** |
+| `SAME_TIER=1` | **1,226** | **1,226** | gained 0, lost 0, **triple identical** |
+
+The within-binary column is what settles it:
+
+| comparison | gained | lost |
+|---|---:|---:|
+| BEFORE default → BEFORE `SAME_TIER=1` | **2** | 0 |
+| AFTER default → AFTER `SAME_TIER=1` | **2** | 0 |
+
+The two gained pairs are exactly `DOLCE-Lite#agent ⊑ endurant` and `⊑ particular` — **in both
+arms**. So the 1,224 → 1,226 gain is caused **entirely by `RUSTDL_CLASSIFY_SAME_TIER=1`, which
+is default OFF, and is present in the pre-fix binary**. The Task-3 measurement compared
+default-vs-`SAME_TIER` within one binary and attributed the difference to the fix; the
+discriminator is BEFORE vs AFTER **under the same flag**, and under either flag it is zero.
+
+Three independent facts agree that this is attribution, not breakage:
+
+1. All four of `4796`'s conjunctive Range fillers contain `ObjectComplementOf`, so the pass
+   provably cannot fire on it (§1a).
+2. `4796` is `OutOfFragment` in **both** arms (§2), so it is not routed differently either.
+3. The pins demonstrably discriminate on `dom_conj.ofn` (§0), so the fix is live in the AFTER
+   binary.
+
+The entailments themselves are real and KM-confirmed; they are recovered by the documented
+same-tier limitation being lifted, which is a different open issue from #110.
+
+**This is the corpus-reward claim of #110 being corrected downward to zero, not the fix failing.**
+The value #110 ships is the removal of a silent drop (the D10 shape — BEFORE returns ∅ with
+`incomplete: false` on `dom_conj`) plus the routing win where the shape is the only blocker,
+which ORE happens never to exhibit.
+
+---
+
+## 4. Two-arm classify sweep — 27 bearing + 20 controls
+
+Sequential, **arm order alternated by index**, 240 s cap, **default per-pair budget**. The frame
+is deliberately *not* run at `--pair-timeout-ms 1000`, which is what makes `10517` and `12451`
+explode. Comparison is the **TRIPLE** (closure pairs, unsatisfiable set, equivalence partition),
+never `direct_subsumptions`, which is the Hasse relation and is restructured rather than extended
+by progress.
+
+### 4a. Bearing frame (27)
+
+**25 IDENTICAL / 0 DIFFER / 2 UNMEASURED / 0 regressed / 0 lost entailments.** The two
+UNMEASURED are `ore_ont_10080` (symmetric DNF) and `ore_ont_10517` (§4b), so **the zero-lost
+result covers 25 measured bearing ontologies, not 26.**
+
+Closures spot-checked against known values: `ore_ont_10908` = 6,001, matching the curated
+oracle. Two members classify every class unsatisfiable in both arms (`11305` 3,660 unsat,
+`16372` 744) — identical across arms.
+
+* **`ore_ont_10080` — UNMEASURED, symmetric.** `rc=124` in both arms at 240 s, matching the
+  pre-registered expectation of a symmetric DNF. Not a regression: no arm completed.
+* **`ore_ont_12451` — measured, no cap escalation needed.** It completed in **both** arms
+  (AFTER 157 s, BEFORE 234 s) and is triple-identical at 27,230 closure pairs. The
+  "needs ≥900 s / one-sided timeout is a candidate not a loss" warning did not bind at the
+  default budget.
+* **`ore_ont_10517` — UNMEASURED (§4b).** The raw comparison shows a difference, but both arms
+  truncate, so the run does not measure the arms; it is booked UNMEASURED, not DIFFER.
+
+### 4b. `ore_ont_10517` — UNMEASURED, demonstrated rather than asserted
+
+Both arms complete (~98 s) but **both report `incomplete: true`**, which is exactly the
+pre-registered candidate condition. The raw cross-arm comparison reads 45 gained / 70 lost.
+
+The decisive control is not the arms but the **binary against itself** — three interleaved
+repeats per arm on an idle host:
+
+| run | BEFORE closure | AFTER closure |
+|---|---:|---:|
+| r1 | 8,836 | 8,829 |
+| r2 | 8,867 | 8,853 |
+| r3 | **8,504** | 8,850 |
+
+`BEFORE.r1` vs `BEFORE.r3` — **one unchanged binary, same input** — differs by **364 lost / 32
+gained**, five times the 70/45 seen between arms. The cross-arm difference is budget truncation,
+not a fix effect. Recorded **UNMEASURED, symmetrically**.
+
+**Stated precisely:** this bounds *attribution*, not existence — it shows the arm difference
+cannot be attributed to the fix, not that no difference exists. An earlier draft said "its
+apparent losses are not real", which overshoots the evidence.
+
+**Three runs were necessary, not two.** r1 vs r2 shows only 29 lost — had the control stopped
+there it would have read as "self-consistent" and the arm difference would have looked real.
+That is the recorded two-runs-cannot-establish-stability trap, reproduced.
+
+### 4c. Controls (20)
+
+Twenty ontologies with **zero** conjunctive Domain/Range (verified: the count is 0 for all 20),
+none in the frame, and — following review — all selected to be `Horn` or `OutOfFragment` in the
+**BEFORE** arm. Selection is a fixed deterministic stride (`awk 'NR%53==7'`, first 20) over that
+population in name order, so it is reproducible and was not chosen after seeing results. That selection is load-bearing: an ontology already `PureEl` in BEFORE cannot
+exhibit a spurious move, so it would be an unobservable control.
+
+**20 IDENTICAL / 0 DIFFER / 0 UNMEASURED**, including large closures (`ore_ont_10073` 305,078
+pairs, `5253` 65,805, `13233` 25,684).
+
+### 4d. Wall
+
+**No wall claim is made for this change.** The sweep is one run per arm and was sized to answer
+an answer-identity question, not a timing one, so it cannot support a performance figure in
+either direction. For completeness: frame completed runs excluding `12451` read BEFORE 253 s /
+AFTER 258 s and controls BEFORE 36 s / AFTER 40 s, while `12451` alone reads 234 s vs 157 s —
+a spread that at one run per arm is run-to-run variance on a heavy ontology. Quote none of
+these as a result.
+
+---
+
+## 5. FP=0 net — inertness, not correctness
+
+`./scripts/run-soundness-diff.sh`, rc=0: **11 VERIFIED, every closure exact, FP=0 / MISSED=0**
+— galen 27,997, notgalen 32,739, sio 8,904, wine 653, ore-10908 6,001, pizza 499, alehif 247,
+ro 158, ore-15672 142, sulo 51, bibtex 16.
+
+Two notes:
+
+* **galen reads 27,997 here, not the 28,007 the brief expected.** The gate is *exact match
+  against the committed oracle*, and that oracle reads 27,997 in this checkout — so the gate is
+  green either way. The 28,007 in `CLAUDE.md` is a **different oracle instance**; the committed
+  `ontologies/external/galen-classified.owx` here is dated 2026-06-15. **Vintage unresolved** —
+  an earlier draft of this document asserted the CLAUDE.md oracle was six weeks *newer*, which
+  is the reverse of what CLAUDE.md itself says, and nothing in this task establishes either
+  direction. Not a reasoner difference, and it changes no #110 verdict.
+* The 3 `NOT VERIFIED` rows (`ro-stripped`, `sulo-stripped`, `sio-stripped`) are the
+  long-documented absent fixtures, unrelated to #110.
+
+**Record this as INERTNESS.** Corpus reach for this shape is now *measured* zero (§2, §4), so a
+green net here demonstrates non-regression only. The correctness evidence is Task 3's four-way
+oracle adjudication (rustdl / Konclude / HermiT / KM equal on 6 of 6) plus its sabotage battery.
+
+---
+
+## 6. DKey discriminators unmoved
+
+| ontology | BEFORE `concept_rules` | AFTER `concept_rules` |
+|---|---:|---:|
+| `ore_ont_9347` | 113 | 113 |
+| `ore_ont_5368` | 18,620,251 | 18,620,251 |
+
+**Both** were run, not just `9347`. `9347` alone cannot discriminate DKey work — it reads 113
+under the real gate *and* under a build emitting no DKey disjointness at all — so `5368` is the
+one that carries the check.
+
+---
+
+## 7. Gates
+
+| gate | result |
+|---|---|
+| pin verification (behavioural, both binaries + both probes) | PASS |
+| FP=0 net | rc=0, 11 VERIFIED, closures exact |
+| fragment routing (effect 1), 1,920 × 2 arms | 0 movers, 0 anomalies |
+| classify answers (effect 2), 27 bearing + 20 controls | 45 IDENTICAL / 0 DIFFER / 2 UNMEASURED / 0 regressed |
+| gate-only probe calibrated vs `classify` banner | 3/3 agree on real pool files |
+| lost entailments on the transitive closure | **0**, over 25 measured bearing + 20 controls |
+| `ok → dnf` | **0** |
+| DKey discriminators | unmoved (both) |
+| `cargo clippy --workspace --all-targets --all-features -D warnings` | clean |
+| `cargo fmt --all -- --check` | clean |
+
+---
+
+## 8. Method notes worth keeping
+
+1. **The closure comparator is a per-node BFS with equivalence groups expanded, and it was
+   self-tested before use.** Equivalence groups are cycles; a memoised `anc(x)` under a
+   cycle-detection stack returns wrong answers on a cycle, which has already produced one
+   fabricated "3 lost entailments" finding in this project. Two self-tests were run against
+   hand-computed values: a 3-cycle `A→B→C→A` plus `C→D` (closure 9, +4 on adding `D→E`), and an
+   equivalence group `{P,Q}` expanding to a 2-cycle (closure 4 → 1, lost 3).
+2. **The comparator's first version printed nothing** — `main()` was never called. It was caught
+   only because the self-test was run before any real data. A silent instrument reads exactly
+   like a clean result.
+3. **A harness bug nearly swallowed the only DIFFER.** The summary loop parsed the comparator's
+   stdout as a single JSON object; when gained/lost rows were appended, `json.load` raised
+   `Extra data` — so the *one* interesting row in 27 surfaced as a traceback. A parse failure in
+   a summary loop must be treated as a finding, not skipped.
+4. **Compare BEFORE vs AFTER under the same flag.** §3 is an entire pre-registered expectation
+   overturned by a comparison that crossed a flag boundary.
+5. **A shape census sizes a population; only the gate predicts an effect.** §1a bins 13
+   ontologies where the pass *can* fire; the gate then shows it changes nothing on any of them.
+6. **Do not wrap runs in `/usr/bin/time`** — it has been observed on this host to hang for hours
+   at 0% CPU after `timeout` kills its child. Walls here are `date +%s` deltas.
+7. **Threat to validity, stated:** the frame classify sweep and the corpus fragment sweep
+   overlapped in time on this 32-core host. The fragment probe is single-threaded, so contention
+   was ~1 core, far from the 6-way parallelism that has manufactured spurious `ok → dnf` here
+   before — and every flagged result (`10517`) was re-adjudicated sequentially on an idle host.
+   The FP=0 net, the DKey discriminators and the `10517` control were all run with nothing else
+   in flight.
+8. **Separate a change's effects before choosing an instrument.** A gate sweep and an answer
+   sweep look redundant here and are not: `dom_partial.ofn` shows the derivation effect firing
+   with the gate *unmoved* (§2b). Had only the gate sweep been run, "0 movers" would have read as
+   "inert" while leaving the larger half of the change unmeasured.

--- a/docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md
+++ b/docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md
@@ -349,6 +349,18 @@ one that carries the check.
    fabricated "3 lost entailments" finding in this project. Two self-tests were run against
    hand-computed values: a 3-cycle `A→B→C→A` plus `C→D` (closure 9, +4 on adding `D→E`), and an
    equivalence group `{P,Q}` expanding to a 2-cycle (closure 4 → 1, lost 3).
+   **The comparator itself was scratchpad-only when this document was first written, which made
+   the method claim unverifiable from the repo record; it is now committed as
+   `scripts/closure-diff.py`** (taking two `classify --json` files, expanding
+   `equivalent_groups` into real graph edges, and running a fresh unmemoised per-node BFS for
+   each closure query — never sharing state across nodes, which is exactly what the
+   `ore_ont_778` memoisation bug got wrong). `python3 scripts/closure-diff.py --self-test`
+   reproduces both hand-computed values above and additionally runs a deliberately-wrong
+   globally-memoised DFS on the equivalence-cycle fixture side by side with the correct
+   algorithm, asserting the two disagree — a direct demonstration, not just an assertion, that
+   sharing memoisation across nodes on a cycle is wrong. This is the committed counterpart to
+   `crates/owl-dl-reasoner/examples/fragment_probe.rs`, which is the instrument for this sweep's
+   other half (§2).
 2. **The comparator's first version printed nothing** — `main()` was never called. It was caught
    only because the self-test was run before any real data. A silent instrument reads exactly
    like a clean result.

--- a/scripts/closure-diff.py
+++ b/scripts/closure-diff.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Transitive-closure diff between two `rustdl classify --json` outputs.
+
+Why this exists (see #110 fix-wave review, Finding 4): the corpus sweep's
+headline "0 lost entailments" (docs/benchmarks/2026-09-06-conjunctive-filler-sweep.md
+§8) was produced by a comparator that lived only in a scratchpad, so the method
+claim was unverifiable from the repo record. This is that comparator, committed,
+alongside the instrument for the sweep's other half
+(`crates/owl-dl-reasoner/examples/fragment_probe.rs`).
+
+`direct_subsumptions` in `classify --json` is the Hasse (direct-parent)
+relation, not the full closure — see CLAUDE.md's "direct-vs-closure trap"
+(docs/2026-08-XX and MEMORY.md `direct-vs-closure-trap.md`): reasoning progress
+RESTRUCTURES that relation (proving a class unsat elides its rows; proving two
+classes equivalent collapses them), it does not just extend it. So the only
+valid comparison is over the full transitive closure, and `equivalent_groups`
+must be expanded into real graph edges before computing it — an equivalence
+group is a CYCLE (every member subsumes every other), and this project has
+already shipped one false "3 lost entailments" finding on `ore_ont_778` from a
+comparator that memoised an `ancestors(x)` result under a cycle-detection
+stack: on a cycle, that memoisation returns a WRONG (too-small) answer for
+whichever node is visited first, and then silently reuses that wrong answer
+for every later node that shares part of the cycle.
+
+The fix here is structural, not a patched special case: every closure query is
+a FRESH, unmemoised BFS from that one node. Nothing computed for node A is ever
+reused when computing node B's closure, so there is no stale partial result to
+leak across a cycle. `--self-test` demonstrates this directly by also running
+the WRONG (memoised, cycle-detecting) algorithm on the same fixture and
+asserting the two disagree — i.e. it does not merely assert this script's
+answer is self-consistent, it shows the naive alternative is measurably wrong
+on exactly the input shape (a cycle) this script exists to get right.
+
+Usage:
+    python3 scripts/closure-diff.py before.json after.json
+    python3 scripts/closure-diff.py --self-test
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import sys
+from typing import Dict, Iterable, List, Set, Tuple
+
+Graph = Dict[str, Set[str]]
+Pair = Tuple[str, str]
+
+
+# ---------------------------------------------------------------------------
+# Graph construction
+# ---------------------------------------------------------------------------
+
+
+def build_graph(data: dict) -> Tuple[Graph, Set[str]]:
+    """Build a directed subsumption graph from one `classify --json` payload.
+
+    Edge `x -> y` means "x is (directly or, after expansion, transitively via
+    an equivalence cycle) known to be subsumed by y". Two sources of edges:
+
+    * `direct_subsumptions`: the Hasse relation, `[sub, sup]` pairs — direct
+      edge `sub -> sup`.
+    * `equivalent_groups`: each group is expanded into a full cycle (every
+      ordered pair within the group gets an edge both ways), because
+      `EquivalentClasses(A, B, C)` means each of A, B, C subsumes the other
+      two. This is the expansion step the docstring above calls load-bearing:
+      skipping it, or approximating a group as "connected but not a clique",
+      under-counts exactly the way the historical `ore_ont_778` bug did.
+    """
+    adj: Graph = collections.defaultdict(set)
+    nodes: Set[str] = set()
+
+    for pair in data.get("direct_subsumptions", []):
+        sub, sup = pair[0], pair[1]
+        adj[sub].add(sup)
+        nodes.add(sub)
+        nodes.add(sup)
+
+    for group in data.get("equivalent_groups", []):
+        members = list(group)
+        for a in members:
+            nodes.add(a)
+        for a in members:
+            for b in members:
+                if a != b:
+                    adj[a].add(b)
+
+    for cls in data.get("unsatisfiable", []):
+        nodes.add(cls)
+
+    return adj, nodes
+
+
+# ---------------------------------------------------------------------------
+# Closure computation — fresh per-node BFS, NO shared memoisation
+# ---------------------------------------------------------------------------
+
+
+def bfs_closure(start: str, adj: Graph) -> Set[str]:
+    """Every node reachable from `start` via `adj`, excluding `start` itself.
+
+    Deliberately allocates a fresh `visited` set on every call and shares no
+    state with any other call. This is what makes it correct on a cycle: a
+    node partway through a cycle is simply visited again and skipped (it is
+    already in *this* call's `visited`), never short-circuited by a result
+    computed for a different starting node.
+    """
+    visited: Set[str] = set()
+    queue = collections.deque(adj.get(start, ()))
+    while queue:
+        n = queue.popleft()
+        if n == start or n in visited:
+            continue
+        visited.add(n)
+        queue.extend(adj.get(n, ()))
+    return visited
+
+
+def closure_pairs(adj: Graph, nodes: Iterable[str]) -> Set[Pair]:
+    """All entailed `(x, y)` pairs, `x != y`, over the whole graph."""
+    pairs: Set[Pair] = set()
+    for x in nodes:
+        for y in bfs_closure(x, adj):
+            pairs.add((x, y))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# The WRONG algorithm, kept only so --self-test can show it disagrees.
+# ---------------------------------------------------------------------------
+
+
+def _buggy_memoized_ancestors(
+    node: str, adj: Graph, memo: Dict[str, Set[str]], stack: Set[str]
+) -> Set[str]:
+    """Deliberately WRONG: a DFS that memoises per-node results GLOBALLY
+    (across different starting nodes) and treats hitting a node already on
+    the current recursion stack as "a cycle, nothing more to add here".
+
+    This reproduces the historical `ore_ont_778` defect: the first node
+    processed inside a cycle gets a memoised result computed WHILE its
+    cycle-mates were still open (so it silently misses whatever those
+    cycle-mates would have contributed), and every later query for a node
+    inside that cycle reuses the stale, too-small memoised value instead of
+    recomputing. `--self-test` calls this ONLY to demonstrate the disagreement
+    — nothing in the real comparator (`closure_pairs`/`bfs_closure` above)
+    shares memoisation across nodes.
+    """
+    if node in memo:
+        return memo[node]
+    if node in stack:
+        return set()
+    stack.add(node)
+    result: Set[str] = set()
+    for succ in adj.get(node, ()):
+        result.add(succ)
+        result |= _buggy_memoized_ancestors(succ, adj, memo, stack)
+    stack.discard(node)
+    memo[node] = result
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def load_closure_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def diff(before: dict, after: dict) -> int:
+    before_adj, before_nodes = build_graph(before)
+    after_adj, after_nodes = build_graph(after)
+
+    before_pairs = closure_pairs(before_adj, before_nodes)
+    after_pairs = closure_pairs(after_adj, after_nodes)
+
+    gained = sorted(after_pairs - before_pairs)
+    lost = sorted(before_pairs - after_pairs)
+
+    print(f"before closure: {len(before_pairs)} pairs "
+          f"({len(before.get('unsatisfiable', []))} unsatisfiable, "
+          f"{len(before.get('equivalent_groups', []))} equivalent groups)")
+    print(f"after  closure: {len(after_pairs)} pairs "
+          f"({len(after.get('unsatisfiable', []))} unsatisfiable, "
+          f"{len(after.get('equivalent_groups', []))} equivalent groups)")
+    print(f"gained: {len(gained)}")
+    print(f"lost:   {len(lost)}")
+
+    max_show = 50
+    if gained:
+        print("\n-- gained pairs (sub, sup) --")
+        for sub, sup in gained[:max_show]:
+            print(f"  + {sub}  ⊑  {sup}")
+        if len(gained) > max_show:
+            print(f"  ... ({len(gained) - max_show} more)")
+    if lost:
+        print("\n-- lost pairs (sub, sup) --")
+        for sub, sup in lost[:max_show]:
+            print(f"  - {sub}  ⊑  {sup}")
+        if len(lost) > max_show:
+            print(f"  ... ({len(lost) - max_show} more)")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+
+
+def _self_test() -> int:
+    ok = True
+
+    # --- Test 1: a directed 3-cycle plus a tail, then extending the tail. ---
+    # A -> B -> C -> A (a genuine cycle, e.g. what an equivalent_groups
+    # expansion of {A,B,C} would produce), plus C -> D.
+    #
+    # Hand-computed (excluding self):
+    #   closure(A) = {B, C, D}  (A->B->C->A revisits A, excluded; C->D)  = 3
+    #   closure(B) = {C, A, D}                                          = 3
+    #   closure(C) = {A, B, D}                                          = 3
+    #   closure(D) = {}                                                  = 0
+    #   total = 9
+    before1 = {
+        "unsatisfiable": [],
+        "equivalent_groups": [],
+        "direct_subsumptions": [["A", "B"], ["B", "C"], ["C", "A"], ["C", "D"]],
+    }
+    adj1, nodes1 = build_graph(before1)
+    pairs1 = closure_pairs(adj1, nodes1)
+    if len(pairs1) != 9:
+        print(f"SELF-TEST FAIL: 3-cycle+tail closure = {len(pairs1)}, expected 9")
+        ok = False
+    else:
+        print("SELF-TEST PASS: 3-cycle (A->B->C->A) + C->D closure = 9")
+
+    # Extend the tail: D -> E. Every node that already reached D now also
+    # reaches E (+1 each for A, B, C, D), and E reaches nothing new.
+    #   closure(A..C) each +1 = 4 each (3 nodes -> +3)
+    #   closure(D) = {E} = 1 (+1)
+    #   closure(E) = {} = 0
+    #   total = 13, gained = 4, lost = 0
+    after1 = {
+        "unsatisfiable": [],
+        "equivalent_groups": [],
+        "direct_subsumptions": [
+            ["A", "B"], ["B", "C"], ["C", "A"], ["C", "D"], ["D", "E"],
+        ],
+    }
+    adj1b, nodes1b = build_graph(after1)
+    pairs1b = closure_pairs(adj1b, nodes1b)
+    gained1 = pairs1b - pairs1
+    lost1 = pairs1 - pairs1b
+    if len(pairs1b) != 13 or len(gained1) != 4 or len(lost1) != 0:
+        print(
+            f"SELF-TEST FAIL: after adding D->E, closure={len(pairs1b)} "
+            f"(expected 13), gained={len(gained1)} (expected 4), "
+            f"lost={len(lost1)} (expected 0)"
+        )
+        ok = False
+    else:
+        print("SELF-TEST PASS: adding D->E: closure 9 -> 13, gained 4, lost 0")
+
+    # --- Test 2: an equivalence group is a cycle, and only a FRESH per-node
+    # BFS gets every member's closure right; a globally-memoised DFS with a
+    # cycle-detection stack gets it wrong. ---
+    #
+    # equivalent_groups=[["P", "Q"]] plus P ⊑ X ⊑ Y.
+    # Expanded graph: P->Q, Q->P, P->X, X->Y.
+    #
+    # Hand-computed correct closure (excluding self):
+    #   closure(P) = {Q, X, Y} = 3
+    #   closure(Q) = {P, X, Y} = 3   <- Q inherits X, Y ONLY via the cycle
+    #   closure(X) = {Y}       = 1
+    #   closure(Y) = {}        = 0
+    #   total = 7
+    equiv_fixture = {
+        "unsatisfiable": [],
+        "equivalent_groups": [["P", "Q"]],
+        "direct_subsumptions": [["P", "X"], ["X", "Y"]],
+    }
+    adj2, nodes2 = build_graph(equiv_fixture)
+    pairs2 = closure_pairs(adj2, nodes2)
+    if len(pairs2) != 7:
+        print(f"SELF-TEST FAIL: equivalence-cycle closure = {len(pairs2)}, expected 7")
+        ok = False
+    else:
+        print("SELF-TEST PASS: equivalence group {P,Q} + P⊑X⊑Y closure = 7")
+
+    q_closure = bfs_closure("Q", adj2)
+    if q_closure != {"P", "X", "Y"}:
+        print(f"SELF-TEST FAIL: closure(Q) = {q_closure}, expected {{P, X, Y}}")
+        ok = False
+    else:
+        print("SELF-TEST PASS: closure(Q) = {P, X, Y} (inherited via the cycle)")
+
+    # Now run the deliberately-WRONG globally-memoised DFS over the SAME
+    # graph, in node order P, Q, X, Y, and show it disagrees with the correct
+    # per-node closure — specifically that it UNDER-counts Q, because Q's
+    # true ancestors were computed while P's DFS frame (part of the same
+    # cycle) was still open on the stack.
+    memo: Dict[str, Set[str]] = {}
+    buggy = {n: _buggy_memoized_ancestors(n, adj2, memo, set()) for n in ["P", "Q", "X", "Y"]}
+    buggy_total = sum(len(v) for v in buggy.values())
+    correct_per_node = {n: len(bfs_closure(n, adj2)) for n in ["P", "Q", "X", "Y"]}
+    if buggy_total == sum(correct_per_node.values()) and buggy["Q"] == {"P", "X", "Y"}:
+        print(
+            "SELF-TEST FAIL: the buggy memoised algorithm was expected to "
+            "disagree with the correct one on this cycle, but it did not — "
+            "the demonstration fixture no longer exercises the bug"
+        )
+        ok = False
+    else:
+        print(
+            f"SELF-TEST PASS: buggy globally-memoised DFS disagrees with the "
+            f"correct per-node BFS on the equivalence cycle "
+            f"(buggy closure(Q)={sorted(buggy['Q'])}, "
+            f"correct closure(Q)={sorted(bfs_closure('Q', adj2))}) — "
+            f"this is why closure_pairs() never shares state across nodes"
+        )
+
+    if ok:
+        print("\nself-test: ALL PASS")
+        return 0
+    print("\nself-test: FAILURES ABOVE")
+    return 1
+
+
+def main(argv: List[str]) -> int:
+    if "--self-test" in argv:
+        return _self_test()
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    before = load_closure_json(argv[1])
+    after = load_closure_json(argv[2])
+    return diff(before, after)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #110.

## The defect

`ObjectPropertyDomain(r, P ⊓ Q)` — and the `Range` equivalent — was **silently dropped** by the EL saturator. `collect_el_rules`' arms handled `Bot` and `Atomic` and fell through on `And`, so `classify` returned zero rows with `"incomplete": false` and `"dropped": {}` under a banner certifying the fragment complete. Konclude, HermiT and Kobayashi-MaRust all derive the entailments; rustdl's own `subclass` proves them. That is the D10 shape: **a gate certifies COMPLETE while the engine drops the axiom.**

Prior art, credited: commit `2341ff8` (2026-07-29) identified this as "Bug B" and shipped an interim mitigation — tighten the gates so the axiom is *refused*, routing the ontology to the hybrid path. That moved the miss rather than closing it: its test passes only via `classify_n2`, while the default `classify()` a user gets still returned nothing.

## The fix

`Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)` is a **logical identity**, so this decomposes rather than approximates. It **reverses** the July mitigation instead of extending it: the ontology becomes genuinely fast-path-safe rather than routed away from a path that could not handle it.

**One shared function, and that is the design.** `pub fn owl_dl_saturation::decompose_role_filler(c, pool, sink) -> bool` pushes each atomic conjunct and reports whether the filler decomposed *completely*. The engine consumes the entries; **both** fragment gates consume the boolean. Gate/engine drift is the mechanism that generates this bug class, and a shared call site makes it unconstructible — the same reasoning that factored out `abox_saturation_inconsistent`.

**Partial decomposition is sound; partial ADMISSION is not.** `Domain(r, P ⊓ ∃s.C)` pushes `P` in the engine (a weaker domain is the safe direction) but is **refused** by both gates — admitting an axiom carrying a conjunct the engine never processed would be a fresh D10 created by the fix for one. A negative canary pins it.

**Why this is safe, and it is not merely "the gate reads the engine's boolean".** `role_domains`/`role_ranges` were **already multi-valued before this change** — `atomic_operands_on_right` pushes multiple heads, and two `Domain` axioms on one role always could — and every consumer iterates the whole `Vec`. Decomposition therefore produces an engine state that was already reachable and already handled.

Also fixed: both **provenance mirrors**, which were `Atomic`-only. Their divergence does not merely empty `axiom_refs` — `mini_effective` drives per-axiom rule-slot delta cursors, so a drift there mis-attributes proofs to the **wrong axiom**.

## Evidence

**Oracles 6/6.** Post-fix rustdl == Konclude == HermiT == KM on named non-`Thing` pair sets across all six probes. Pre-fix returned ∅ with `incomplete: false` on three of them while certifying `Horn`. Konclude judged by content (2414–2537 bytes, never the ~896-byte stub); its silence on the disjunctive probe licensed *affirmatively* via a positive control.

**Sabotage: 6 run, 5 caught, 1 SURVIVED.** The survivor is "the gate re-implements the decomposition locally" — the canaries pin *behaviour*, not the *no-drift property*, which rests on the shared call site alone. Reported, not rounded up. (It is also extensionally undetectable: `ConceptPool::and` flattens nested `And`, drops `Top` and annihilates on `Bot`, so a local `all(matches!(Atomic))` agrees on every interner-constructible input. The risk is future drift, not present incorrectness.)

**Corpus: 45 IDENTICAL / 0 DIFFER / 2 UNMEASURED / 0 regressed / 0 lost entailments** over 25 measured bearing ontologies + 20 controls, triple-compared on the transitive closure. **Zero fragment-routing movers across all 1,920**, measured by gate.

**Corpus reward is measured ZERO.** This is a correctness fix. The FP=0 net's green here is **inertness, not confirmation** — the evidence is the oracle adjudication and the canaries.

> That figure went through three revisions, recorded in `CLAUDE.md` because this project treats design-record drift as a recurring failure: *zero* (right, but over a frame of 14) → *non-zero* (**wrong**: it compared `SAME_TIER=0` vs `=1` within one binary, measuring the flag rather than the fix) → *zero*, measured properly with two pinned binaries. The lesson was already in the file from the label-cache work: **measuring a flag's effect and measuring the ship delta are different questions.**

Frame corrected too: the grep superset is **27**, not the ≤14 previously recorded — the old scan's `break` fired after the first axiom body matching a broad regex.

## Gates

`cargo test --workspace --exclude owl-dl-py` **1960 passed / 0 failed / 85 ignored**; fmt clean; clippy `--workspace --all-targets --all-features -D warnings` clean; doctests clean. `owl-dl-py` excluded: it fails to **link** on undefined CPython symbols on this host — environmental, and this change touches no Python surface.

Commits are **bisect-safe**: the engine fix lands before the gate move, and the intermediate state errs safe (engine derives more, gate still refuses → hybrid).

## Merge note

This branch and `docs/verify-el-horn-widening-no-go` (PR #111) both touch `CLAUDE.md` and `crates/owl-dl-verify/tests/horn_widening_market.rs`. The CLAUDE.md entry here is **deliberately anchored at the sibling's insertion point so the merge conflicts rather than silently interleaving** — PR #111 carries a `#110`-is-unfixed paragraph and a `≤14` frame that this branch falsifies.

**Resolve in favour of this branch**, verified rather than assumed: `a2b64eb` and this HEAD differ on that test file only in the third test being retargeted, so nothing is dropped.

## New infrastructure

`scripts/closure-diff.py` — the transitive-closure comparator behind the "0 lost entailments" result, committed so the claim is reproducible. Fresh per-node BFS, equivalence groups expanded as cliques, no shared memoisation, with a `--self-test` that demonstrates a buggy memoised DFS **disagreeing** with it (`closure(Q)`: buggy `{P}` vs correct `{P,X,Y}`). This repo has already produced a false "3 lost entailments" finding from a memoised comparator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzVE2TSVVMc3n8Wrce65Jg
