### PR TITLE
chore(deps): horned-owl 1.4 -> 3.0, drop the fork, retire whelk-compare (#99, #123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1118,10 +1118,23 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
     NEGATIVE one, which includes an ordinary `EquivalentClasses(C, ObjectHasSelf(r))`: the
     `⊒` direction puts `Self` in the antecedent, and NNF makes it negative. So a grep for
     `ObjectComplementOf(ObjectHasSelf(…))` gives the right answer for the wrong reason;
-    re-scanned for the corrected pattern, ORE still has **0 of 9**. **`VarCap` is the live
-    residual here at 39 ontologies** — a clause silently discarded for exceeding
-    `MAX_BODY_VARS`, the same shape `NotTree` had — recorded, not queued, since raising that
-    cap is a measured hard stop. Two instruments disagreeing on COUNTS (`ro` 2 vs 6) is
+    re-scanned for the corrected pattern, ORE still has **0 of 9**. **`VarCap` WAS the live
+    residual here at 39 ontologies — MEASURED OUT 2026-09-06.** Re-censused at **37** refusing
+    ontologies, of which **11 are ALL-HORN** (`disjunctive=0`, so the refused body is provably
+    Horn) — which **REFUTES** the expectation that they would all be disjunctive. The earlier
+    "23 binders at 8→16, all disjunctive" was not wrong; it measured a DIFFERENT population —
+    binding at 16 and being refused at 8 are not the same set. All 11 refuse at **exactly 9
+    variables**, so the cap is off by ONE for this whole set, not mis-tuned across the
+    9/11/12/16/25/133 spread. **But the shape is INERT:** two arms at cap 8 vs 16, closure-
+    compared — **4 measurable with 0 answer changes; 7 DNF SYMMETRICALLY in both arms**, so
+    there is no answer for a withheld clause to change (claim bounded as 0 of 4, not 0 of 11).
+    And `ore_ont_7775` is both one of the 11 and one of the three completers cap-16 is recorded
+    as destroying, so the naive fix trades recoveries for known regressions. **Do not
+    re-propose without a single ontology where a 9-variable Horn body changes an answer.**
+    **Instrument note:** the first positive control did NOT fire — the fixture was pure-EL, so
+    `classify` took the saturation fast path and never reached the hyper engine; a census run
+    then would have read "0 addressable" from a silent instrument. Adding one `∀` fixed it.
+    See `docs/benchmarks/2026-09-06-varcap-horn-bodies-are-inert.md`. Two instruments disagreeing on COUNTS (`ro` 2 vs 6) is
     expected and was adjudicated rather than papered over: the engine counts indexing EVENTS
     (`ro` is re-indexed 3×) and the probe counts distinct clause bodies; as booleans they
     agree 4/4. See `docs/benchmarks/2026-09-04-self-filter-refusal-census.md`. A companion clausifier gap closed in `8ae984c`: `emit_head`'s `Not` arm handled only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2161,7 +2161,10 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
 
 
 - **`crates/owl-dl-cli`** (`rustdl` binary) and **`crates/owl-dl-bench`**
-  (`owl-dl-bench`: `classify`/`sat`/`synthetic-el`/`corpus`/`compare-whelk`).
+  (`owl-dl-bench`: `classify`/`sat`/`synthetic-el`/`corpus`/`matrix`; the in-process
+  `compare-whelk` subcommand was retired 2026-09-07 when the workspace moved to
+  horned-owl 3.x — whelk-rs pins `^1.4` — see
+  `docs/whelk-rs-comparison-2026-07-08.md`).
   `xtask/` holds build automation (corpus fetch, license inventory).
   `diagnose` partitions unsatisfiable classes into root (causes) vs derived
   (collateral) via a stingy structural dependency graph and justifies the roots;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -101,26 +101,26 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -136,12 +136,6 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -166,24 +160,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -202,21 +187,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -230,9 +215,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -240,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -252,14 +237,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -293,19 +278,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -313,18 +289,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crypto-common"
@@ -342,7 +318,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30667fc7792d940719ecada2201aeaedf0f38b876675fa69191e632dabc57569"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
 ]
 
 [[package]]
@@ -379,21 +355,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "enum_meta"
@@ -402,19 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66766e489640531c2663bb422bb689e32d5ac7dd15975c4928c10317d6f42fbd"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -434,7 +386,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -450,20 +402,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "findshlibs"
@@ -484,16 +436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,15 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,21 +455,21 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -556,17 +489,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -579,15 +501,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -633,17 +553,30 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
+
+[[package]]
+name = "horned-catalog"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3914b8e6d9a25a8483c9fa6c6706d4b0c0ffe0173945fe2ceb59d7cd36f5cf9a"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "horned-owl"
-version = "1.4.0"
-source = "git+https://github.com/micheldumontier/horned-owl?rev=b188edaf7c92600918f0524962d928097ecd6b4d#b188edaf7c92600918f0524962d928097ecd6b4d"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70641513828c1879596b64aeea537633210b5511530c22cb63663596f8dd7743"
 dependencies = [
  "curie",
  "enum_meta",
+ "horned-catalog",
+ "horned-pretty-rdf",
  "indexmap 1.9.3",
  "lazy_static",
  "log",
@@ -652,139 +585,21 @@ dependencies = [
  "oxrdfio",
  "pest",
  "pest_derive",
- "pretty_rdf",
  "quick-xml 0.37.5",
  "thiserror 1.0.69",
- "ureq",
 ]
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
+name = "horned-pretty-rdf"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "23df1fbcad1f889bb794d4a26f2bdc0d8cdd0429cf01cb440c376aec05bdf102"
 dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
+ "indexmap 1.9.3",
+ "oxrdf",
+ "oxrdfio",
+ "quick-xml 0.31.0",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -799,14 +614,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -816,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "is-terminal",
  "itoa",
  "log",
@@ -835,7 +648,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -845,15 +658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,13 +665,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -884,28 +687,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -918,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchers"
@@ -933,15 +724,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -953,7 +744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -973,7 +763,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1033,7 +823,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
- "whelk",
 ]
 
 [[package]]
