### PR TITLE
docs(classify): the Domain/Range gate is now stricter than the engine, and say why

### DIFF
--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -2119,16 +2119,50 @@ fn is_atomic_concept(c: ConceptId, pool: &ConceptPool) -> bool {
     matches!(pool.get(c), ConceptExpr::Atomic(_))
 }
 
-/// True if `c` is a concept that the engine handles completely for
-/// `ObjectPropertyDomain` / `ObjectPropertyRange` filler positions:
+/// True if `c` is a filler this gate will certify for
+/// `ObjectPropertyDomain` / `ObjectPropertyRange` positions:
 /// - `Atomic` — stored in `role_domains` / `role_ranges` and propagated.
 /// - `Bot`    — stored in `poisoned_roles`; any `∃r.*` class becomes unsat.
 /// - `Top`    — dropped by the engine, but semantically trivial: `Domain(r, ⊤)`
 ///   adds no subsumptions, so dropping it is sound (no missed entailment).
 ///
-/// Everything else (`And`, `Some`, `Or`, …) is silently dropped by the engine
-/// while potentially entailing real subsumptions — those MUST fall to the hybrid
-/// path.  See `collect_el_rules`, the `ObjectPropertyDomain` arm.
+/// **This predicate is now STRICTER than the engine.** It used to be exact —
+/// gate-admitted ⟺ engine-handled-or-trivial. Since `ed2ab5f` and `ed94a81`
+/// `collect_el_rules` calls `atomic_conjuncts`, so it also
+/// - handles an `And` of atomics COMPLETELY (a logical identity), and
+/// - handles a MIXED `And` PARTIALLY, contributing the atomic conjuncts only.
+///
+/// Refusing both is right for this gate's own job, which is to never certify
+/// `pure-EL` over an axiom the saturator handles only in part — that is the D10
+/// shape. **But do not read refusal as "the answer is still complete."** A
+/// refused axiom routes to the hybrid path, whose tier walk only discovers a
+/// non-closure pair `sub ⊑ sup` when `closure_count(sub) > closure_count(sup)`;
+/// a dropped or partial filler is exactly when the EL closure fails to make
+/// those counts monotone. `Domain(r, ∃s.Z)` with `∃s.Z ⊑ W` loses `X ⊑ W`, and
+/// `Domain(r⁻, P)` loses its pair outright — both with `direct_subsumptions: []`
+/// and `incomplete: false`, both confirmed by Konclude and `HermiT`, and both
+/// recovered by `RUSTDL_CLASSIFY_SAME_TIER=1` but by no `trust_sat` /
+/// hypertableau flag. Those are PRE-EXISTING misses, not consequences of the
+/// decomposition work, and `Classification::completeness_guaranteed` still
+/// admits their `Horn` verdict — so `disjoint --json` reports
+/// `incomplete: false` on them too.
+///
+/// The fully decomposable case is therefore a MISSED FAST PATH rather than a
+/// missed answer, and for a specific reason: on an otherwise-EL ontology the
+/// saturator's closure is complete, so the tier walk reproduces it exactly.
+/// `Domain(r, P ⊓ Q)` gets the same rows as the atomic spelling; it is only
+/// banner-reported `Horn` instead of `pure-EL`.
+///
+/// Do NOT widen this by pattern-matching `And` here — that re-creates the drift
+/// this comment exists to record. **And do not widen it by delegating to
+/// `atomic_conjuncts` either: that function returns a PARTIAL subset by design,
+/// so a `!atomic_conjuncts(c).is_empty()` gate would admit the MIXED filler and
+/// manufacture the exact D10 regression described above.** Delegation needs the
+/// engine to expose an ALL-atomic predicate (or this gate to compare
+/// `atomic_conjuncts(c).len()` against the filler's own conjunct count). Gate
+/// the flip on a two-arm ORE sweep: it moves ontologies onto the
+/// saturation-only fast path. See `collect_el_rules`, the
+/// `ObjectPropertyDomain` arm.
 fn is_atomic_or_trivial_concept(c: ConceptId, pool: &ConceptPool) -> bool {
     matches!(
         pool.get(c),


### PR DESCRIPTION
Comment only — **no behaviour change**. `git diff --stat` is one file, one doc comment.

## What was wrong

`is_atomic_or_trivial_concept` (`crates/owl-dl-reasoner/src/classify.rs`) is the fragment gate's predicate for `ObjectPropertyDomain`/`Range` fillers. Its doc comment claimed:

> Everything else (`And`, `Some`, `Or`, …) is silently dropped by the engine

That stopped being true at `ed2ab5f` (#112) and `ed94a81` (#120): `collect_el_rules` now calls `atomic_conjuncts`, which handles an `And` of atomics **completely** and a **mixed** `And` **partially**. The gate still admits only `Atomic`/`Bot`/`Top`, so it is no longer exact — it is strictly *stricter* than the engine.

## Measured on the merged tree before rewriting

| filler | fragment banner | rows | verdict |
|---|---|---|---|
| `Domain(r, P)` | `pure-EL` | `X⊑P` | exact |
| `Domain(r, P ⊓ Q)` | `Horn` | `X⊑P`, `X⊑Q` | correct answers, **missed fast path** |
| `Domain(r, P ⊓ ∃s.Z)` | `Horn` | `X⊑P` | correctly refused — partial handling is incomplete |

No soundness or completeness defect: the gate refusing what the engine handles costs a fast path, not an answer. #112's warning that partial decomposition would put "the ENGINE ahead of the fragment GATE" did come true at #120, but it landed on the harmless side of the asymmetry.

## The review catch that mattered

The first draft advised widening the gate by *"DELEGATING to the engine's own decomposer."* **That advice would have caused the bug the comment exists to prevent.** `atomic_conjuncts` returns a bare `Vec<ClassId>` — a PARTIAL subset by design — so a `!atomic_conjuncts(c).is_empty()` gate admits the MIXED filler and manufactures a D10 regression. The comment now says delegation needs the engine to expose an **all-atomic** predicate, or this gate to compare `atomic_conjuncts(c).len()` against the filler's own conjunct count.

## "Strictly safe direction" was not airtight

Refusal routes to the hybrid path, whose tier walk only discovers a non-closure pair `sub ⊑ sup` when `closure_count(sub) > closure_count(sup)` — and a dropped or partial filler is exactly when the EL closure fails to make those counts monotone. Two **pre-existing** misses, reproduced here, are now recorded at the gate:

```
Domain(r, ∃s.Z) + ∃s.Z ⊑ W   ⟹  X ⊑ W
  classify        →  direct_subsumptions: []   incomplete: false
  subclass X W    →  yes
  disjoint --json →  incomplete: false

Domain(r⁻, P)                 loses its pair outright
```

Both Konclude- and HermiT-confirmed, both recovered by `RUSTDL_CLASSIFY_SAME_TIER=1` and by **no** `trust_sat`/hypertableau flag. `completeness_guaranteed()` admits their `Horn` verdict, so the false certificate reaches the public API. **Neither is caused by the decomposition work — neither involves a conjunction at all.** But the draft's framing rested on ignoring them.

The fully-decomposable case is a missed *fast path* rather than a missed answer, and the comment now states the **reason** instead of asserting it: on an otherwise-EL ontology the saturator's closure is complete, so the tier walk reproduces it exactly. "Gets correct answers via the hybrid path" was too strong as a general claim about the hybrid path — the two misses above falsify it.

## Also corrected

- Cite commit hashes (`ed2ab5f`, `ed94a81`), not issue numbers — the code landed in #112/#120 while #110/#119 are the issues.
- Dropped "the engine took `Atomic` and dropped everything else": `Bot` poisoning predates this (2026-07-29) and `Top` was always admitted-and-dropped as trivial. The accurate statement is that gate-admitted ⟺ engine-handled-or-trivial.

## Review

Adversarially reviewed. It found no soundness or completeness hole — checked every gate-admitted shape against both oracles including sub-role and chain-induced domain/range, `P ⊓ ⊤`/`P ⊓ ⊥` (which `ConceptPool::and` collapses before either gate or engine sees them), both call sites (`is_el_axiom` and `is_saturator_axiom`, confirmed symmetric), and inverse roles. It also **refuted a regression hypothesis** I had not raised: with a pinned pre-#120 binary, #120 is a strict gain on every probe, 0 losses.

## Not in this PR — worth filing

- **`completeness_guaranteed()`'s `Horn` arm is a live false certificate.** This is the "hyper Horn fixpoint is complete" justification `CLAUDE.md` already records as false-as-implemented for the D10 shortcircuit, still live one level up at the public API.
- **`Domain(r⁻, C)` is a silent classify miss** the saturator could handle as `Range(r, C)` by identity, if the gate learned it too. The in-tree comment "inverse-role domain = forward range; handled by the tableau" is false comfort — `classify` does not get it.

## Gates

- clippy `--all-targets --all-features` exit 0; `cargo fmt --check` clean
- `conjunctive_domain_range` 7/7, `gci_domain_nonatomic_head` 6/6
- No FP=0 net or corpus sweep: nothing here changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)