### PR TITLE
fix(saturation): partial Domain/Range filler decomposition + provenance mirrors (#118, #119)

### DIFF
--- a/crates/owl-dl-cli/tests/fixtures/json/prove_conjunctive_domain.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/prove_conjunctive_domain.ofn
@@ -1,0 +1,10 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+Declaration(Class(:P))
+Declaration(Class(:Q))
+Declaration(Class(:X))
+Declaration(Class(:B))
+Declaration(ObjectProperty(:r))
+SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q))
+)

--- a/crates/owl-dl-cli/tests/fixtures/json/prove_conjunctive_range.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/prove_conjunctive_range.ofn
@@ -1,0 +1,12 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+Declaration(Class(:P))
+Declaration(Class(:Q))
+Declaration(Class(:X))
+Declaration(Class(:B))
+Declaration(Class(:D))
+Declaration(ObjectProperty(:r))
+SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))
+SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)
+)

--- a/crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs
+++ b/crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs
@@ -1,0 +1,181 @@
+//! #118 — `prove` must attribute a conjunctive `ObjectPropertyDomain` /
+//! `ObjectPropertyRange`-derived subsumption to its axiom.
+//!
+//! `collect_el_rules_with_provenance` (owl-dl-saturation) carries two mirrors of
+//! the real Pass 1 domain/range lowering, used purely to attribute derived rule
+//! slots to their source axiom: the `domain_axiom_refs` collector, and a mini
+//! Pass-1 simulation that rebuilds `effective_ranges`/`chain_ranges` so the
+//! per-axiom rule-slot delta cursors in the mini re-run of `lower_sub_class_of`
+//! stay aligned with the real run. Before this fix, both mirrors accepted only
+//! an `Atomic` filler, so a conjunctive one (`ObjectIntersectionOf(:P :Q)`) was
+//! invisible to them even though the real Pass 1 (#110/#119) now decomposes it:
+//! `prove` on a conjunctive-domain pair produced the right ANSWER with NO axiom
+//! reference (`(Domain(sub)) ⊢ X SubClassOf P` with no `[axiom[i]]`), and on a
+//! conjunctive-range pair the cursor misalignment misattributed (or dropped)
+//! provenance for every axiom processed after the affected one.
+//!
+//! These two canaries are deliberately SEPARATE — a single domain fixture
+//! leaves the range mirror unguarded, which is how this gap survived once
+//! already (see the domain-only fix in #110/PR #112).
+
+#![allow(clippy::unwrap_used)]
+
+use std::process::Command;
+
+fn rustdl() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rustdl"))
+}
+
+fn prove_conjunctive_domain() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/prove_conjunctive_domain.ofn"
+    )
+}
+
+fn prove_conjunctive_range() -> &'static str {
+    concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/prove_conjunctive_range.ofn"
+    )
+}
+
+/// Recursively collect `(rule, conclusion, axioms[])` from every node of a
+/// `prove --json` proof tree.
+fn collect_nodes<'a>(node: &'a serde_json::Value, out: &mut Vec<(&'a str, &'a str, Vec<&'a str>)>) {
+    let rule = node["rule"].as_str().unwrap();
+    let conclusion = node["conclusion"].as_str().unwrap();
+    let axioms: Vec<&str> = node["axioms"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a.as_str().unwrap())
+        .collect();
+    out.push((rule, conclusion, axioms));
+    for premise in node["premises"].as_array().unwrap() {
+        collect_nodes(premise, out);
+    }
+}
+
+#[test]
+fn prove_attributes_a_conjunctive_domain_derived_subsumption_to_its_axiom() {
+    // ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q)) + X ⊑ ∃r.B ⟹ X ⊑ P.
+    let out = rustdl()
+        .args([
+            "prove",
+            "--json",
+            prove_conjunctive_domain(),
+            "http://ex/#X",
+            "http://ex/#P",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["entailed"], true);
+    assert_eq!(
+        v["has_proof"], true,
+        "conjunctive domain is EL-fragment; must have a step proof"
+    );
+
+    let mut nodes = Vec::new();
+    collect_nodes(&v["proof"], &mut nodes);
+
+    // The root step must be a Domain derivation citing the ObjectPropertyDomain
+    // axiom — not an empty axiom_refs, which is exactly the #118 bug (the
+    // engine derived the right ANSWER with no provenance).
+    let root_rule = v["proof"]["rule"].as_str().unwrap();
+    assert_eq!(root_rule, "Domain(sub)", "expected a Domain(sub) root step");
+    let root_axioms: Vec<&str> = v["proof"]["axioms"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a.as_str().unwrap())
+        .collect();
+    assert!(
+        !root_axioms.is_empty(),
+        "the conjunctive-domain-derived step must cite its source axiom, got none"
+    );
+    assert!(
+        root_axioms.iter().any(|a| {
+            a.contains("ObjectPropertyDomain") && a.contains(":P") && a.contains(":Q")
+        }),
+        "expected the cited axiom to be ObjectPropertyDomain(:r ObjectIntersectionOf(:P :Q)); \
+         got {root_axioms:?}"
+    );
+    // Sanity: some node in the tree must still be the exists-fact leaf.
+    assert!(
+        nodes
+            .iter()
+            .any(|(rule, _, axioms)| *rule == "ToldFact" && axioms.iter().any(|a| a.contains(":B"))),
+        "expected a ToldFact leaf citing the SubClassOf(:X ObjectSomeValuesFrom(:r :B)) axiom"
+    );
+}
+
+#[test]
+fn prove_attributes_a_conjunctive_range_derived_subsumption_to_its_axiom() {
+    // ObjectPropertyRange(:r ObjectIntersectionOf(:P :Q))
+    // + X ⊑ ∃r.B + ∃r.(B⊓P) ⊑ D  ⟹  X ⊑ D.
+    //
+    // The range mirror's bug does not show up at the ROOT step — that step's
+    // axiom_refs come from `domain_axiom_refs`-independent machinery
+    // (`ConjunctiveTrigger`/`ExistentialTrigger`, which already cite the
+    // consuming axiom correctly either way). It shows up DEEPER: the
+    // conjunctive range folds `Range(r) = P⊓Q` into the Tseitin synthetic
+    // `F ≡ B⊓P⊓Q` that stands in for X's ∃r.B witness, and the mini
+    // provenance simulation must re-derive that SAME synthetic (so its
+    // per-axiom rule-slot cursors for every axiom after the affected one stay
+    // aligned with the real run) to correctly attribute the leaf
+    // `F ⊑ B` / `F ⊑ P` ToldSubsumer steps back to the EXISTS axiom
+    // (`SubClassOf(:X ObjectSomeValuesFrom(:r :B))`). Before the fix these
+    // leaves lost their axiom reference entirely.
+    let out = rustdl()
+        .args([
+            "prove",
+            "--json",
+            prove_conjunctive_range(),
+            "http://ex/#X",
+            "http://ex/#D",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["entailed"], true);
+    assert_eq!(
+        v["has_proof"], true,
+        "conjunctive range is EL-fragment; must have a step proof"
+    );
+
+    let mut nodes = Vec::new();
+    collect_nodes(&v["proof"], &mut nodes);
+
+    // Find the ToldSubsumer leaves for the range-widened synthetic
+    // (ObjectIntersectionOf(:B :P :Q)) and require each to cite the EXISTS
+    // axiom that created the fact the synthetic stands in for.
+    let range_widened_leaves: Vec<&(&str, &str, Vec<&str>)> = nodes
+        .iter()
+        .filter(|(rule, conclusion, _)| {
+            *rule == "ToldSubsumer" && conclusion.contains("ObjectIntersectionOf(:B :P :Q)")
+        })
+        .collect();
+    assert!(
+        !range_widened_leaves.is_empty(),
+        "expected ToldSubsumer leaves for the range-widened synthetic \
+         ObjectIntersectionOf(:B :P :Q); got nodes {nodes:?}"
+    );
+    for (rule, conclusion, axioms) in &range_widened_leaves {
+        assert!(
+            !axioms.is_empty(),
+            "range-widened ToldSubsumer leaf ({rule}) {conclusion} lost its axiom \
+             reference — this is the #118 range-mirror bug"
+        );
+        assert!(
+            axioms.iter().any(|a| {
+                a.contains(":X") && a.contains(":B") && a.contains("ObjectSomeValuesFrom")
+            }),
+            "expected the cited axiom to be SubClassOf(:X ObjectSomeValuesFrom(:r :B)); \
+             got {axioms:?}"
+        );
+    }
+}

--- a/crates/owl-dl-reasoner/tests/conjunctive_domain_range.rs
+++ b/crates/owl-dl-reasoner/tests/conjunctive_domain_range.rs
@@ -14,6 +14,19 @@
 //!
 //! The atomic controls are what show the cause is the CONJUNCTIVE filler rather
 //! than the domain/range mechanism: they derived their pair correctly throughout.
+//!
+//! #119 — a PARTLY-atomic filler must contribute the atomic conjuncts it CAN
+//! represent, not drop whole. `#110` shipped all-or-nothing on purpose (a filler
+//! mixing atomic and non-atomic parts, e.g. `P ⊓ ∃s.Z`, dropped WHOLE); that was
+//! itself the residual bug — `Domain(r, P ⊓ Q)` where `Q` happens to be
+//! non-atomic (`P ⊓ ∃s.Z`) still entails `∃r.⊤ ⊑ P`, a WEAKER (strictly more
+//! permissive) constraint than the full axiom, so contributing `P` alone can
+//! only MISS a subsumption that needs the dropped part, never assert a false
+//! one. Partial DECOMPOSITION is sound; partial ADMISSION to the fragment gate
+//! is not, so the gate (`analyze_fragment`) must keep refusing a partly-atomic
+//! filler even though the engine now derives part of it — pinned below so a
+//! future widening of the gate cannot silently admit an axiom the engine only
+//! partly processed.
 
 #![allow(clippy::unwrap_used)]
 
@@ -22,6 +35,7 @@ use horned_owl::io::ofn::reader::read as read_ofn;
 use horned_owl::model::RcStr;
 use horned_owl::ontology::set::SetOntology;
 use owl_dl_reasoner::classify_top_down_with_timeout;
+use owl_dl_reasoner::{FragmentClassification, analyze_fragment};
 use std::io::Cursor;
 use std::time::Duration;
 
@@ -93,21 +107,58 @@ fn a_nested_conjunction_is_flattened() {
 }
 
 #[test]
-fn a_filler_mixing_atomic_and_non_atomic_parts_still_drops_whole() {
-    // ALL-OR-NOTHING, on purpose. Taking the atomic half would be sound in
-    // isolation (`⊑ P ⊓ Z` entails `⊑ P`) but would put the ENGINE ahead of the
-    // fragment GATE, which decides membership separately — the gate would keep
-    // calling this out-of-fragment while the engine acted on part of it. That is
-    // the D10 shape this fix exists to close, so it must not be re-created here.
+fn a_filler_mixing_atomic_and_non_atomic_parts_contributes_its_atomic_conjuncts() {
+    // #119: PARTIAL decomposition, not all-or-nothing. This FLIPS the pre-#119
+    // assertion (`!holds`) — see [[tests-that-pin-the-bug]]: a fixture chosen to
+    // characterise a defect becomes a bug-pin once the defect closes, and this
+    // one was explicitly flagged for exactly that in #110's own comment ("If a
+    // future change teaches the gate about conjunctive fillers, this becomes the
+    // wrong assertion and should be FLIPPED rather than deleted" — the engine
+    // side changed, not the gate, but the effect on this fixture is the same).
     //
-    // If a future change teaches the gate about conjunctive fillers, this becomes
-    // the wrong assertion and should be FLIPPED rather than deleted.
+    // `Domain(r, P ⊓ ∃s.Z)` means `∃r.⊤ ⊑ P` AND `∃r.⊤ ⊑ ∃s.Z`; contributing only
+    // the atomic `P` conjunct asserts a WEAKER (more permissive) constraint than
+    // the full axiom, so it can only MISS a subsumption that needs the dropped
+    // `∃s.Z` half, never assert a false one — the opposite direction of risk
+    // from a `DataUnionOf` in a `∀`/range position, where keeping half narrows
+    // the range and manufactures a clash.
     let body = format!(
         "{EXISTS}\n\
          ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :Z)))"
     );
     assert!(
-        !holds(&body, "X", "P"),
-        "a mixed filler must drop WHOLE, keeping engine and fragment gate in agreement"
+        holds(&body, "X", "P"),
+        "a partly-atomic filler must contribute the atomic conjuncts it CAN represent (P)"
+    );
+}
+
+#[test]
+fn a_partly_atomic_domain_filler_is_not_admitted_to_the_pure_el_fragment() {
+    // #119's load-bearing constraint: partial DECOMPOSITION in the engine is
+    // sound, but partial ADMISSION to the fragment gate is NOT — a conjunct the
+    // engine never processed, inside a completeness-certified fragment, is
+    // exactly the D10 bug class #110 exists to close. `is_atomic_or_trivial_concept`
+    // (the gate `classify.rs` uses for `ObjectPropertyDomain`/`Range` fillers)
+    // must keep refusing this axiom outright even though the engine now derives
+    // PART of it, so a future widening of the gate cannot silently admit an
+    // axiom the engine only partly processed.
+    let ofn = format!(
+        "Prefix(:=<http://rustdl.test/>)\nOntology(\n\
+         Declaration(Class(:P)) Declaration(Class(:Q)) Declaration(Class(:X))\n\
+         Declaration(Class(:B)) Declaration(Class(:D)) Declaration(Class(:Z))\n\
+         Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))\n\
+         {EXISTS}\n\
+         ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :Z)))\n)\n"
+    );
+    let mut reader = Cursor::new(ofn);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    let internal = owl_dl_core::convert::convert_ontology(&onto).expect("convert");
+    assert_ne!(
+        analyze_fragment(&internal),
+        FragmentClassification::PureEl,
+        "a partly-atomic domain filler must NOT be certified PureEl — the engine only \
+         partly processes it, so the gate must keep routing it to the sound+complete \
+         hybrid path"
     );
 }

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -3147,11 +3147,14 @@ fn collect_el_rules_with_provenance(
                 }
                 disjt_cur += count;
             }
-            Axiom::ObjectPropertyDomain { role, domain } => {
-                if !role.is_inverse()
-                    && let ConceptExpr::Atomic(id) = internal.concepts.get(*domain)
-                {
-                    domain_axiom_refs.push((role.role_id(), *id, ax_idx));
+            // Mirror the real Pass 1 domain arm's decomposition exactly (#118): a
+            // conjunctive filler now contributes each atomic conjunct it decomposes
+            // into (#119, possibly a strict subset), not just a single fully-atomic
+            // filler — one provenance entry per conjunct so `prove` can attribute a
+            // conjunctive-domain-derived subsumption to this axiom.
+            Axiom::ObjectPropertyDomain { role, domain } if !role.is_inverse() => {
+                for id in atomic_conjuncts(&internal.concepts, *domain) {
+                    domain_axiom_refs.push((role.role_id(), id, ax_idx));
                 }
             }
             Axiom::SubObjectPropertyOf {
@@ -3215,16 +3218,23 @@ fn collect_el_rules_with_provenance(
         // up as a wrong or missing proof rather than a wrong answer.
         for ax in &internal.axioms {
             match ax {
-                Axiom::ObjectPropertyRange { role, range }
-                    if !role.is_inverse()
-                        && matches!(internal.concepts.get(*range), ConceptExpr::Atomic(_)) =>
-                {
-                    if let ConceptExpr::Atomic(id) = internal.concepts.get(*range) {
+                Axiom::ObjectPropertyRange { role, range } if !role.is_inverse() => {
+                    // Mirror the real Pass 1 range arm's decomposition exactly
+                    // (#118) — a conjunctive filler contributes each atomic
+                    // conjunct it decomposes into (#119, possibly a strict
+                    // subset), same as `atomic_conjuncts` at the real Pass 1 site.
+                    // This feeds `mini_effective`/`mini_chain_ranges`, which
+                    // `lower_sub_class_of`'s per-axiom rule-slot delta cursors
+                    // below rely on staying byte-for-byte aligned with the real
+                    // Pass 1 — a silent divergence here mis-attributes every
+                    // LATER axiom's proof, not just this one's.
+                    let ids = atomic_conjuncts(&internal.concepts, *range);
+                    if !ids.is_empty() {
                         mini_rules
                             .role_ranges
                             .entry(role.role_id())
                             .or_default()
-                            .push(*id);
+                            .extend(ids);
                     }
                 }
                 Axiom::SubObjectPropertyOf {
@@ -3462,16 +3472,21 @@ fn collect_el_rules(
                     // no individual may be an r-source. Poison the role so that
                     // any class deriving `∃r.X` is marked unsatisfiable.
                     rules.poisoned_roles.insert(role.role_id());
-                } else if let Some(ids) = all_atomic_conjuncts(&internal.concepts, *domain) {
+                } else {
                     // `ObjectPropertyDomain(r, P ⊓ Q)` ≡ `∃r.⊤ ⊑ P ⊓ Q` ≡
                     // `∃r.⊤ ⊑ P` AND `∃r.⊤ ⊑ Q` — a logical identity, so splitting
                     // is sound and completeness-preserving by construction (#110).
-                    // The atomic case is the one-element instance of it.
-                    rules
-                        .role_domains
-                        .entry(role.role_id())
-                        .or_default()
-                        .extend(ids);
+                    // The atomic case is the one-element instance of it. A part
+                    // that isn't atomic (or a conjunction of atomics) contributes
+                    // nothing rather than dropping the whole filler (#119).
+                    let ids = atomic_conjuncts(&internal.concepts, *domain);
+                    if !ids.is_empty() {
+                        rules
+                            .role_domains
+                            .entry(role.role_id())
+                            .or_default()
+                            .extend(ids);
+                    }
                 }
             }
             Axiom::ObjectPropertyRange { role, range } => {
@@ -3482,16 +3497,20 @@ fn collect_el_rules(
                     // r-edge can exist in any model. Poison the role so that any
                     // class deriving `∃r.X` is marked unsatisfiable.
                     rules.poisoned_roles.insert(role.role_id());
-                } else if let Some(ids) = all_atomic_conjuncts(&internal.concepts, *range) {
+                } else {
                     // Same identity on the range side: `Range(r, P ⊓ Q)` ≡
                     // `Range(r, P)` AND `Range(r, Q)`. Measured to have the same
                     // defect as the domain arm — HermiT derives the pair, rustdl
-                    // reported `[]` with `incomplete: false` (#110).
-                    rules
-                        .role_ranges
-                        .entry(role.role_id())
-                        .or_default()
-                        .extend(ids);
+                    // reported `[]` with `incomplete: false` (#110). Same partial
+                    // decomposition as the domain arm applies (#119).
+                    let ids = atomic_conjuncts(&internal.concepts, *range);
+                    if !ids.is_empty() {
+                        rules
+                            .role_ranges
+                            .entry(role.role_id())
+                            .or_default()
+                            .extend(ids);
+                    }
                 }
             }
             Axiom::SubObjectPropertyOf {
@@ -4535,36 +4554,55 @@ fn domain_heads_el(
     .collect()
 }
 
-/// The atomic conjuncts of a domain/range filler, or `None` if any part is not
-/// atomic.
+/// The atomic conjuncts a domain/range filler decomposes into — possibly a
+/// STRICT SUBSET of its conjuncts (#119), possibly empty.
 ///
-/// `C` alone when `C` is atomic; each operand when `C` is an `And` of atomics,
-/// recursively. `ObjectPropertyDomain(r, P ⊓ Q)` is `∃r.⊤ ⊑ P ⊓ Q`, which is
-/// exactly `∃r.⊤ ⊑ P` and `∃r.⊤ ⊑ Q` — a logical identity, hence sound and
-/// completeness-preserving by construction (#110). Before this, only the atomic
-/// case was accepted and a conjunctive filler was silently DROPPED: `classify`
-/// returned zero rows with `incomplete: false` under a banner certifying the
-/// fragment complete, while both peer reasoners derived the pairs and rustdl's own
-/// `subclass` proved them.
+/// `C` alone when `C` is atomic; each operand when `C` is an `And`, recursively
+/// — including operands that are themselves non-atomic, which contribute
+/// nothing rather than aborting the whole walk. `ObjectPropertyDomain(r, P ⊓ Q)`
+/// is `∃r.⊤ ⊑ P ⊓ Q`, which is exactly `∃r.⊤ ⊑ P` and `∃r.⊤ ⊑ Q` — a logical
+/// identity, hence sound and completeness-preserving by construction (#110).
+/// Before #110, only the fully-atomic case was accepted and a conjunctive
+/// filler was silently DROPPED whole: `classify` returned zero rows with
+/// `incomplete: false` under a banner certifying the fragment complete, while
+/// both peer reasoners derived the pairs and rustdl's own `subclass` proved
+/// them.
 ///
-/// ALL-OR-NOTHING on purpose. A filler mixing atomic and non-atomic parts (say
-/// `P ⊓ ∃s.Z`) still drops WHOLE, exactly as before, rather than contributing its
-/// atomic half. Taking the half would be sound in isolation — `⊑ P ⊓ Z` entails
-/// `⊑ P` — but it would put the ENGINE ahead of the fragment GATE, which decides
-/// membership separately: the gate would keep calling the axiom out-of-fragment
-/// while the engine quietly acted on part of it. Keeping the two in agreement is
-/// what avoids re-creating the D10 shape this fix exists to close.
-fn all_atomic_conjuncts(pool: &ConceptPool, c: ConceptId) -> Option<Vec<ClassId>> {
+/// PARTIAL DECOMPOSITION, not all-or-nothing (#119 — #110 shipped all-or-
+/// nothing on purpose, and that was itself the residual bug). A filler mixing
+/// atomic and non-atomic parts (say `P ⊓ ∃s.Z`) now contributes its atomic
+/// conjuncts (`P`) and drops only the part it cannot represent (`∃s.Z`).
+/// `Domain(r, P ⊓ Z)` semantically means `∃r.⊤ ⊑ P` AND `∃r.⊤ ⊑ Z`; asserting
+/// only the first is a WEAKER (more permissive) constraint than the true
+/// axiom, so this can only MISS the `Z`-derived subsumptions, never assert a
+/// false one — the same direction of risk as every other domain/range
+/// completeness fix in this file. Unlike `DataUnionOf` (where keeping half a
+/// union NARROWS a range and manufactures a clash), a domain/range filler
+/// narrows nothing: each conjunct is an independent, separately-true
+/// constraint, so dropping one just drops an independent constraint.
+///
+/// Partial DECOMPOSITION is sound; partial ADMISSION to the fragment gate is
+/// NOT (the D10 shape #110 exists to close) — `is_atomic_or_trivial_concept`
+/// in `owl-dl-reasoner::classify` still refuses any non-atomic filler outright
+/// (a `Bot`/`Top` in a domain/range filler is orthogonal — its own arms of the
+/// `ObjectPropertyDomain`/`Range` match already run first), so a partly-atomic
+/// filler is never certified `PureEl` even though the engine now derives part
+/// of it. Do NOT loosen that gate to match this function.
+fn atomic_conjuncts(pool: &ConceptPool, c: ConceptId) -> Vec<ClassId> {
+    let mut out = Vec::new();
+    collect_atomic_conjuncts(pool, c, &mut out);
+    out
+}
+
+fn collect_atomic_conjuncts(pool: &ConceptPool, c: ConceptId, out: &mut Vec<ClassId>) {
     match pool.get(c) {
-        ConceptExpr::Atomic(id) => Some(vec![*id]),
+        ConceptExpr::Atomic(id) => out.push(*id),
         ConceptExpr::And(ops) => {
-            let mut out = Vec::with_capacity(ops.len());
             for op in ops {
-                out.extend(all_atomic_conjuncts(pool, *op)?);
+                collect_atomic_conjuncts(pool, *op, out);
             }
-            Some(out)
         }
-        _ => None,
+        _ => {}
     }
 }
 

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -4560,9 +4560,11 @@ fn domain_heads_el(
 /// `C` alone when `C` is atomic; each operand when `C` is an `And`, recursively
 /// — including operands that are themselves non-atomic, which contribute
 /// nothing rather than aborting the whole walk. `ObjectPropertyDomain(r, P ⊓ Q)`
-/// is `∃r.⊤ ⊑ P ⊓ Q`, which is exactly `∃r.⊤ ⊑ P` and `∃r.⊤ ⊑ Q` — a logical
-/// identity, hence sound and completeness-preserving by construction (#110).
-/// Before #110, only the fully-atomic case was accepted and a conjunctive
+/// is `∃r.⊤ ⊑ P ⊓ Q`, which is exactly `∃r.⊤ ⊑ P` and `∃r.⊤ ⊑ Q` — for a
+/// FULLY-ATOMIC filler this is a logical identity, hence sound and
+/// completeness-preserving by construction (#110); see the PARTIAL-case
+/// caveat below for a filler that isn't. Before #110, only the fully-atomic
+/// case was accepted and a conjunctive
 /// filler was silently DROPPED whole: `classify` returned zero rows with
 /// `incomplete: false` under a banner certifying the fragment complete, while
 /// both peer reasoners derived the pairs and rustdl's own `subclass` proved

--- a/scripts/closure-diff.py
+++ b/scripts/closure-diff.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""closure-diff.py — transitive-closure comparator for `rustdl classify --json`.
+
+Takes two `classify --json` output files (e.g. a BEFORE and AFTER run) and
+reports:
+  - the size of each side's full transitive-closure subsumption set
+  - which (sub, sup) pairs were GAINED (in AFTER but not BEFORE)
+  - which (sub, sup) pairs were LOST (in BEFORE but not AFTER)
+  - unsatisfiable-class and equivalent-group diffs, as a sanity cross-check
+
+Why this exists (read before trusting any output): `direct_subsumptions` in
+`classify --json` is the Hasse (direct-parent) relation, not the full closure
+-- and reasoning progress RESTRUCTURES it rather than only extending it:
+proving a class unsatisfiable ELIDES its rows, proving classes equivalent
+COLLAPSES them into one node. A naive line-count or set-diff over
+`direct_subsumptions` therefore reads a *correct* improvement as a regression
+just as often as a real one (see CLAUDE.md's "direct-vs-closure trap", hit
+four times in this repo's history). This script computes the actual
+transitive closure so a diff means what it says.
+
+THE BUG THIS SCRIPT IS DESIGNED NOT TO REPRODUCE, stated plainly because it
+already happened once in this repo: `equivalent_groups` are CYCLES (every
+member mutually subsumes every other), and a transitive-closure computation
+that memoises `ancestors(x)` behind a "currently visiting -> return empty"
+cycle guard can cache an INCOMPLETE result for one member of an equivalence
+group while still mid-cycle, and that incomplete memo then poisons every
+later, unrelated query that reuses it -- silently under-counting entailments
+for every group member except the one whose own direct edges happened to
+reach the missing subsumer first. This produced a false "3 lost entailments"
+finding (then "4 lost") on a real ontology in this project's history; a
+correct per-node BFS on the same input gives the true answer, `lost = 0`.
+`--self-test` reproduces the bug mechanism on a small fixture and shows the
+buggy and correct algorithms disagreeing, so this instrument validates
+itself rather than merely asserting it is correct.
+
+The fix, applied throughout this file: every closure query starts a FRESH
+BFS with its own local visited-set. No ancestor set is ever cached and reused
+across different starting nodes -- the only "memoisation" is the adjacency
+list itself (which is exact, not derived), so there is no stale partial
+result to poison a later query.
+
+Usage:
+    python3 scripts/closure-diff.py before.json after.json
+    python3 scripts/closure-diff.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict, FrozenSet, Iterable, List, Set, Tuple
+
+Pair = Tuple[str, str]
+Graph = Dict[str, Set[str]]
+
+OWL_THING = "http://www.w3.org/2002/07/owl#Thing"
+OWL_NOTHING = "http://www.w3.org/2002/07/owl#Nothing"
+
+
+# ---------------------------------------------------------------------------
+# Graph construction
+# ---------------------------------------------------------------------------
+
+
+def build_adjacency(
+    direct_subsumptions: Iterable[Iterable[str]],
+    equivalent_groups: Iterable[Iterable[str]],
+) -> Graph:
+    """Build the direct-edge adjacency (sub -> {sup, ...}).
+
+    `direct_subsumptions` contributes one directed edge per row.
+    `equivalent_groups` each contribute a CLIQUE: every ordered pair (a, b)
+    with a != b in the group gets a bidirectional edge, so the closure
+    correctly threads through the group in both directions and any chain
+    that passes through it. This is the load-bearing requirement the task
+    names explicitly -- a group is not a single representative node, it is
+    every member mutually entailing every other.
+    """
+    adj: Graph = {}
+
+    def add_edge(a: str, b: str) -> None:
+        if a == b:
+            return
+        adj.setdefault(a, set()).add(b)
+        adj.setdefault(b, set())  # ensure b exists as a node even if it has no out-edges
+
+    for row in direct_subsumptions:
+        sub, sup = row[0], row[1]
+        add_edge(sub, sup)
+
+    for group in equivalent_groups:
+        members = list(group)
+        for a in members:
+            for b in members:
+                if a != b:
+                    add_edge(a, b)
+
+    return adj
+
+
+# ---------------------------------------------------------------------------
+# Correct closure: a FRESH per-node BFS, no shared memoisation
+# ---------------------------------------------------------------------------
+
+
+def ancestors_bfs(start: str, adj: Graph) -> Set[str]:
+    """All nodes reachable from `start` via the adjacency, excluding `start`
+    itself. A plain BFS/DFS reachability walk handles cycles correctly by
+    construction: `visited` is local to this call, so a node is expanded
+    exactly once regardless of how many cycles pass through it, and there is
+    no cross-call cache to poison a later, unrelated query.
+    """
+    visited: Set[str] = {start}
+    queue: List[str] = [start]
+    out: Set[str] = set()
+    while queue:
+        node = queue.pop()
+        for nxt in adj.get(node, ()):
+            if nxt not in visited:
+                visited.add(nxt)
+                out.add(nxt)
+                queue.append(nxt)
+    return out
+
+
+def transitive_closure(adj: Graph) -> Set[Pair]:
+    """The full transitive closure as a set of (sub, sup) pairs, sub != sup."""
+    out: Set[Pair] = set()
+    for node in adj:
+        for anc in ancestors_bfs(node, adj):
+            out.add((node, anc))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The buggy alternative, kept ONLY so `--self-test` can demonstrate the
+# mechanism this script avoids. Never used for a real diff.
+# ---------------------------------------------------------------------------
+
+
+def _buggy_memoized_ancestors_all(adj: Graph) -> Dict[str, Set[str]]:
+    """A plausible-looking but WRONG closure computation: a recursive
+    `ancestors(x)` memoised across ALL top-level queries, which gives up
+    (returns the empty set) the moment it revisits a node already on the
+    current call stack ("cycle detected") -- and then CACHES whatever it
+    computed under that truncation. A later, independent query for a
+    different node can reuse that cached, incomplete result verbatim.
+
+    This is the historical bug, reproduced deliberately for `--self-test`.
+    Do not import or reuse this function outside of the self-test.
+    """
+    memo: Dict[str, Set[str]] = {}
+
+    def anc(node: str, stack: Set[str]) -> Set[str]:
+        if node in memo:
+            return memo[node]
+        if node in stack:
+            # "cycle detected" -- give up on this branch. This is the bug:
+            # the caller has no way to know this answer is incomplete, and
+            # if `node`'s own top-level result gets memoised while some
+            # branch of its computation returned early like this, the
+            # memoised value is silently wrong.
+            return set()
+        stack = stack | {node}
+        result: Set[str] = set()
+        for nxt in sorted(adj.get(node, ())):
+            result.add(nxt)
+            result |= anc(nxt, stack)
+        memo[node] = result
+        return result
+
+    for node in sorted(adj):
+        anc(node, set())
+    return memo
+
+
+# ---------------------------------------------------------------------------
+# classify --json loading
+# ---------------------------------------------------------------------------
+
+
+class ClassifyResult:
+    def __init__(self, path: str, data: dict):
+        self.path = path
+        self.consistent: bool = data.get("consistent", True)
+        self.incomplete: bool = data.get("incomplete", False)
+        self.unsatisfiable: Set[str] = set(data.get("unsatisfiable", []))
+        self.equivalent_groups: List[List[str]] = [list(g) for g in data.get("equivalent_groups", [])]
+        self.direct_subsumptions: List[List[str]] = [list(r) for r in data.get("direct_subsumptions", [])]
+        self.adjacency: Graph = build_adjacency(self.direct_subsumptions, self.equivalent_groups)
+        self.closure: Set[Pair] = transitive_closure(self.adjacency)
+
+    def equivalent_group_key(self) -> Set[FrozenSet[str]]:
+        return {frozenset(g) for g in self.equivalent_groups}
+
+
+def load_classify_json(path: str) -> ClassifyResult:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return ClassifyResult(path, data)
+
+
+# ---------------------------------------------------------------------------
+# Diff reporting
+# ---------------------------------------------------------------------------
+
+
+def format_pairs(pairs: Iterable[Pair], limit: int = 20) -> str:
+    pairs = sorted(pairs)
+    shown = pairs[:limit]
+    lines = [f"    {sub}  ⊑  {sup}" for sub, sup in shown]
+    if len(pairs) > limit:
+        lines.append(f"    ... and {len(pairs) - limit} more")
+    return "\n".join(lines) if lines else "    (none)"
+
+
+def diff(before_path: str, after_path: str) -> int:
+    before = load_classify_json(before_path)
+    after = load_classify_json(after_path)
+
+    gained = after.closure - before.closure
+    lost = before.closure - after.closure
+
+    print(f"before: {before_path}")
+    print(f"  closure size: {len(before.closure)}")
+    print(f"  unsatisfiable: {len(before.unsatisfiable)}")
+    print(f"  equivalent groups: {len(before.equivalent_groups)}")
+    print(f"  consistent={before.consistent} incomplete={before.incomplete}")
+    print(f"after:  {after_path}")
+    print(f"  closure size: {len(after.closure)}")
+    print(f"  unsatisfiable: {len(after.unsatisfiable)}")
+    print(f"  equivalent groups: {len(after.equivalent_groups)}")
+    print(f"  consistent={after.consistent} incomplete={after.incomplete}")
+    print()
+    print(f"gained (in after, not before): {len(gained)}")
+    print(format_pairs(gained))
+    print(f"lost (in before, not after): {len(lost)}")
+    print(format_pairs(lost))
+
+    unsat_gained = after.unsatisfiable - before.unsatisfiable
+    unsat_lost = before.unsatisfiable - after.unsatisfiable
+    if unsat_gained or unsat_lost:
+        print()
+        print(f"unsatisfiable gained: {sorted(unsat_gained)}")
+        print(f"unsatisfiable lost:   {sorted(unsat_lost)}")
+
+    eq_before = before.equivalent_group_key()
+    eq_after = after.equivalent_group_key()
+    if eq_before != eq_after:
+        print()
+        print(f"equivalent groups only in before: {sorted(eq_before - eq_after)}")
+        print(f"equivalent groups only in after:  {sorted(eq_after - eq_before)}")
+
+    if lost:
+        print()
+        print(
+            "NOTE: a 'lost' pair is not automatically a regression -- proving a class "
+            "unsatisfiable or merging classes into a new equivalence group both "
+            "legitimately remove pairs from the closure. Cross-check against "
+            "unsatisfiable/equivalent-group diffs above before calling this a defect."
+        )
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# --self-test
+# ---------------------------------------------------------------------------
+
+
+def self_test() -> int:
+    # Fixture: a 5-member equivalence clique {G1..G5} (mirroring the real
+    # ontology this bug was found on -- a 5-member equivalence group where
+    # only ONE member carries the outgoing edge to something outside the
+    # group) plus a single told edge G1 -> P. Every group member entails P
+    # transitively via the clique, so the correct answer is that ALL of
+    # G1..G5 have P in their ancestor set.
+    members = ["G1", "G2", "G3", "G4", "G5"]
+    direct_subsumptions = [["G1", "P"]]
+    equivalent_groups = [members]
+    adj = build_adjacency(direct_subsumptions, equivalent_groups)
+
+    correct = transitive_closure(adj)
+    expected = set()
+    for m in members:
+        for other in members:
+            if m != other:
+                expected.add((m, other))
+        expected.add((m, "P"))
+    assert correct == expected, (
+        f"self-test FAILED: the correct (fresh-BFS) closure disagrees with the "
+        f"hand-verified expected answer.\n  got:      {sorted(correct)}\n"
+        f"  expected: {sorted(expected)}"
+    )
+    print("[ok] fresh-BFS closure matches the hand-verified expected answer "
+          f"({len(correct)} pairs, every group member reaches P).")
+
+    # Now run the buggy memoised-DFS-with-cycle-guard version and show it
+    # disagrees -- specifically, it must fail to derive at least one
+    # (member, P) pair for a member other than G1 itself (G1 always gets P
+    # right because P is G1's own direct edge, explored before any recursive
+    # call can memoise a truncated result for G1).
+    buggy = _buggy_memoized_ancestors_all(adj)
+    buggy_pairs: Set[Pair] = set()
+    for node, ancs in buggy.items():
+        for a in ancs:
+            buggy_pairs.add((node, a))
+
+    missing_from_buggy = correct - buggy_pairs
+    p_misses = {(m, s) for (m, s) in missing_from_buggy if s == "P"}
+    assert p_misses, (
+        "self-test FAILED: expected the buggy memoized-DFS to lose at least one "
+        "(member, P) entailment via the equivalence cycle, but it reproduced the "
+        "correct closure -- the demonstration fixture no longer exercises the bug "
+        "mechanism, or the buggy implementation was fixed and should be updated "
+        "or removed."
+    )
+    print(
+        f"[ok] the buggy memoized-DFS-with-cycle-guard DISAGREES with the correct "
+        f"closure, missing {len(p_misses)} of the true (member, P) entailments via "
+        f"the equivalence cycle: {sorted(p_misses)}"
+    )
+    print(
+        "     (this is the same mechanism that produced a false '3 lost entailments' "
+        "finding on a real ontology in this project's history -- see the module "
+        "docstring)"
+    )
+
+    # And confirm the buggy version is not simply "always wrong" -- G1 itself
+    # (whose direct edge to P is explored before any cycle truncation can
+    # occur) must still be correct, which is what makes the failure mode
+    # insidious (some entailments from the SAME axiom set are right, others
+    # silently wrong, depending on iteration order).
+    assert ("G1", "P") in buggy_pairs, (
+        "self-test FAILED: expected G1 -> P to survive in the buggy version too "
+        "(it is G1's own direct edge) -- if this fails the fixture needs revisiting"
+    )
+    print("[ok] G1 -> P (a direct, non-cyclic edge) is correct even in the buggy "
+          "version -- confirming the failure is specific to cycle-truncated "
+          "memoisation, not a wholesale bug.")
+
+    print()
+    print("self-test PASSED: the instrument validates itself.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("before", nargs="?", help="BEFORE classify --json file")
+    parser.add_argument("after", nargs="?", help="AFTER classify --json file")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the built-in cyclic-fixture self-test and exit (no files needed)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.before or not args.after:
+        parser.error("both BEFORE and AFTER files are required unless --self-test is given")
+
+    return diff(args.before, args.after)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/closure-diff.py
+++ b/scripts/closure-diff.py
@@ -216,6 +216,12 @@ def format_pairs(pairs: Iterable[Pair], limit: int = 20) -> str:
 
 
 def diff(before_path: str, after_path: str) -> int:
+    """Print the BEFORE/AFTER closure diff. Returns 0 unconditionally --
+    THE EXIT CODE IS NOT A VERDICT: a non-empty `lost` set is not automatically
+    a regression (see the NOTE printed below), so this never fails a lost-pair
+    check by exit code alone. A caller wiring this into a gate must read and
+    adjudicate the printed output, not `$?`.
+    """
     before = load_classify_json(before_path)
     after = load_classify_json(after_path)
 


### PR DESCRIPTION
Closes #118. Closes #119.

Two residuals left by `ed2ab5f` (PR #112, which closed #110). That commit taught the real Pass 1 to decompose a conjunctive `ObjectPropertyDomain`/`Range` filler — `Domain(r, P ⊓ Q) ≡ Domain(r,P) ∧ Domain(r,Q)`, a logical identity — and answers have been correct since. These are the two things it did not reach.

## #119 — a partly-atomic filler was still dropped whole

`all_atomic_conjuncts` was all-or-nothing: its `?` returned `None` on the first non-atomic conjunct, so nothing was pushed.

`ObjectPropertyDomain(:r ObjectIntersectionOf(:P ObjectSomeValuesFrom(:s :S)))` + `SubClassOf(:X ObjectSomeValuesFrom(:r :B))` entails `X ⊑ P`.

| | before | after |
|---|---|---|
| rustdl | **nothing** | `X ⊑ P` |
| Konclude v0.7.0-1138 | `X ⊑ P` | — |
| Kobayashi-MaRust | `X ⊑ P` | — |

Now the atomic conjuncts that *are* representable get pushed. A partial result is a **weaker** (larger) domain than the axiom states — the safe direction. Confirmed structurally in review: `role_domains`/`role_ranges` entries are consumed **additively**, each becoming a separate `∃r.⊤ ⊑ dom` obligation, so dropping a conjunct removes an obligation and can only MISS. It cannot narrow a domain anywhere. `Domain(r, ⊥)` still hits the poison arm first.

This is the opposite of the `DataUnionOf` case, where keeping half a union *narrows* a range and manufactures a clash, so all-or-nothing is load-bearing there. For a domain/range the direction of risk is reversed.

**Partial decomposition is sound; partial ADMISSION is not.** The fragment gates are deliberately **untouched** — `git diff --name-only` over `owl-dl-reasoner/src` and `owl-dl-core/src` returns zero files — and still refuse every non-atomic filler. A conjunct the engine never processed, inside a completeness-certified fragment, would be a fresh instance of the D10 class #110 was about. `a_partly_atomic_domain_filler_is_not_admitted_to_the_pure_el_fragment` pins that, and it is not vacuous: the fixture's only non-EL construct is the `∃s.Z` inside the filler, so the realistic widening makes it `PureEl` and the assertion fires.

## #118 — `prove` could not attribute a conjunctive derivation

`collect_el_rules_with_provenance`'s two mirrors still accepted `Atomic` only, so they diverged from the real Pass 1. With the discriminating control:

| filler | `(Domain(sub)) ⊢ X ⊑ P` before | after |
|---|---|---|
| atomic `:P` | `[axiom[1]]` | `[axiom[1]]` |
| conjunctive `P ⊓ Q` | *no axiom reference* | `[axiom[1]]` |

Not a regression — the mirrors were always `Atomic`-only (checked at `ed2ab5f~1`), and pre-#112 the axiom was dropped so there was no derivation to attribute. #112 gave the engine a capability the mirrors were never taught.

Both now route through the same `atomic_conjuncts` as the real Pass 1, so they cannot drift again.

**The range mirror is the higher-risk half**, and it is guarded separately for a reason: its `mini_effective` feeds `lower_sub_class_of`'s per-axiom rule-slot delta cursors, so a divergence there mis-attributes proofs to the **wrong** axiom rather than merely emptying `axiom_refs`. Review confirmed `domain_axiom_refs` is consumed by `(role, class)` lookup and so cannot misalign, while the range path is the positional one. A single domain fixture leaving the range mirror unguarded is exactly how this gap survived #112.

## Evidence

**Sabotage: 3 run, 3 caught, 0 survived** — range mirror alone, domain mirror alone, and all-or-nothing restored, each failing exactly its own canary with all others green and `git diff` clean between.

Domain and range have **separate** `prove` canaries (`crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs`).

## Also included: `scripts/closure-diff.py`

The transitive-closure comparator behind closure claims, committed so they are reproducible. Fresh per-node BFS, `equivalent_groups` expanded as cliques, **no shared memoisation** — equivalence groups are cycles, and this repo has already produced a false "3 lost entailments" finding from a memoised comparator on `ore_ont_778`.

Its `--self-test` is a real differential rather than an assertion: it shows a buggy memoised DFS missing **4 of 5** entailments through a clique, with a third check diagnosing that as *cycle-truncated memoisation* rather than a wholesale bug. Its docstring states plainly that **the exit code is not a verdict** — a non-empty `lost` set needs adjudication, not `$?`.

## Gates

`cargo test --workspace --exclude owl-dl-py` **1971 passed / 0 failed / 85 ignored** (184 groups, tallied after process exit); doctests clean on the final HEAD; `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features -D warnings` clean; `closure-diff.py --self-test` exit 0.

`owl-dl-py` excluded: it fails to **link** on undefined CPython symbols on this host — environmental, and nothing here touches a Python surface.

## Provenance

These were found while independently reimplementing #110 in a parallel branch (#117, now closed as superseded by #112). That branch is not being merged; only the two residuals it surfaced are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzVE2TSVVMc3n8Wrce65Jg