@@ -1070,7 +859,7 @@ dependencies = [
  "horned-owl",
  "proptest",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1080,7 +869,7 @@ version = "0.4.28"
 dependencies = [
  "owl-dl-core",
  "proptest",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1092,7 +881,7 @@ dependencies = [
  "owl-dl-core",
  "owl-dl-reasoner",
  "pyo3",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1109,7 +898,7 @@ dependencies = [
  "owl-dl-tableau",
  "proptest",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1125,7 +914,7 @@ dependencies = [
  "proptest",
  "rayon",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1142,7 +931,7 @@ dependencies = [
  "owl-dl-saturation",
  "proptest",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1160,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "oxilangtag"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f3f87617a86af77fa3691e6350483e7154c2ead9f1261b75130e21ca0f8acb"
+checksum = "5d3b4eb570abd4a1dcb062c31fd37b832264d9dc7292c3e69acfe926c87b063f"
 dependencies = [
  "serde",
 ]
@@ -1175,66 +964,66 @@ checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
 
 [[package]]
 name = "oxjsonld"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e1380a504a8571763f13b8bcad629ff90d0300d47d8a519f3c6c599625840e"
+checksum = "86a3e89e005662e60327027f45ec7cefd0472404e01831b5d83a3ac522cfabe0"
 dependencies = [
  "json-event-parser",
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "oxrdf"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afd5c28e4a399c57ee2bc3accd40c7b671fdc7b6537499f14e95b265af7d7e0"
+checksum = "4be15186205eb60ddbdc2fb47cb25df472c7f399bbe119b68c0972b6b6dd46ea"
 dependencies = [
  "oxilangtag",
  "oxiri",
  "rand",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "oxrdfio"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696223589ecbcab06b1a5df9b527dc25b0c656160cca38752fdb3878a5d3dd03"
+checksum = "17b3fe3bb34179c376ab04f2a1b32616b0babab574b3b7eef64d587e60d5e1db"
 dependencies = [
  "oxjsonld",
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "oxrdfxml"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5516ae083d09bc57ec65ed5ee97701481725de6ffaa83d968ab42a96157ba1"
+checksum = "71853d12051879f3e424c6864e978f5f5cbecd8e86a9817adbccaefccac9d61d"
 dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "oxttl"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03fd471bd54c23d76631c0a2677aa4bb308d905f6e491ee35dcb0732b7c5c6c"
+checksum = "b1d0fe19fa62a6a102f85b052bbd86e3cdc3360cd6a338d01bab1a6743bf1d8e"
 dependencies = [
  "memchr",
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1251,16 +1040,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1268,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1278,25 +1061,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -1307,18 +1089,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "pprof"
@@ -1352,32 +1125,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_rdf"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef451f785c5b7a8f2bc55ebdc88864156bb39afcd67a9c6af35d71c87043505"
-dependencies = [
- "indexmap 1.9.3",
- "oxrdf",
- "oxrdfio",
- "quick-xml 0.31.0",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1390,7 +1141,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1403,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -1417,18 +1168,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1436,26 +1187,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1493,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1520,12 +1271,12 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1535,14 +1286,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1559,16 +1304,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1597,26 +1333,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1625,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rgb"
@@ -1639,30 +1363,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustdl"
@@ -1678,53 +1388,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -1740,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "ryu-js"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -1760,16 +1435,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1777,29 +1446,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1830,25 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"
@@ -1858,15 +1511,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]
@@ -1888,12 +1541,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
@@ -1920,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1930,14 +1577,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
+name = "syn"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1959,19 +1606,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1985,11 +1623,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -2000,37 +1638,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -2052,7 +1680,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2096,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -2119,52 +1747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,9 +1754,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2212,34 +1794,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2250,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2260,91 +1827,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "whelk"
-version = "0.1.0"
-source = "git+https://github.com/INCATools/whelk-rs#701710d58b6039794bc5a4348880d813eecf2bbb"
-dependencies = [
- "clap",
- "env_logger",
- "horned-owl",
- "humantime",
- "im",
- "itertools",
- "log",
- "rustc-hash",
 ]
 
 [[package]]
@@ -2369,7 +1869,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2386,15 +1886,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2403,168 +1894,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -2584,110 +1917,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ owl-dl-verify = { path = "crates/owl-dl-verify", version = "0.4.28" }
 owl-dl-reasoner = { path = "crates/owl-dl-reasoner", version = "0.4.28" }
 rustdl = { path = "crates/rustdl", version = "0.4.28" }
 
-horned-owl = { version = "1.4", default-features = false }
+horned-owl = { version = "3.0", default-features = false }
 
 hashbrown = "0.15"
 smallvec = { version = "1.13", features = ["const_generics", "union"] }
@@ -110,20 +110,3 @@ inherits = "release"
 [profile.dev]
 debug = "line-tables-only"
 
-[patch.crates-io]
-# Manchester Syntax io/omn. STATUS CORRECTED 2026-09-03: the upstream PR
-# (phillord/horned-owl#176) MERGED on 2026-07-11 and `io::omn` ships in RELEASED
-# horned-owl 2.0.0 (2026-07-17) and 3.0.0 -- including `reader::read` and
-# `reader::parse_class_expression`. This patch is still needed only because rustdl
-# pins 1.4 (omn landed in 2.0), and because the fork's per-item `AsManchester`
-# rendering trait did NOT land upstream -- upstream ships only a whole-ontology
-# `writer::write`, which cannot render a single axiom. Dropping the patch is a
-# horned-owl MAJOR upgrade plus replacing that trait; tracked in #99.
-# Pinned
-# to a rev on the `manchester-io-rebased` branch of the fork — rebased onto
-# upstream/main (1.4.0) and conformance-complete (PR micheldumontier/horned-owl →
-# phillord/horned-owl #176) so this builds reproducibly anywhere (the upstream
-# merge will drop this patch). See
-# docs/superpowers/specs/2026-06-12-horned-owl-manchester-io-design.md and
-# docs/manchester/manchester-io-report.md in the fork.
-horned-owl = { git = "https://github.com/micheldumontier/horned-owl", rev = "b188edaf7c92600918f0524962d928097ecd6b4d" }

--- a/crates/owl-dl-bench/Cargo.toml
+++ b/crates/owl-dl-bench/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
-publish = false   # whelk dep is git-only (not on crates.io); bench is an internal dev tool
+publish = false   # internal dev tool
 
 [[bin]]
 name = "owl-dl-bench"
@@ -37,10 +37,6 @@ owl-dl-reasoner.workspace = true
 [lints]
 workspace = true
 
-[dependencies.whelk]
-git = "https://github.com/INCATools/whelk-rs"
-optional = true
-
 [dependencies.pprof]
 version = "0.14"
 features = ["flamegraph"]
@@ -48,7 +44,6 @@ optional = true
 
 [features]
 default = []
-whelk-compare = ["dep:whelk"]
 profile = ["dep:pprof"]
 # Forward owl-dl-tableau's per-rule counters. Enable for the same
 # diagnostic builds as `profile`; activate at runtime with

--- a/crates/owl-dl-bench/src/main.rs
+++ b/crates/owl-dl-bench/src/main.rs
@@ -155,18 +155,6 @@ enum Command {
         #[arg(long)]
         pair_timeout_ms: Option<u64>,
     },
-    /// In-process comparison against `whelk-rs` (another EL
-    /// reasoner in Rust), running both engines on the same input.
-    /// Available only when built with `--features whelk-compare`.
-    #[cfg(feature = "whelk-compare")]
-    CompareWhelk {
-        /// Path to the OWL functional-syntax ontology.
-        file: PathBuf,
-        /// Number of timing iterations (default 5; first is warmup
-        /// and dropped).
-        #[arg(long, default_value = "5")]
-        iters: usize,
-    },
     /// Run the authoritative reasoner×ontology performance matrix.
     Matrix {
         #[arg(long, default_value = "curated")]
@@ -185,8 +173,8 @@ enum Command {
 fn parse_ofn(path: &Path) -> Result<SetOntology<RcStr>> {
     use horned_owl::io::owx::reader::read as read_owx;
     use horned_owl::io::rdf::reader::read as read_rdf;
-    // Content-sniff so the whelk comparison works on OFN (ORE), OWX (pilot
-    // canon), and RDF/XML (BioPortal) alike — both engines share this parse.
+    // Content-sniff so this works on OFN (ORE), OWX (pilot canon), and
+    // RDF/XML (BioPortal) alike.
     let src = std::fs::read_to_string(path)
         .with_context(|| format!("opening ontology file: {}", path.display()))?;
     let cfg = ParserConfiguration::default();
@@ -368,8 +356,6 @@ fn run(cli: Cli) -> Result<()> {
             repeats,
             pair_timeout_ms,
         } => run_corpus(&dir, quiet, repeats, pair_timeout_ms)?,
-        #[cfg(feature = "whelk-compare")]
-        Command::CompareWhelk { file, iters } => run_compare_whelk(&file, iters)?,
         Command::Matrix {
             tier,
             out,
@@ -400,198 +386,6 @@ fn run(cli: Cli) -> Result<()> {
             matrix::run_matrix(&args)?;
         }
     }
-    Ok(())
-}
-
-#[cfg(feature = "whelk-compare")]
-fn run_compare_whelk(path: &Path, iters: usize) -> Result<()> {
-    use owl_dl_core::convert::convert_ontology as core_convert;
-    use whelk::whelk::owl::translate_ontology;
-    use whelk::whelk::reasoner::assert as whelk_assert;
-
-    anyhow::ensure!(iters >= 2, "need at least 2 iters (first is warmup)");
-    let ontology = parse_ofn(path)?;
-    println!("file: {}", path.display());
-    println!("iters: {iters} (first iteration discarded as warmup)\n");
-
-    // Time rustdl `classify` (full: convert + saturate + classify_pure_el matrix).
-    let mut rustdl_samples: Vec<std::time::Duration> = Vec::with_capacity(iters);
-    let mut last_rustdl_stats = None;
-    for _ in 0..iters {
-        let start = Instant::now();
-        let h = classify(&ontology).context("rustdl classify")?;
-        let elapsed = start.elapsed();
-        last_rustdl_stats = Some((h.classes().len(), h.stats()));
-        rustdl_samples.push(elapsed);
-    }
-
-    // Time rustdl `saturate()` only (convert_ontology + saturate, no classify matrix).
-    // This is the fair apples-to-apples comparison with whelk's `assert()`.
-    // The pair-count is computed OUTSIDE the timing window to avoid contaminating
-    // the measurement with an extra n² scan.
-    let mut rustdl_sat_samples: Vec<std::time::Duration> = Vec::with_capacity(iters);
-    let mut last_closure = None;
-    let mut last_internal = None;
-    for _ in 0..iters {
-        let start = Instant::now();
-        let internal = core_convert(&ontology).context("rustdl convert_ontology")?;
-        let closure = owl_dl_saturation::saturate(&internal);
-        let elapsed = start.elapsed();
-        last_closure = Some(closure);
-        last_internal = Some(internal);
-        rustdl_sat_samples.push(elapsed);
-    }
-    // Count non-reflexive named-to-named pairs in the saturation closure,
-    // excluding synthetics and Top/Bot. Computed outside the timing window.
-    let last_rustdl_sat_pairs: usize =
-        if let (Some(cl), Some(internal)) = (&last_closure, &last_internal) {
-            let n = internal.vocabulary.num_classes();
-            let mut count = 0usize;
-            for i in 0..n {
-                let ci = owl_dl_core::ClassId::new(u32::try_from(i).expect("fits"));
-                let sub_iri = internal.vocabulary.class_iri(ci);
-                if sub_iri == "http://www.w3.org/2002/07/owl#Thing"
-                    || sub_iri == "http://www.w3.org/2002/07/owl#Nothing"
-                    || sub_iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX)
-                    || sub_iri.starts_with("urn:rustdl-")
-                {
-                    continue;
-                }
-                for j in 0..n {
-                    if i == j {
-                        continue;
-                    }
-                    let cj = owl_dl_core::ClassId::new(u32::try_from(j).expect("fits"));
-                    let sup_iri = internal.vocabulary.class_iri(cj);
-                    if sup_iri == "http://www.w3.org/2002/07/owl#Thing"
-                        || sup_iri == "http://www.w3.org/2002/07/owl#Nothing"
-                        || sup_iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX)
-                        || sup_iri.starts_with("urn:rustdl-")
-                    {
-                        continue;
-                    }
-                    if cl.contains(ci, cj) {
-                        count += 1;
-                    }
-                }
-            }
-            count
-        } else {
-            0
-        };
-
-    // Time whelk: translate_ontology + assert (the saturation step).
-    let mut whelk_samples: Vec<std::time::Duration> = Vec::with_capacity(iters);
-    let mut last_whelk_subsumptions: usize = 0;
-    let mut last_whelk_state = None;
-    for _ in 0..iters {
-        let start = Instant::now();
-        let translated = translate_ontology(&ontology);
-        let state = whelk_assert(&translated);
-        let elapsed = start.elapsed();
-        last_whelk_subsumptions = state.named_subsumptions().len();
-        last_whelk_state = Some(state);
-        whelk_samples.push(elapsed);
-    }
-
-    // Drop the warmup iteration (first) and report.
-    let summary = |label: &str, samples: &[std::time::Duration]| {
-        let trimmed = &samples[1..];
-        let total: std::time::Duration = trimmed.iter().sum();
-        let mean = total / u32::try_from(trimmed.len()).expect("iter count fits");
-        let min = trimmed.iter().min().copied().unwrap_or_default();
-        let max = trimmed.iter().max().copied().unwrap_or_default();
-        println!("{label:<20} mean={mean:>9.3?}  min={min:>9.3?}  max={max:>9.3?}");
-    };
-    summary("rustdl classify", &rustdl_samples);
-    summary("rustdl saturate()", &rustdl_sat_samples);
-    summary("whelk assert()", &whelk_samples);
-
-    if let Some((classes, stats)) = last_rustdl_stats {
-        println!();
-        println!(
-            "rustdl classify: classes={classes} pure_el_mode={} sat_sub={} tab_sub={} sat_unsat={} tab_unsat={}",
-            stats.pure_el_mode,
-            stats.saturation_subsumption_hits,
-            stats.tableau_subsumption_calls,
-            stats.saturation_unsat_hits,
-            stats.tableau_unsat_calls,
-        );
-    }
-    println!("rustdl saturate(): non-reflexive pairs in full closure = {last_rustdl_sat_pairs}");
-    println!(
-        "whelk assert(): named_subsumptions (includes reflexive + ⊑Top) = {last_whelk_subsumptions}"
-    );
-
-    // Closure set comparison: build (sub_iri, sup_iri) pairs from both engines,
-    // normalized to exclude reflexive and ⊑ owl:Thing / ⊑ owl:Nothing edges,
-    // restricted to declared named classes. Diff surfaces any genuine disagreement.
-    println!("\n--- Closure diff (declared named classes, excluding reflexive and ⊑Top/Bot) ---");
-    let internal_for_diff = core_convert(&ontology).context("convert for diff")?;
-    let closure_for_diff = owl_dl_saturation::saturate(&internal_for_diff);
-    let vocab = &internal_for_diff.vocabulary;
-    let n = vocab.num_classes();
-    // Build rustdl set: (class_iri, class_iri) for named classes only,
-    // excluding Top/Bot and DKey/aux synthetics.
-    let mut rustdl_pairs: std::collections::BTreeSet<(String, String)> =
-        std::collections::BTreeSet::default();
-    for i in 0..n {
-        let ci = owl_dl_core::ClassId::new(u32::try_from(i).expect("fits"));
-        let sub_iri = vocab.class_iri(ci);
-        if sub_iri == "http://www.w3.org/2002/07/owl#Thing"
-            || sub_iri == "http://www.w3.org/2002/07/owl#Nothing"
-            || sub_iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX)
-            || sub_iri.starts_with("urn:rustdl-")
-        {
-            continue;
-        }
-        for j in 0..n {
-            if i == j {
-                continue;
-            }
-            let cj = owl_dl_core::ClassId::new(u32::try_from(j).expect("fits"));
-            let sup_iri = vocab.class_iri(cj);
-            if sup_iri == "http://www.w3.org/2002/07/owl#Thing"
-                || sup_iri == "http://www.w3.org/2002/07/owl#Nothing"
-                || sup_iri.starts_with(owl_dl_core::DKEY_IRI_PREFIX)
-                || sup_iri.starts_with("urn:rustdl-")
-            {
-                continue;
-            }
-            if closure_for_diff.contains(ci, cj) {
-                rustdl_pairs.insert((sub_iri.to_string(), sup_iri.to_string()));
-            }
-        }
-    }
-    // Build whelk set: from the last whelk state, collect all AtomicConcept pairs,
-    // excluding reflexive and ⊑ owl:Thing / ⊑ owl:Nothing.
-    let mut whelk_pairs: std::collections::BTreeSet<(String, String)> =
-        std::collections::BTreeSet::default();
-    if let Some(ref ws) = last_whelk_state {
-        for (sub_name, sup_name) in ws.named_subsumptions() {
-            if sub_name == sup_name {
-                continue;
-            }
-            if sup_name == "http://www.w3.org/2002/07/owl#Thing"
-                || sup_name == "http://www.w3.org/2002/07/owl#Nothing"
-                || sub_name == "http://www.w3.org/2002/07/owl#Thing"
-                || sub_name == "http://www.w3.org/2002/07/owl#Nothing"
-            {
-                continue;
-            }
-            whelk_pairs.insert((sub_name.to_string(), sup_name.to_string()));
-        }
-    }
-    let rustdl_only: Vec<_> = rustdl_pairs.difference(&whelk_pairs).take(10).collect();
-    let whelk_only: Vec<_> = whelk_pairs.difference(&rustdl_pairs).take(10).collect();
-    println!("rustdl normalized pairs: {}", rustdl_pairs.len());
-    println!("whelk  normalized pairs: {}", whelk_pairs.len());
-    println!("in rustdl only (first 10): {rustdl_only:?}");
-    println!("in whelk only  (first 10): {whelk_only:?}");
-    println!(
-        "symmetric diff total: {}",
-        rustdl_pairs.symmetric_difference(&whelk_pairs).count()
-    );
     Ok(())
 }
 

--- a/crates/owl-dl-bench/src/matrix/mod.rs
+++ b/crates/owl-dl-bench/src/matrix/mod.rs
@@ -253,8 +253,11 @@ fn build_cell(
                 }
             }
             "whelk-rs" => {
-                // whelk runs in-process behind the `whelk-compare` feature; when
-                // the feature is off, record `na` with a note rather than a fake number.
+                // whelk-rs was never wired into this matrix as a runnable
+                // comparator (the in-process `whelk-compare` feature this
+                // reasoner slot anticipated was retired 2026-09-07 — see
+                // `docs/whelk-rs-comparison-2026-07-08.md`); record `na`
+                // rather than a fake number.
                 status = Status::Na;
             }
             _ => unreachable!(),

--- a/crates/owl-dl-cli/Cargo.toml
+++ b/crates/owl-dl-cli/Cargo.toml
@@ -10,18 +10,14 @@ repository.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
-# Uses `horned_owl::io::omn` (Manchester reader/writer), which exists only in the
-# `[patch.crates-io]` fork rev, NOT in horned-owl 1.4 -- the version this workspace
-# PINS. NB `io::omn` DOES exist in released horned-owl 2.0.0+/3.0.0; what remains
-# fork-only is the per-item `AsManchester` rendering trait. So this is a pinned-
-# version problem plus one trait, not an upstream-feature gap; tracked in #99.
-# `[patch]` is not carried in a published manifest, so a consumer resolves
-# upstream and this crate FAILS TO COMPILE for them (measured: E0432
-# `unresolved import horned_owl::io::omn`) — while building green here, because
-# the patch applies locally. Distribution is the GitHub Release binaries built
-# by .github/workflows/release-cli.yml. Flip back to publishable once upstream
-# PR phillord/horned-owl#176 lands and the patch is dropped.
-publish = false
+# Uses `horned_owl::io::omn` (Manchester reader/writer) and the per-item
+# `AsManchester` rendering trait. Both ship in RELEASED horned-owl 3.x, so this
+# crate no longer depends on a `[patch.crates-io]` fork and is publishable again.
+# The historical blocker (#99) was that the workspace pinned 1.4 while `io::omn`
+# first appears in 2.0; `AsManchester` was believed fork-only and is NOT — upstream
+# 3.0.0 exports it from `io::omn` with an identical signature, and carries MORE
+# impls than the fork did (17 vs 13, adding the SWRL Atom/DArgument/IArgument/
+# Variable shapes). Dropping the fork also removes an LGPL-3.0 dependency edge.
 
 [[bin]]
 name = "rustdl"

--- a/crates/owl-dl-py/tests/python/test_explain.py
+++ b/crates/owl-dl-py/tests/python/test_explain.py
@@ -1,7 +1,7 @@
 """Tests for the Python explanation/debugging surface + materialize re-exports."""
 import rustdl
 
-BROKEN = """Prefix(:=<urn:>)
+BROKEN = """Prefix(:=<http://ex/#>)
 Ontology(
   Declaration(Class(:A)) Declaration(Class(:Bad)) Declaration(Class(:SubBad))
   SubClassOf(:Bad ObjectIntersectionOf(:A ObjectComplementOf(:A)))
@@ -37,7 +37,7 @@ def test_reexports_present():
 
 def test_justify(tmp_path):
     p = _write(tmp_path, BROKEN)
-    ax = rustdl.justify(p, ["unsat", "urn:Bad"])
+    ax = rustdl.justify(p, ["unsat", "http://ex/#Bad"])
     assert ax, "expected a non-empty justification"
     assert any("Bad" in a for a in ax)
 
@@ -53,15 +53,15 @@ def test_prepared_justify_matches_free_function(tmp_path):
     # as the one-shot rustdl.justify().
     p = _write(tmp_path, BROKEN)
     onto = rustdl.prepare(p)
-    prepared = onto.justify(["unsat", "urn:Bad"])
-    cold = rustdl.justify(p, ["unsat", "urn:Bad"])
+    prepared = onto.justify(["unsat", "http://ex/#Bad"])
+    cold = rustdl.justify(p, ["unsat", "http://ex/#Bad"])
     assert prepared, "expected a non-empty justification"
     assert sorted(prepared) == sorted(cold)
 
 
 def test_prepare_bytes():
     onto = rustdl.prepare_bytes(BROKEN.encode(), format="ofn")
-    ax = onto.justify(["unsat", "urn:Bad"])
+    ax = onto.justify(["unsat", "http://ex/#Bad"])
     assert any("Bad" in a for a in ax)
 
 
@@ -69,13 +69,13 @@ def test_diagnose(tmp_path):
     p = _write(tmp_path, BROKEN)
     consistent, roots, derived = rustdl.diagnose(p)
     assert consistent is True
-    assert "urn:Bad" in roots
-    assert any(d == "urn:SubBad" for (d, _) in derived)
+    assert "http://ex/#Bad" in roots
+    assert any(d == "http://ex/#SubBad" for (d, _) in derived)
 
 
 def test_repair(tmp_path):
     p = _write(tmp_path, BROKEN)
-    reps = rustdl.repair(p, ["unsat", "urn:Bad"], 10)
+    reps = rustdl.repair(p, ["unsat", "http://ex/#Bad"], 10)
     assert reps and all(isinstance(r, list) for r in reps)
 
 
@@ -85,17 +85,17 @@ def test_debug_consistent_with_unsat(tmp_path):
     assert isinstance(d, rustdl.Diagnosis)
     # attribute API
     assert d.consistent is True
-    assert "urn:Bad" in d.unsatisfiable
-    bad = next(r for r in d.roots if r.iri == "urn:Bad")
+    assert "http://ex/#Bad" in d.unsatisfiable
+    bad = next(r for r in d.roots if r.iri == "http://ex/#Bad")
     assert bad.justification and bad.repairs
-    assert "urn:SubBad" in bad.derives
+    assert "http://ex/#SubBad" in bad.derives
     # back-compat dict API
     assert d["consistent"] is True
-    assert any(r["iri"] == "urn:Bad" for r in d["roots"])
+    assert any(r["iri"] == "http://ex/#Bad" for r in d["roots"])
 
 
 def test_debug_coherent(tmp_path):
-    p = _write(tmp_path, "Prefix(:=<urn:>)\nOntology(Declaration(Class(:A)))\n")
+    p = _write(tmp_path, "Prefix(:=<http://ex/#>)\nOntology(Declaration(Class(:A)))\n")
     d = rustdl.debug(p)
     assert d.consistent is True
     assert d.unsatisfiable == ()
@@ -103,7 +103,7 @@ def test_debug_coherent(tmp_path):
 
 
 def test_materialize_property_assertions(tmp_path):
-    p = _write(tmp_path, """Prefix(:=<urn:>)
+    p = _write(tmp_path, """Prefix(:=<http://ex/#>)
 Ontology(
   Declaration(NamedIndividual(:a)) Declaration(NamedIndividual(:b))
   Declaration(ObjectProperty(:hasParent)) Declaration(ObjectProperty(:hasAncestor))
@@ -112,4 +112,4 @@ Ontology(
 )
 """)
     triples = rustdl.materialize_inferred_property_assertions(p)
-    assert ("urn:a", "urn:hasAncestor", "urn:b") in triples
+    assert ("http://ex/#a", "http://ex/#hasAncestor", "http://ex/#b") in triples

--- a/docker/owlapi-bench/README.md
+++ b/docker/owlapi-bench/README.md
@@ -32,8 +32,10 @@ up as `null` in the output — it's still ELK; we use
 
 ## What this is for
 
-Fair comparison against rustdl. Use `owl-dl-bench compare-whelk` for
-the in-process Rust vs Rust comparison; use this harness for
-Rust vs JVM. JVM startup is paid once via the warmup iteration plus
-the static cost of one `java` invocation, so the per-call number is
-a meaningful estimate of reasoning time.
+Fair comparison against rustdl. `owl-dl-bench compare-whelk`, the
+in-process Rust vs Rust comparison, was retired 2026-09-07 when the
+workspace moved to horned-owl 3.x (whelk-rs pins `^1.4`) — see
+`docs/whelk-rs-comparison-2026-07-08.md`; use this harness for
+Rust vs JVM instead. JVM startup is paid once via the warmup iteration
+plus the static cost of one `java` invocation, so the per-call number
+is a meaningful estimate of reasoning time.

--- a/docs/benchmarks/2026-09-06-varcap-horn-bodies-are-inert.md
+++ b/docs/benchmarks/2026-09-06-varcap-horn-bodies-are-inert.md
@@ -1,0 +1,90 @@
+# `VarCap`: the Horn-bodied refusals exist, and they are inert — WS2 closed as a negative
+
+**Verdict: stop.** The roadmap's kill condition fires, but on B2 rather than B1, and the route
+there corrects two things that were previously inferred rather than measured.
+
+## What was expected, and why that was wrong
+
+`docs/2026-08-03-max-body-vars.md` found 23 binders when raising `MAX_BODY_VARS` 8 → 16 and
+recorded that **in each case the withheld clause is disjunctive**. I predicted B1 would therefore
+find ~0 Horn-bodied refusals and the kill condition would fire immediately.
+
+**It did not. 11 of 37 refusing ontologies are all-Horn.**
+
+The prior was not wrong — it measured a *different population*. "Binds when the cap is raised to
+16" and "is refused at 8" are not the same set. Both hold at once: the bodies that start firing at
+16 are disjunctive, while other bodies refused at 8 are Horn. This is why B1 was specified as a
+measurement rather than an inference, and it is worth keeping as an instance of a recorded number
+being true and still not answering the question asked of it.
+
+## B1 — the census
+
+Instrument: `RUSTDL_TRACE_BODY_VARS=1` over `classify`, all 1,920, 30 s cap, 6-way.
+Joined against `examples/clause_stats_probe` (clausify-only) over the same 1,920 to identify
+ontologies with `disjunctive=0` — an ontology with only Horn clauses can only have Horn-bodied
+refusals, which makes that half of the split *provable* rather than inferred.
+
+| | count |
+|---|---:|
+| refusing ontologies | **37** |
+| of which **all-Horn** (`disjunctive=0`) | **11** |
+| of which mixed (`disjunctive>0`) — body indeterminate | 26 |
+| unmeasured at the 30 s cap | 134 |
+| corpus split: all-Horn / mixed / unmeasured | 1,226 / 689 / 5 |
+
+The 11: `ore_ont_` `1182, 3529, 3575, 5218, 7361, 7775, 9855, 11629, 11745, 12432, 14572`.
+(The earlier census said 39; the difference sits inside the 134 unmeasured at this cap.)
+
+**INSTRUMENT VALIDATION, and it nearly cost the whole result.** The first positive control —
+twelve `∃`-conjuncts, 13 distinct body variables — produced **zero** trace lines. Had the census
+run then, "0 refusals" would have read as "0 addressable" from an instrument that was not firing.
+Cause: the fixture was pure-EL, so `classify` took the saturation fast path and the hyper engine
+never indexed a clause. Adding one `∀` to force the hybrid path made it fire at once
+(`[mbv] refused body: vars=13 ... reason=VarCap { vars: 9, cap: 8 }`). Both negative controls
+(`ro`, `pizza`) stay silent. **Prove the instrument fires, on the path the defect lives on.**
+
+## The cap is off by ONE, not mis-tuned across a range
+
+Every one of the 11 refuses at **exactly 9 variables** — not the 9/11/12/16/25/133 spread the
+earlier census recorded for binders.
+
+## B2 — does the withheld clause change an ANSWER?
+
+Two arms (`RUSTDL_WIDE_BODY_VARS` 0 vs 1, cap 8 vs 16 — enough to admit every one of the 11 at
+9 vars), arm order alternated, 300 s cap, compared on the transitive closure with
+`scripts/closure-diff.py`.
+
+| | count |
+|---|---:|
+| completed in both arms | 4 |
+| **answer changes among them** | **0** (gained 0 / lost 0, all four) |
+| DNF **symmetrically** in both arms — UNMEASURED | 7 |
+
+`ore_ont_1182` 1,835 · `ore_ont_3529` 3,278 · `ore_ont_7775` 3,765 · `ore_ont_12432` 27,997
+closure entries, identical across arms.
+
+**The 7 unmeasured do not weaken the verdict**: they produce no answer in *either* arm, so there
+is no answer for a withheld clause to change within reach of this budget. The claim is bounded
+accordingly — 0 of 4 measurable, not 0 of 11.
+
+## Why the naive fix stays disqualified
+
+`ore_ont_7775` is in the 11 **and** is one of the three completers `docs/2026-08-03-max-body-vars.md`
+records as destroyed by cap 16 (3.14 s → DNF). Raising the cap admits the Horn bodies and the
+disjunctive ones together; only a Horn/disjunctive split separates them.
+
+**One discrepancy, recorded not resolved:** here `ore_ont_7775` **completes** in the wide arm
+(3 s → 11 s, 3.7× slower, answers identical), where that document records a DNF. Different
+conditions are the likely explanation and I did not chase it. Anyone reviving this must re-measure
+that case rather than trust either number.
+
+## Verdict
+
+**Kill condition fires on B2.** The shape the roadmap hoped for is real and larger than expected —
+11 ontologies, all one variable over the cap — but **inert**: it changes no answer anywhere it can
+be measured. A branching-cap policy in the wedge's hot path cannot be justified by a population
+whose withheld clauses derive nothing, and the one case that would most benefit is the same case
+the cap increase is known to destroy.
+
+**Do not re-propose without new evidence.** The cheapest thing that would change this verdict is a
+single ontology where a 9-variable Horn body changes an answer; none of the 4 measurable ones does.

--- a/docs/whelk-rs-comparison-2026-07-08.md
+++ b/docs/whelk-rs-comparison-2026-07-08.md
@@ -1,5 +1,16 @@
 # rustdl vs whelk-rs — full comparison (2026-07-08)
 
+> **RETIRED 2026-09-07.** The in-process comparator this doc describes
+> (`owl-dl-bench compare-whelk`, the `whelk-compare` feature) was removed when
+> the workspace moved from a pinned `[patch.crates-io]` horned-owl 1.4 fork to
+> released upstream horned-owl 3.0. `whelk-rs` pins `horned-owl = "^1.4"`
+> (upstream `whelk-rs` master still does), which excludes 3.x, so the
+> comparator could no longer build. The findings below stand — the comparison
+> campaign that produced them is complete, and it found 2 real rustdl EL gaps
+> (since fixed) and concluded whelk-rs itself is unsound on some patterns.
+> Reviving the in-process comparator needs `whelk-rs` upgraded to horned-owl
+> 3.x upstream.
+
 whelk-rs (INCATools, a Rust port of Balhoff's Scala *whelk*) is rustdl's closest
 comparator: another **native-Rust, consequence-based EL** reasoner. This is the
 head-to-head across every axis, for paper positioning.


### PR DESCRIPTION
Closes #99. Closes #123.

Upgrades `horned-owl` from a pinned `[patch.crates-io]` fork (1.4) to released upstream **3.0**, and retires the one feature that cannot survive it.

## #99's premise was wrong — every stated blocker is already resolved upstream

The issue recorded this as a blocked major-version upgrade requiring reimplementation across a licence boundary. Probed against the 3.0.0 source:

| #99 claimed | upstream 3.0.0 |
|---|---|
| `io::omn::AsManchester` — "404, fork-only" | **public**, re-exported as `io::omn::AsManchester` |
| the method rustdl calls at 6 sites | `as_manchester_with_prefixes` — **identical signature** |
| LGPL-vs-Apache/MIT reimplementation needed | **moot**, nothing to reimplement |
| "major-version upgrade, 1.4 → 3.x" | **two-line `Cargo.toml` change** |

Upstream is also *more* complete than the fork: **17 `AsManchester` impls vs 13**, adding the SWRL `Atom` / `DArgument` / `IArgument` / `Variable` shapes. Dropping the patch gains rendering coverage.

The "404" was presumably probed before it landed, or read off a docs path that does not exist while the re-export does.

## It closes #123 for free

The fork's RDF/XML reader carried a literal `// TODO!` above `ox_quad.unwrap()`; upstream replaced it with `map_err(…)?`. Both panicking ontologies now fail cleanly:

```
gsso   rc=101 panic  ->  rc=1 with a diagnostic
htn    rc=101 panic  ->  rc=1 with a diagnostic
```

That restores the graceful-degradation contract for the RDF/XML path: a diagnostic and a classifiable exit code instead of an aborted process.

## Retired: `whelk-compare`

`whelk-rs` pins `horned-owl = "^1.4"` — a caret range excluding 3.x — so `whelk::translate_ontology` wants `SetOntology` from 1.4 while the bench crate now parses with 3.0 (`E0308`, two majors in one graph). Upstream `whelk-rs` master still pins `^1.4`, so this is not a rev bump. It broke only CI's `cargo clippy --workspace --all-targets --all-features`.

The comparison campaign this existed for is **complete and recorded**: `docs/whelk-rs-comparison-2026-07-08.md` found 2 real rustdl EL gaps (both since fixed) and concluded whelk-rs is itself unsound on some patterns. Those documents are **kept untouched** — they are findings, not tooling — with a retirement note added saying what reviving it would need.

Worth recording: the `matrix/*.rs` "whelk-rs" comparator slot **never actually ran** the in-process comparator. It reported `na` regardless of the feature, so that slot was a latent instrument that never fired.

## Consequences

- `owl-dl-cli` is **publishable again** — `publish = false` removed. That unblocks `cargo install rustdl`, which was the practical cost #99 was filed over.
- **One `horned-owl` in the graph** (3.0.0), down from two; zero `whelk` entries; zero `[patch.crates-io]` sections.
- An **LGPL-3.0 dependency edge is gone** from everything shipped — the licence-hygiene win #99 wanted, reached from the other end.
- `owl-dl-bench` keeps `publish = false` (still an internal dev tool) but its justification is corrected — the "whelk dep is git-only" half no longer applies.

## Verification

**Answer-preserving on every entailment surface measured — plus one input-acceptance change, recorded below.** Checked on real output rather than by compiling:

| surface | result |
|---|---|
| `justify` / `--all` / `--laconic`, `explain`, `diagnose`, `report`, `prove` | **byte-identical** (229 / 190 / 480 bytes of real output) |
| `classify --json --pair-timeout-ms 1000` on pizza | **183 rows, identical set**, 2 unsat, `incomplete: false` both |

At the *default* budget the two binaries differ — that is pizza's documented truncation nondeterminism, demonstrated rather than assumed: the **unchanged** fork binary varies **171 / 172 / 176** rows across three runs of its own. Hence the comparison at a non-truncating budget.

**Gates:** `cargo test --workspace --exclude owl-dl-py` **1974 passed / 0 failed / 85 ignored**; `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (the job that was failing `E0308`); `cargo tree | grep -c 'horned-owl v1.4'` = **0**.

### CORRECTION: one input-acceptance change, and the exclusion that hid it

This description originally called the upgrade "answer-preserving" without qualification, and said `owl-dl-py` was excluded for a reason "unrelated to this change." **Both needed fixing, and the second is the one that mattered.**

**3.0 rejects an IRI that 1.4 accepted.** `Prefix(:=<urn:>)` parses under the fork and fails upstream with `expected RFC3987_IriHierPart`. This is a *parser strictness* difference, not an answer difference — no entailment moved; an input the front end used to accept is now refused. It failed **8 of 68 pytest cases on both Python 3.10 and 3.13** while all eight Rust jobs passed.

RFC 3987 permits `ipath-empty`, so `urn:` **is** a legal IRI and 3.0 is over-strict here — **already filed upstream as [phillord/horned-owl#292](https://github.com/phillord/horned-owl/issues/292)** (open), which pins the root cause in the grammar rather than just the symptom: `src/grammars/rfc3987.pest:28` reads `RFC3987_IriPathEmpty = ${ "0" ~ RFC3987_IriIpChar }`, a mis-transcription of RFC 3986's ABNF `path-empty = 0<pchar>` — where `0<pchar>` means *zero* repetitions, i.e. the empty string, not a literal `0`. So the rule matches `0a` and never matches empty, leaving `RFC3987_IriHierPart` with no empty-path alternative. Verified in the vendored 3.0.0 we depend on. It also affects `<mailto:>` and `<tel:>`.

Not worth waiting on, because the reach here is **zero real-world**:

| surface | bare `<urn:>` |
|---|---|
| 1,920 ORE ontologies | **0** |
| 190 OBO ontologies | **0** |
| in-tree fixtures | **1** (this repo's own Python test) |

A repo-wide *unfiltered* scan (not extension-filtered — the first pass was, and would have missed this) finds it nowhere else except historical plan documents under `docs/superpowers/plans/`, which nothing executes. No `.rs` doc comment carries the pattern, so there is no doctest exposure.

Fixed in `f8a4fcc` by moving to `<http://ex/#>`, the prefix the neighbouring Python tests already use 15 times. Because the assertions hardcode *expanded* IRIs, the prefix and the 14 `urn:Bad`-style references must move together — changing only the prefix trades 8 failures for 7 different ones, which is exactly what the first attempt did.

**The exclusion is what let this reach CI, and it was avoidable.** The `cargo test -p owl-dl-py` failure is real and environmental, but it is confined to the **lib-test** target; the **cdylib** builds fine under maturin. So `pip install ./crates/owl-dl-py` + `pytest` — the exact path CI uses — was reproducible locally the whole time. Now run: **67 passed, 1 skipped, 0 failed** on 3.10 (3.13 covered by CI; the 8 failures were identical across both jobs, so one interpreter is sufficient evidence for *this* fix). Inferring "unrelated to this change" from "does not link here" was the error — a crate you cannot test is not a crate that cannot break.

**Scope of that claim, stated precisely.** The census above establishes that **`<urn:>` specifically** has zero real-world reach. It does **not** establish that `<urn:>` is the only IRI form 1.4 accepted and 3.0 refuses — this one was found because CI failed, not by enumerating the class, and the parser is the component this PR actually replaced while the identity evidence above is *reasoning* output over a handful of fixtures. The discriminating check is a two-arm **parse-only** accept/reject sweep over the corpus (`locality-stats` runs parse+convert with no reasoning), comparing exit status per file, with the 1.4 arm built from `ded32b6` since this PR deletes the `[patch.crates-io]` block it needs. **Not yet run** — recorded here as the outstanding pre-merge check rather than left implied.

### THE CHECK RAN, AND IT FOUND A REAL REGRESSION: 7 of 1,920 ORE ontologies no longer parse

**This supersedes the "zero real-world reach" framing above, which was correct only for `<urn:>` specifically.** The empty-path class really is absent from both corpora — a grep for `<scheme:>` across all 2,110 files (1,920 ORE + 190 OBO), calibrated against a known positive, finds **0**. But 3.x *also* began validating IRIs against `RFC3987_Iri` generally, and that tightening is **not** inert:

| | 1.4 (fork) | 3.0 |
|---|---|---|
| `ore_ont_10197`, `11411`, `16542`, `9694`, `9881` | **parses** | `expected RFC3987_IriPctEncoded or RFC3987_IriUCSChar` |
| `ore_ont_20`, `5753` | **parses** | same |

Both binaries pin-verified against a discriminating input (`<urn:>` → rc 0 on 1.4, rc 1 on 3.0), single-thread, 120 s cap. Two distinct causes, both genuinely invalid per RFC 3987:

- **5 files carry U+FFFD** (`ef bf bd`) inside IRIs — 85–86 occurrences each, a mojibake'd `Baden-Württemberg` in `puls.cs.helsinki.fi/med/expression1#…`. U+FFFD is outside `ucschar`, so it is not a legal IRI character.
- **2 files carry `[`, `]`, `,`** in IRI fragments — ~138,000 occurrences each, `lod-analysis-properties-data.owl#[dul:Entity,dul:Concept]`.

**3.0 is right and 1.4 was lenient**, so this is a deliberate upstream tightening, not an upstream bug — consistent with horned-owl #232/#234 (writer emitting unescaped `[`/`]`) having been fixed. #292's empty-path fix does **not** help these; it is a different rule.

**The consequence for rustdl is what needs a decision.** A parse abort happens *before* conversion, so it cannot degrade: `convert_ontology`'s graceful-degradation contract (#43) records unsupported content in `dropped` and reasons over the rest, but an invalid IRI loses the **whole ontology**. Seven real ontologies that this repo processed at `ded32b6` do not parse at all after this PR.

Not fixed here, and deliberately not papered over. The options are to accept and document it as a known limitation, to ask upstream for a lenient/recovery mode on the reader, or to sanitize invalid IRI characters at read time — the last being semantically fraught, since rewriting an IRI changes entity identity.

**Method note, since it nearly cost the finding.** I had argued for replacing this two-arm sweep with a grep, on the grounds that #292 pins the root cause and the affected class is analytically enumerable. That reasoning was sound for `path-empty` and **wrong overall**: the grep returned 0, and only actually running the parser found the seven. The residual it could not see — "3.x validates IRIs more strictly in ways unrelated to this rule" — was the part that mattered.

One methodological note, since it nearly reached this description: the first Manchester comparison I ran was **vacuous**. `ontologies/real/` is gitignored, absent in a fresh worktree, so both binaries failed identically and `cmp` reported "IDENTICAL" on two error messages. The numbers above are from a re-run with an absolute fixture path and a non-empty-output assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzVE2TSVVMc3n8Wrce65Jg



