### PR TITLE
fix(datatypes): give the XSD integer-derived types a DKey bucket (#121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1674,6 +1674,57 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
     is most likely the bucket element growing and costing cache in the k² scan; if it ever
     needs to be cheap, shrink the ELEMENT or index the loop.
     Canaries `crates/owl-dl-reasoner/tests/data_union_of_intervals.rs`.
+  - **XSD integer-DERIVED datatypes (`xsd:int`, `xsd:long`, …) — CLOSED 2026-09-07 (#121,
+    unflagged).** `parse_integer_range` keyed on the EXACT `xsd:integer` IRI, so every derived
+    type had no bucket and the whole axiom dropped — `xsd:int` MISSED where `xsd:integer`
+    derived. A SOUND, SURFACED under-approximation (`dropped` was non-empty), so a completeness
+    fix, not a D10. Each type now maps to its exact bounded `IntegerRange`
+    (`int → [-2^31, 2^31-1]`, `nonNegativeInteger → [0, ∞)`, …); they share ONE value space so
+    they share the integer bucket and `IntegerRange::subset` gives the type hierarchy for free.
+    Deliberately unlike the `xsd:float`/`xsd:double` split, where the value spaces genuinely
+    differ and SEPARATE buckets are what keeps them sound.
+    **EXACTNESS IS LOAD-BEARING IN BOTH DIRECTIONS, which is why `xsd:unsignedLong` still
+    DROPS.** Its max `2^64 - 1` does not fit `IntegerRange`'s `i64`, and *neither* approximation
+    is safe: wider makes `nonNegativeInteger ⊆ unsignedLong` derivable, narrower makes
+    `unsignedLong ⊆ [0, i64::MAX]` derivable, and both are FALSE POSITIVES. A canary pins the
+    visible drop and says to FLIP it if `IntegerRange` ever widens to `i128`.
+    **A `DatatypeRestriction` on a derived type must INTERSECT with the datatype's own space** —
+    `xsd:byte` capped at 200 is still `[-128, 127]`. Taking the facets alone was correct when
+    only `xsd:integer` reached that arm (its base is unbounded) and is not now. Discriminator:
+    value 150 → unsat with the intersect, sat without; 100 stays sat.
+    **CORPUS REACH IS NOT ZERO HERE — 341 of 1,920 (17.8%) — and that is unusual for this
+    subsystem, so the sweep is load-bearing rather than non-regression theatre.** Two-arm
+    (pinned `fada7c2a`/`4aeb336e`, pin verified behaviourally, arm order alternated, sequential
+    on an idle host): **329 IDENTICAL / 9 BOTH_DNF / 3 DIFFER / 0 REGRESSED / 0 RECOVERED**, and
+    all 3 DIFFERs show `dropped` FALLING, the intended effect. `ore_ont_11647` is a real gain:
+    **+60 closure pairs, 0 lost, all 60 Konclude-confirmed**, drops 66 → 36.
+    **MY FRAME GREP WAS WRONG BY ~85× AND NEARLY SKIPPED THE SWEEP.** A full-IRI grep
+    (`XMLSchema#int`) found **4** ontologies; the pool writes prefixed `xsd:int`, and the real
+    frame is **341**, with 28,380 `xsd:int` occurrences in `DataPropertyRange` positions. Had I
+    trusted it I would have declared reach negligible and gated on canaries alone.
+    **THREE RUNS ARE NOT ENOUGH ON A BUDGET-TRUNCATED ONTOLOGY — it took NINE per arm.**
+    `ore_ont_16420` and `ore_ont_9577` (both `incomplete: true`) each "lost"
+    `Quotation ⊑ InheritableType`. On `9577` the first **3 AFTER runs all missed it while BEFORE
+    produced it 2/3**, which reads as a systematic loss; six more runs give **AFTER 4/9, BEFORE
+    6/9** — both arms nondeterministic, zero real losses. This is the sibling of the recorded
+    `ore_ont_1508` case where a third run refuted a two-run control.
+    **THE TWO ORACLES SPLIT BY QUESTION, so name which one answers which.** `HermiT` decides the
+    type hierarchy and agrees 4/4 (`int`-inside-`integer` and `short`-inside-`int` derived, both
+    converses refused); **Konclude reports NOTHING on any of the four, including the positives** —
+    a further under-report, and that reading is licensed by a DISCRIMINATING CONTROL rather than
+    assumed: adding a plain `SubClassOf(:C :E)` makes Konclude report `C ⊑ E` while still omitting
+    the datatype pair, so it is reasoning over the file. Conversely the corpus gain rests on
+    **Konclude alone** — `HermiT` via robot dies on `ore_ont_11647` with an `axiom-impl` classpath
+    error, minutes after working on the small fixtures, so that ontology is single-oracle.
+    **SABOTAGE: 5 run, 5 caught**, three by exactly one test each — the naive all-unbounded
+    mapping (3 tests, incl. the FP guard), reverting to `xsd:integer`-only (3), dropping the facet
+    intersect (1), under-approximating `unsignedLong` (1), cross-seeding `decimal` (1).
+    **A PROBE THAT CANNOT PRODUCE A POSITIVE PROVES NOTHING ABOUT FALSE ONES.** The first
+    direction probe used two `SubClassOf` NECESSARY conditions (`A ⊑ ∃p.int`, `B ⊑ ∃p.integer`),
+    which cannot entail `A ⊑ B` — it answered "no" for every pair and read as "no FPs" while being
+    vacuous. The target needs the SUFFICIENT direction (`∃p.integer ⊑ W`). Same shape as #42's
+    vacuous subset canary. Gates: suite 1981/0; FP=0 net 21 VERIFIED, every closure exact; clippy
+    clean. Canaries `crates/owl-dl-reasoner/tests/xsd_integer_derived_datatypes.rs` (7).
   - **STILL DROPPED (sound), recorded rather than implied:** unions with any member no
     integer interval set can express — bare DATATYPES (`xsd:decimal`), `DataComplementOf`,
     other-datatype enumerations — which drop WHOLE and VISIBLY (`dropped` is non-empty),

--- a/crates/owl-dl-core/src/data_axioms.rs
+++ b/crates/owl-dl-core/src/data_axioms.rs
@@ -2010,24 +2010,68 @@ fn scan_class_for_existentials<A: ForIRI>(class_iri: &str, ce: &ClassExpression<
 /// datatypes, unrecognized facets, unparseable literals, or
 /// overflowing exclusive-bound adjustments — sound under-approximation:
 /// unrecognized ranges contribute no constraint (vs. wrong constraints).
+/// The value space of an XSD integer-derived datatype, as an `IntegerRange`,
+/// or `None` if this is not one we can represent EXACTLY.
+///
+/// `xsd:integer` is unbounded; every derived type is a bounded sub-range of it
+/// (XSD 1.1 §3.4). Because they all live in ONE value space, they share the
+/// integer `DKey` bucket and `IntegerRange::subset` gives the type hierarchy
+/// for free — `int ⊆ integer` holds and the converse does not. This is
+/// deliberately unlike the `xsd:float`/`xsd:double` split, where the value
+/// spaces genuinely differ and SEPARATE buckets are what keeps them sound (the
+/// v0.4.6–v0.4.9 FP).
+///
+/// **EXACTNESS IS LOAD-BEARING — neither direction of approximation is safe.**
+/// A range WIDER than the truth makes `nonNegativeInteger ⊆ unsignedLong`
+/// derivable, which is false. A range NARROWER than the truth makes
+/// `unsignedLong ⊆ [0, i64::MAX]` derivable, which is also false. Both are
+/// FALSE POSITIVES, in opposite directions, so a type we cannot express
+/// exactly must keep DROPPING rather than be approximated.
+///
+/// That is why **`xsd:unsignedLong` is absent**: its maximum is `2^64 - 1`,
+/// which does not fit the `i64` bounds of `IntegerRange`. It continues to drop
+/// VISIBLY (`dropped` is non-empty), which is the sound, surfaced behaviour.
+/// `xsd:decimal` is absent for a different reason — it is a distinct value
+/// space with its own `dec:` bucket, and integer/decimal are deliberately never
+/// cross-seeded.
+fn xsd_integer_derived_range(local: &str) -> Option<IntegerRange> {
+    let (min, max) = match local {
+        "integer" => (None, None),
+        "long" => (Some(i64::MIN), Some(i64::MAX)),
+        "int" => (Some(-2_147_483_648), Some(2_147_483_647)),
+        "short" => (Some(-32_768), Some(32_767)),
+        "byte" => (Some(-128), Some(127)),
+        "nonNegativeInteger" => (Some(0), None),
+        "positiveInteger" => (Some(1), None),
+        "nonPositiveInteger" => (None, Some(0)),
+        "negativeInteger" => (None, Some(-1)),
+        "unsignedInt" => (Some(0), Some(4_294_967_295)),
+        "unsignedShort" => (Some(0), Some(65_535)),
+        "unsignedByte" => (Some(0), Some(255)),
+        // "unsignedLong" is NOT here on purpose — see the doc comment.
+        _ => return None,
+    };
+    Some(IntegerRange { min, max })
+}
+
 pub(crate) fn parse_integer_range<A: ForIRI>(dr: &DataRange<A>) -> Option<IntegerRange> {
-    const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
     match dr {
         // Phase D6 (Part A): a bare `xsd:integer` datatype (no facet) is
         // the unbounded integer range. `DataSomeValuesFrom(p, xsd:integer)`
         // thus lowers to `∃p.DKey(-∞,+∞)` — a sound necessary condition
         // that keeps the enclosing conjunction alive (e.g. Prime/Zoom).
-        DataRange::Datatype(dt) if dt.0.to_string() == XSD_INTEGER => {
-            Some(IntegerRange::unbounded())
-        }
-        // Only xsd:integer for Tier C; other numeric datatypes
-        // (xsd:decimal, xsd:dateTime) extend with their own range types
-        // but share this preprocessing's algebra. Float/double are
-        // handled by `parse_xsd_float_range`/`parse_xsd_double_range`
-        // (DISTINCT datatype buckets — see the DKey datatype-tagging in
-        // `convert.rs`).
-        DataRange::DatatypeRestriction(dt, facets) if dt.0.to_string() == XSD_INTEGER => {
-            parse_integer_facets(facets)
+        // Since #121 the integer-DERIVED types resolve here too, each to its
+        // own exact bounded range, so `xsd:int` is no longer dropped.
+        DataRange::Datatype(dt) => xsd_integer_derived_range(dt.0.to_string().strip_prefix(XSD)?),
+        // A restriction TIGHTENS the datatype's own value space, so the two
+        // must be intersected: `xsd:int` with `minInclusive 0` is `[0, 2^31-1]`,
+        // not `[0, +∞)`. Before #121 only `xsd:integer` reached here, whose base
+        // range is unbounded, which is why taking the facets alone was correct
+        // then and is not now.
+        DataRange::DatatypeRestriction(dt, facets) => {
+            let base = xsd_integer_derived_range(dt.0.to_string().strip_prefix(XSD)?)?;
+            Some(base.intersect(parse_integer_facets(facets)?))
         }
         _ => None,
     }

--- a/crates/owl-dl-reasoner/tests/xsd_integer_derived_datatypes.rs
+++ b/crates/owl-dl-reasoner/tests/xsd_integer_derived_datatypes.rs
@@ -1,0 +1,211 @@
+//! #121 — the XSD integer-DERIVED datatypes (`xsd:int`, `xsd:long`, …) must get
+//! a `DKey` bucket instead of dropping.
+//!
+//! `parse_integer_range` keyed on the exact `xsd:integer` IRI, so every derived
+//! type had no bucket and the whole axiom dropped — `xsd:int` MISSED where
+//! `xsd:integer` derived, with `dropped: {'SubClassOf: unsupported data range'}`.
+//! That was a SOUND, SURFACED under-approximation (a caller could tell), which is
+//! why this is a completeness fix and not a D10.
+//!
+//! **DIRECTION OF RISK IS A FALSE POSITIVE**, because the fix ADDS subsumptions:
+//! all these types share ONE value space and therefore one bucket, so
+//! `IntegerRange::subset` gives the type hierarchy directly. The negative
+//! controls below carry the weight — `∃p.xsd:integer ⊑ ∃p.xsd:int` must NOT be
+//! derivable, since `xsd:int` is the NARROWER type.
+//!
+//! **EXACTNESS IS LOAD-BEARING, in BOTH directions.** A range wider than the
+//! truth makes `nonNegativeInteger ⊆ unsignedLong` derivable; a range narrower
+//! than the truth makes `unsignedLong ⊆ [0, i64::MAX]` derivable. Both are false.
+//! So `xsd:unsignedLong`, whose max `2^64 - 1` does not fit `IntegerRange`'s
+//! `i64`, keeps DROPPING — pinned below.
+//!
+//! **PROBE SHAPE MATTERS AND THE FIRST VERSION OF IT WAS VACUOUS.** Two
+//! `SubClassOf` NECESSARY conditions (`A ⊑ ∃p.int`, `B ⊑ ∃p.integer`) cannot
+//! entail `A ⊑ B` — `B` is not defined by its condition — so that probe answered
+//! "no" for every pair and could not have produced a positive either. The target
+//! needs the SUFFICIENT direction (`∃p.integer ⊑ W`). See
+//! [[tests-that-pin-the-bug]]; the sibling trap is #42's vacuous subset canary.
+//!
+//! ORACLE: **`HermiT` 1.4.3 is the oracle here and agrees 4/4** on the adjudicated
+//! probes — it derives `A ⊑ W` for `int`-inside-`integer` and `short`-inside-`int`
+//! and refuses both converses. **Konclude v0.7.0-1138 reports NOTHING on any of
+//! the four, including the positives**, which is a further instance of the
+//! under-reporting this repo already records. That reading is licensed by a
+//! DISCRIMINATING CONTROL, not assumed: adding a plain `SubClassOf(:C :E)` to the
+//! same file makes Konclude report `C ⊑ E` while still omitting `A ⊑ W`, so it is
+//! reasoning over the file and simply not over these datatypes.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::{classify_top_down_with_timeout, dropped_axioms};
+use std::io::Cursor;
+use std::time::Duration;
+
+const PRE: &str = "Prefix(:=<http://ex.org/>)\n\
+     Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n";
+
+fn parse(ofn: &str) -> SetOntology<RcStr> {
+    let mut reader = Cursor::new(ofn.to_string());
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    onto
+}
+
+/// `A` carries a `have` value; anything carrying a `target` value is `W`.
+/// Returns whether `A ⊑ W` is derived. The SUFFICIENT direction on `target` is
+/// what makes this non-vacuous — see the module header.
+fn a_is_w(have: &str, target: &str) -> bool {
+    let ofn = format!(
+        "{PRE}Ontology(<http://ex.org/o>\n\
+         Declaration(Class(:A)) Declaration(Class(:W)) Declaration(DataProperty(:dp))\n\
+         SubClassOf(:A DataSomeValuesFrom(:dp xsd:{have}))\n\
+         SubClassOf(DataSomeValuesFrom(:dp xsd:{target}) :W)\n)\n"
+    );
+    let onto = parse(&ofn);
+    let r = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+    r.is_subclass("http://ex.org/A", "http://ex.org/W")
+}
+
+/// Every representable integer-derived type must now reach its own bucket, so a
+/// value of that type satisfies a restriction to the SAME type.
+#[test]
+fn each_integer_derived_type_reaches_a_bucket() {
+    for t in [
+        "integer",
+        "long",
+        "int",
+        "short",
+        "byte",
+        "nonNegativeInteger",
+        "positiveInteger",
+        "nonPositiveInteger",
+        "negativeInteger",
+        "unsignedInt",
+        "unsignedShort",
+        "unsignedByte",
+    ] {
+        assert!(a_is_w(t, t), "xsd:{t} must reach an integer DKey bucket");
+    }
+}
+
+/// The narrower type's values sit inside the wider type. These are the pairs
+/// `HermiT` confirms.
+#[test]
+fn a_narrower_type_is_subsumed_by_a_wider_one() {
+    for (narrow, wide) in [
+        ("int", "integer"),
+        ("long", "integer"),
+        ("int", "long"),
+        ("short", "int"),
+        ("byte", "short"),
+        ("positiveInteger", "nonNegativeInteger"),
+        ("unsignedByte", "unsignedShort"),
+        ("unsignedInt", "long"),
+    ] {
+        assert!(
+            a_is_w(narrow, wide),
+            "xsd:{narrow} ⊆ xsd:{wide} must be derived"
+        );
+    }
+}
+
+/// THE FP GUARD, and the whole reason this fix needs controls. Mapping a derived
+/// type to the same UNBOUNDED range as `xsd:integer` would make these mutually
+/// subsumable and every one of them would fire.
+#[test]
+fn a_wider_type_is_not_subsumed_by_a_narrower_one() {
+    for (wide, narrow) in [
+        ("integer", "int"),
+        ("integer", "long"),
+        ("long", "int"),
+        ("int", "short"),
+        ("short", "byte"),
+        ("nonNegativeInteger", "positiveInteger"),
+        ("unsignedShort", "unsignedByte"),
+    ] {
+        assert!(
+            !a_is_w(wide, narrow),
+            "xsd:{wide} ⊄ xsd:{narrow} — the wider type is NOT inside the narrower one"
+        );
+    }
+}
+
+/// Ranges that overlap in neither direction must stay unrelated both ways.
+#[test]
+fn incomparable_types_are_related_in_neither_direction() {
+    for (a, b) in [
+        ("positiveInteger", "negativeInteger"),
+        ("unsignedByte", "negativeInteger"),
+    ] {
+        assert!(!a_is_w(a, b), "xsd:{a} ⊄ xsd:{b}");
+        assert!(!a_is_w(b, a), "xsd:{b} ⊄ xsd:{a}");
+    }
+}
+
+/// `xsd:integer` and `xsd:decimal` are DISTINCT value spaces with distinct
+/// buckets and are deliberately never cross-seeded, so widening the integer
+/// parser must not have leaked across. `dt_family` lumps both under `Numeric`,
+/// which is a different classification and must not be mistaken for a bucket.
+#[test]
+fn the_integer_family_does_not_cross_seed_with_decimal() {
+    assert!(!a_is_w("int", "decimal"), "int must not reach dec:");
+    assert!(
+        !a_is_w("decimal", "int"),
+        "decimal must not reach the int bucket"
+    );
+}
+
+/// `xsd:unsignedLong`'s max is `2^64 - 1`, outside `IntegerRange`'s `i64`, and
+/// NEITHER direction of approximation is sound (see the module header). So it
+/// keeps dropping, and the drop stays VISIBLE.
+///
+/// If `IntegerRange` ever widens to `i128`, FLIP this test rather than deleting
+/// it — `unsignedLong` becomes representable and should join the family.
+#[test]
+fn unsigned_long_is_not_representable_and_still_drops_visibly() {
+    let ofn = format!(
+        "{PRE}Ontology(<http://ex.org/o>\n\
+         Declaration(Class(:A)) Declaration(Class(:W)) Declaration(DataProperty(:dp))\n\
+         SubClassOf(:A DataSomeValuesFrom(:dp xsd:unsignedLong))\n\
+         SubClassOf(DataSomeValuesFrom(:dp xsd:unsignedLong) :W)\n)\n"
+    );
+    let onto = parse(&ofn);
+    assert!(
+        !dropped_axioms(&onto).expect("dropped_axioms").is_empty(),
+        "an unrepresentable data range must drop VISIBLY, never silently"
+    );
+    assert!(!a_is_w("unsignedLong", "unsignedLong"));
+}
+
+/// A `DatatypeRestriction` TIGHTENS the datatype's own value space, so the two
+/// must be INTERSECTED. `xsd:byte` capped at 200 is still `[-128, 127]`, so the
+/// value 150 lies outside it and the class is unsatisfiable.
+///
+/// This is the discriminator for the intersect: taking the facets alone gives
+/// `(-∞, 200]`, which CONTAINS 150, and the probe would read `sat`. Before #121
+/// only `xsd:integer` reached that arm, whose base range is unbounded, which is
+/// why facets-alone was correct then and is not now.
+#[test]
+fn a_restriction_on_a_derived_type_intersects_with_its_value_space() {
+    let probe = |value: &str| {
+        let ofn = format!(
+            "{PRE}Ontology(<http://ex.org/o>\n\
+             Declaration(Class(:A)) Declaration(DataProperty(:dp))\n\
+             SubClassOf(:A DataHasValue(:dp \"{value}\"^^xsd:integer))\n\
+             SubClassOf(:A DataAllValuesFrom(:dp DatatypeRestriction(xsd:byte \
+             xsd:maxInclusive \"200\"^^xsd:integer)))\n)\n"
+        );
+        let onto = parse(&ofn);
+        let r = classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify");
+        r.unsatisfiable_classes().contains(&"http://ex.org/A")
+    };
+    assert!(probe("150"), "150 is outside xsd:byte, so A must be unsat");
+    assert!(
+        !probe("100"),
+        "100 is inside xsd:byte — discriminating control"
+    );
+}


### PR DESCRIPTION
Closes #121.

## The defect

`parse_integer_range` keyed on the **exact** `xsd:integer` IRI, so every integer-**derived** type — `xsd:int`, `xsd:long`, `xsd:short`, `xsd:byte`, the `unsigned*` family, `nonNegativeInteger`, `positiveInteger` — had no `DKey` bucket and the whole axiom **dropped**. `dt_family` in the same file already classified all of them as `Numeric`, so one part of the crate knew `xsd:int` was an integer and the DKey parser did not.

| `<T>` in `DataSomeValuesFrom(:dp xsd:<T>)` | before | after |
|---|---|---|
| `integer` | `X ⊑ W` | `X ⊑ W` |
| `int`, `long`, `short`, `byte`, `nonNegativeInteger`, `positiveInteger`, `nonPositiveInteger`, `negativeInteger`, `unsignedInt`, `unsignedShort`, `unsignedByte` | **MISSED**, `dropped: {…×2}` | `X ⊑ W` |
| `unsignedLong` | MISSED, dropped | **MISSED, dropped** (deliberate — see below) |

This was a **sound, surfaced** under-approximation (`dropped` non-empty, so a caller could tell), hence a completeness fix and not a D10.

## The fix

Each type maps to its **exact** bounded `IntegerRange`. They all live in one value space, so they share the integer bucket and `IntegerRange::subset` gives the type hierarchy for free — `int ⊆ integer` holds, the converse does not. No new bucket, deliberately unlike the `xsd:float`/`xsd:double` split where the value spaces genuinely differ and *separate* buckets are what keeps them sound (the v0.4.6–v0.4.9 FP).

**Two things the issue did not call out, both of which changed the implementation:**

1. **`xsd:unsignedLong` cannot be included.** Its max is 2⁶⁴−1, outside `IntegerRange`'s `i64`, and **neither direction of approximation is safe** — wider makes `nonNegativeInteger ⊆ unsignedLong` derivable, narrower makes `unsignedLong ⊆ [0, i64::MAX]` derivable, and both are false positives. It keeps dropping visibly, pinned by a canary that says to **flip** it if `IntegerRange` ever widens to `i128`.
2. **A `DatatypeRestriction` on a derived type must intersect with the datatype's own space.** `xsd:byte` capped at 200 is still `[-128, 127]`. Facets-alone was correct when only `xsd:integer` reached that arm (base unbounded) and is not now. Discriminator: value 150 → `unsat` with the intersect, `sat` without; 100 stays `sat`.

## Direction of risk is a FALSE POSITIVE

The fix adds subsumptions, so the negative controls carry the weight: **8 positives derive, 7 FP guards refuse**, incomparable types stay unrelated both ways, and `decimal` does not cross-seed.

**A probe that cannot produce a positive proves nothing about false ones.** My first direction probe used two `SubClassOf` *necessary* conditions (`A ⊑ ∃p.int`, `B ⊑ ∃p.integer`), which cannot entail `A ⊑ B` — it answered "no" for every pair and read as "no false positives" while being **vacuous**. The target needs the *sufficient* direction (`∃p.integer ⊑ W`). Same shape as #42's vacuous subset canary.

## The two oracles split by question — so the PR names which answers which

- **`HermiT` decides the type hierarchy: agrees 4/4** (`int`-inside-`integer` and `short`-inside-`int` derived, both converses refused).
- **Konclude reports nothing on any of the four, including the positives** — a further under-report. That reading is licensed by a **discriminating control**, not assumed: adding a plain `SubClassOf(:C :E)` to the same file makes Konclude report `C ⊑ E` while still omitting the datatype pair, so it *is* reasoning over the file.
- Conversely the corpus gain below rests on **Konclude alone**: `HermiT` via robot dies on `ore_ont_11647` with an `axiom-impl` classpath error, minutes after working on the small fixtures. That ontology is single-oracle and this PR says so rather than implying agreement.

## Corpus reach is NOT zero here, so the sweep is load-bearing

**341 of 1,920 (17.8%)** — unusual for this subsystem, where recent fixes have been provably inert. Two-arm, pinned binaries (`fada7c2a` / `4aeb336e`, pin verified **behaviourally** before use), arm order alternated, sequential on an idle host, 60 s cap:

| verdict | count |
|---|---|
| IDENTICAL | 329 |
| BOTH_DNF | 9 |
| DIFFER | 3 |
| **REGRESSED / RECOVERED** | **0 / 0** |

All 3 DIFFERs show `dropped` **falling** — the intended effect. **`ore_ont_11647` is a real gain: +60 closure pairs, 0 lost, all 60 Konclude-confirmed**, drops 66 → 36.

**My frame grep was wrong by ~85× and nearly skipped this sweep.** A full-IRI grep (`XMLSchema#int`) found **4** ontologies; the pool writes *prefixed* `xsd:int`, and the real frame is **341**, with 28,380 occurrences in `DataPropertyRange` positions. Had I trusted it I would have declared reach negligible and gated on canaries alone.

**Three runs are not enough on a budget-truncated ontology — it took nine per arm.** `ore_ont_16420` and `ore_ont_9577` (both `incomplete: true`) each "lost" `Quotation ⊑ InheritableType`. On `9577` the first **3 AFTER runs all missed it while BEFORE produced it 2/3**, which reads as a systematic loss; six more give **AFTER 4/9, BEFORE 6/9** — both arms nondeterministic, **zero real losses**. Sibling of the recorded `ore_ont_1508` case where a third run refuted a two-run control.

## Sabotage: 5 run, 5 caught (three by exactly one test each)

| # | mutation | caught by |
|---|---|---|
| S1 | all derived types → unbounded (**the naive fix the issue warns about**) | 3 tests, incl. the FP guard |
| S2 | revert to `xsd:integer`-only | 3 tests |
| S3 | drop the facet intersect | the intersect test, **alone** |
| S4 | `unsignedLong` under-approximated to `[0, i64::MAX]` | the drop test, **alone** |
| S5 | `decimal` cross-seeded into the integer bucket | the cross-seed test, **alone** |

## Gates

- suite **1981 passed / 0 failed**
- FP=0 net **21 VERIFIED**, every closure exact, zero mismatches (galen 28007, sio 8904, ore-10080 32356, ore-10908 6001, wine 653, pizza 499, ro 158, ore-15672 142, sulo 51, bibtex 16). The NOT VERIFIED rows are all **absent fixtures** — the documented residual, not diffs.
- clippy `--all-targets --all-features` exit 0; `cargo fmt --check` clean
- Canaries `crates/owl-dl-reasoner/tests/xsd_integer_derived_datatypes.rs` (7)
- `owl-dl-py` fails to link locally; **confirmed pre-existing on clean `main`**, so not from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)