### PR TITLE
fix(saturation): lower an inverse-role ObjectPropertyDomain/Range (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2028,6 +2028,76 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   paths can label one logical nested-existential witness differently and get deduped into two
   separate elements — not shown unsound, but untested against a future concept-level check).
 
+> **AN INVERSE-ROLE DOMAIN/RANGE WAS DISCARDED UNDER A CORRECT IDENTITY (2026-09-08, #125,
+> unflagged).** Both `collect_el_rules` arms did nothing at all when `role.is_inverse()`, under
+> the comment *"inverse-role domain = forward range; handled by the tableau"*. **The identity is
+> right and the conclusion was false comfort for `classify`**: the pair was SILENTLY missed —
+> `direct_subsumptions: []`, `incomplete: false`, `dropped: {}` — while `subclass` answered `yes`
+> and both oracles derived it. D10 shape.
+>
+> **The fix is a TABLE FLIP, not a new rule.** `Domain(r⁻, C) ≡ Range(r, C)` and
+> `Range(r⁻, C) ≡ Domain(r, C)` are logical identities, and `Role::role_id` already returns the
+> underlying `r` for BOTH polarities, so the only thing an inverse changes is which table receives
+> the classes. Both arms now route through one `lower_domain_or_range`, and the polarity rule has a
+> single home in `constrains_sources` — called by Pass 1 AND both provenance mirrors, because a
+> mirror that decides polarity independently is exactly how #110 became #118/#119.
+> `⊥` now poisons the role in either polarity (`Domain(r⁻, ⊥)` is `Range(r, ⊥)`); it previously did
+> nothing.
+>
+> **DIRECTION OF RISK IS A FALSE POSITIVE — flipping the table the WRONG WAY asserts of a role's
+> SOURCES something true only of its TARGETS.** The guard that fails first is
+> `an_inverse_domain_does_not_constrain_the_forward_sources`. `HermiT` agrees 5/5 (both positives,
+> the FP guard, both `⊥` cases).
+>
+> **READ ROBOT'S ERROR STREAM, NOT JUST ITS OUTPUT FILE.** On an ontology with an unsatisfiable
+> class `robot reason` writes NO output file and reports the unsatisfiability on stderr. Grepping
+> the (absent) output file scores that as "the oracle did not confirm it" — which is what the first
+> version of this adjudication did, nearly recording a `HermiT` disagreement that does not exist.
+>
+> **FEATURE REACH IS PROVABLY ZERO; THE REFACTOR'S BLAST RADIUS IS 868 — DO NOT CONFLATE THEM.**
+> **0 of 1,920** ORE ontologies author an inverse `ObjectPropertyDomain`/`Range` (two instruments
+> agree, and all 1,920 pool files start with `Prefix(`, i.e. are OFN, so `ObjectInverseOf` is the
+> only spelling and the grep is a genuine superset). But folding both arms into a shared helper
+> touches the FORWARD path that **868** ontologies use, so the sweep is load-bearing here in a way
+> it was not for #110/#114/#84. Two-arm, pinned (`28010645`/`10ffcc2f`, verified behaviourally),
+> alternating, sequential: **816 IDENTICAL / 49 BOTH_DNF / 2 DIFFER / 1 "REGRESSED" — and all three
+> flagged rows adjudicate clean.** `ore_ont_205` and `7499` are byte-identical at
+> `--pair-timeout-ms 1000`; `ore_ont_2111` completes in BOTH arms at a 300 s cap, 8/8 runs, identical
+> 66,459 rows.
+>
+> **I CALLED `ore_ont_2111` A REAL REGRESSION AFTER 3 OF 6 DATA POINTS AND IT WAS NOISE.** AFTER had
+> DNF'd twice at 180 s while BEFORE completed in 89 s; the remaining runs showed BEFORE DNFing and
+> AFTER completing. Second instance in one session — see the #121 entry's nine-runs-per-arm case.
+> **Do not read a partial run on a cap-boundary ontology.** The mechanism check is what should have
+> led: all three flagged ontologies contain ZERO inverse domain/range, so the feature cannot fire on
+> them, and the mirrors only run under `record_proofs` so they are off the classify path entirely.
+>
+> **SABOTAGE: 4 run, 3 caught, 1 SURVIVED — and one canary was VACUOUS until sabotage exposed it.**
+> Caught: inverting the polarity (4 canaries + 4 prove + 5 neighbouring tests), reverting inverse to
+> a no-op (2 + 2), and dropping the `domain_axiom_refs` entry for an inverse range — caught by
+> exactly ONE prove test and by NO reasoner test, which is why that canary had to exist.
+> **The survivor** is dropping the mini Pass-1 sim's inverse-domain contributor: every test stays
+> green, on TWO separately constructed fixtures, the second built specifically to expose it per
+> #118's note that the damage lands on LATER axioms' cursors. Attribution came back byte-identical
+> both times. The arm is KEPT — it maintains the Pass-1 mirror invariant #118 established, and
+> failing to observe it is a limit of the fixtures, not evidence the arm is dead.
+> **The vacuous canary** asserted on a `ToldSubsumer` node that does not exist in that proof tree,
+> so it could never fire; retargeted to the folded `ObjectIntersectionOf(:B :P)` witness and
+> re-verified to fail under the no-op revert. Sibling of [[sabotage-your-own-guard-tests]].
+>
+> **A TEST WAS PINNING THIS BUG, AND IT WAS GUARDING A FLAG.**
+> `classify_inverse_domain.rs`'s `default_classify_off_misses_inverse_domain_subsumption` asserted
+> the default must NOT find `C ⊑ D`. It existed to document `RUSTDL_CLASSIFY_SAME_TIER`'s opt-in
+> semantics and used the inverse-domain miss as its VEHICLE. The fix gives `C` its EL subsumers,
+> which fixes the tier grouping as a side effect, so the default now derives a pair the flag-ON test
+> asserts on the SAME ontology. **Flipped, not deleted.** What is no longer guarded there is a
+> demonstration that the flag CHANGES behaviour — the default itself stays pinned by
+> `internal_flag_defaults`. The obvious retarget, `Domain(r, ∃s.Z)`, is **issue #124, an open
+> defect**, so pointing the test at it would re-create the identical trap the moment #124 closes.
+>
+> Canaries `crates/owl-dl-reasoner/tests/inverse_domain_range.rs` (7) +
+> `crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs` (4). Gates: suite 1990/0; clippy clean.
+
 > **A NON-ATOMIC GCI DOMAIN HEAD WAS DISCARDED, NOT DROPPED (2026-09-06, #114, unflagged) — THE
 > SAME D10 FAMILY AS #110, ONE SPELLING OVER.** `SubClassOf(ObjectSomeValuesFrom(:r owl:Thing), C)`
 > is the GCI spelling of `ObjectPropertyDomain(r, C)`. Its arm pushed

--- a/crates/owl-dl-cli/tests/fixtures/json/prove_inverse_domain.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/prove_inverse_domain.ofn
@@ -1,0 +1,11 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+Declaration(Class(:P))
+Declaration(Class(:X))
+Declaration(Class(:B))
+Declaration(Class(:D))
+Declaration(ObjectProperty(:r))
+SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+ObjectPropertyDomain(ObjectInverseOf(:r) :P)
+SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)
+)

--- a/crates/owl-dl-cli/tests/fixtures/json/prove_inverse_range.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/json/prove_inverse_range.ofn
@@ -1,0 +1,9 @@
+Prefix(:=<http://ex/#>)
+Ontology(<http://ex/>
+Declaration(Class(:P))
+Declaration(Class(:X))
+Declaration(Class(:B))
+Declaration(ObjectProperty(:r))
+SubClassOf(:X ObjectSomeValuesFrom(:r :B))
+ObjectPropertyRange(ObjectInverseOf(:r) :P)
+)

--- a/crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs
+++ b/crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs
@@ -179,3 +179,77 @@ fn prove_attributes_a_conjunctive_range_derived_subsumption_to_its_axiom() {
         );
     }
 }
+
+/// #125, DOMAIN mirror — `Range(r⁻, P) ≡ Domain(r, P)`, so an INVERSE range feeds
+/// `role_domains` and its derived step must cite the `ObjectPropertyRange` axiom.
+///
+/// Before #125 the `domain_axiom_refs` collector matched only `ObjectPropertyDomain`
+/// on a NON-inverse role, so this step printed `(Domain(sub)) ⊢ X SubClassOf P`
+/// with an EMPTY `axiom_refs` — the same silent shape as #118, one polarity over.
+#[test]
+fn prove_attributes_an_inverse_range_derived_subsumption_to_its_axiom() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/prove_inverse_range.ofn"
+    );
+    let out = rustdl()
+        .args(["prove", "--json", path, "http://ex/#X", "http://ex/#P"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(v["entailed"], true, "Range(r⁻,P) makes every r-source a P");
+    assert_eq!(v["has_proof"], true);
+    assert_eq!(v["proof"]["rule"].as_str().unwrap(), "Domain(sub)");
+    let axioms: Vec<&str> = v["proof"]["axioms"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a.as_str().unwrap())
+        .collect();
+    assert!(
+        axioms.iter().any(|a| a.contains("ObjectPropertyRange")),
+        "the inverse-range-derived step must cite its ObjectPropertyRange axiom; got {axioms:?}"
+    );
+}
+
+/// #125 — the INVERSE-DOMAIN range fold must reach the witness and stay attributed.
+///
+/// `Domain(r⁻, P) ≡ Range(r, P)`, so `X`'s `r`-witness must be a `B ⊓ P`, which is
+/// what lets `∃r.(B ⊓ P) ⊑ D` fire. The discriminating check is that the `ToldFact`
+/// leaf's CONCLUSION carries the folded `ObjectIntersectionOf(:B :P)` — reverting the
+/// inverse handling leaves it as a bare `∃r.B` and the proof disappears entirely.
+///
+/// **This does NOT guard the mini Pass-1 range mirror**, and the distinction is
+/// recorded rather than blurred: dropping that mirror's inverse-domain contributor
+/// leaves this test — and every other test in the repo — green, on two separately
+/// constructed fixtures. See the sabotage note in the #125 commit.
+#[test]
+fn prove_attributes_an_inverse_domain_range_fold_to_its_axiom() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/json/prove_inverse_domain.ofn"
+    );
+    let out = rustdl()
+        .args(["prove", "--json", path, "http://ex/#X", "http://ex/#D"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is valid JSON");
+    assert_eq!(
+        v["entailed"], true,
+        "Domain(r⁻,P) folds P into the r-witness"
+    );
+    assert_eq!(v["has_proof"], true);
+
+    let mut nodes = Vec::new();
+    collect_nodes(&v["proof"], &mut nodes);
+    let folded = nodes.iter().any(|(rule, concl, axioms)| {
+        *rule == "ToldFact" && concl.contains("ObjectIntersectionOf") && !axioms.is_empty()
+    });
+    assert!(
+        folded,
+        "expected an attributed ToldFact whose witness carries the folded range \
+         ObjectIntersectionOf(:B :P); got {nodes:?}"
+    );
+}

--- a/crates/owl-dl-reasoner/tests/classify_inverse_domain.rs
+++ b/crates/owl-dl-reasoner/tests/classify_inverse_domain.rs
@@ -121,24 +121,45 @@ fn default_classify_finds_inverse_domain_subsumption() {
     );
 }
 
-/// Documents opt-in semantics: with SP1.1 OFF (default), the inverse-domain
-/// same-tier subsumption C ⊑ D is NOT found by classify. This is expected —
-/// the feature is corpus-invisible and ~2× wall, so it defaults OFF.
+/// **FLIPPED by #125 — this asserted the OPPOSITE until the engine learned
+/// `Domain(p⁻, H)`.**
+///
+/// It was written to document `RUSTDL_CLASSIFY_SAME_TIER`'s opt-in semantics, and
+/// used this inverse-domain fixture as its VEHICLE: with the flag off the tier walk
+/// missed `C ⊑ D`, so "the default misses it" doubled as "the flag does something".
+/// #125 made the saturator lower `Domain(p⁻, H)` as `Range(p, H)`, which gives `C`
+/// its EL subsumers, which fixes the tier grouping as a side effect — so the DEFAULT
+/// now derives `C ⊑ D` with no flag at all. The pair is genuinely entailed (the
+/// flag-ON test above asserts it must be found, on this same ontology), so this is
+/// the engine improving, not the flag regressing.
+///
+/// **Flipped rather than deleted**, per this repo's standing rule for a test whose
+/// subject was a defect: it now pins that #125's recovery survives, and would fail
+/// if the inverse-domain lowering were reverted.
+///
+/// **What is NO LONGER guarded here, stated plainly:** a demonstration that the flag
+/// CHANGES behaviour on some ontology. The flag's default-OFF state is still pinned
+/// behaviourally by `internal_flag_defaults` in `lib.rs`, so the default itself is
+/// covered. A future test wanting the behaviour-change demonstration back needs a
+/// fixture whose same-tier miss is a DESIGN DECISION, not an open defect — note that
+/// `Domain(r, ∃s.Z)` (issue #124) would work today and break again the moment #124 is
+/// fixed, which is the bug-pin trap this comment exists to avoid repeating.
 #[test]
-fn default_classify_off_misses_inverse_domain_subsumption() {
+fn default_classify_now_finds_inverse_domain_subsumption_without_the_flag() {
     let _serial = ENV_MUTEX
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    // Explicitly remove the flag so the default-OFF path is active regardless
-    // of any ambient env value from a parent process.
+    // Explicitly remove the flag so the default path is active regardless of any
+    // ambient env value from a parent process.
     let _flag = SetEnvGuard::remove("RUSTDL_CLASSIFY_SAME_TIER");
     let mut r = Cursor::new(INVERSE_DOMAIN_SRC);
     let (onto, _): (SetOntology<RcStr>, _) =
         read_ofn(&mut r, ParserConfiguration::default()).expect("parse");
     let c = owl_dl_reasoner::classify(&onto).expect("classify");
     assert!(
-        !classification_has_subsumption(&c, "http://e#C", "http://e#D"),
-        "with RUSTDL_CLASSIFY_SAME_TIER unset (default OFF): classify must NOT find C ⊑ D (opt-in semantics)"
+        classification_has_subsumption(&c, "http://e#C", "http://e#D"),
+        "since #125 the default classify must find C ⊑ D: `Domain(p⁻, H)` is lowered \
+         as `Range(p, H)`, giving C the EL subsumers the tier walk needs"
     );
 }
 

--- a/crates/owl-dl-reasoner/tests/inverse_domain_range.rs
+++ b/crates/owl-dl-reasoner/tests/inverse_domain_range.rs
@@ -1,0 +1,175 @@
+//! #125 — `ObjectPropertyDomain(r⁻, C)` and `ObjectPropertyRange(r⁻, C)` must be
+//! lowered, not silently discarded.
+//!
+//! Both arms of `collect_el_rules` did nothing at all on an inverse role, under
+//! the comment *"inverse-role domain = forward range; handled by the tableau"*.
+//! The identity was right and the conclusion was false comfort for `classify`:
+//! the pair was SILENTLY missed — `direct_subsumptions: []` with
+//! `incomplete: false` and `dropped: {}`, while `subclass` answered `yes` and both
+//! oracles derived it. D10 shape.
+//!
+//! **The fix is a TABLE FLIP, not a new rule.** `Domain(r⁻, C) ≡ Range(r, C)` and
+//! `Range(r⁻, C) ≡ Domain(r, C)` are logical identities, and `Role::role_id`
+//! already returns the underlying `r` for both polarities, so the only thing an
+//! inverse changes is which table receives the classes.
+//!
+//! **DIRECTION OF RISK: flipping the WRONG WAY is a false positive**, because it
+//! would assert of a role's sources something only true of its targets. That is
+//! what `an_inverse_domain_does_not_constrain_the_forward_sources` guards, and it
+//! is the test that would fail first if the polarity were inverted.
+//!
+//! ORACLE: `HermiT` 1.4.3 agrees on all five probes — it derives both positives,
+//! refuses the FP guard, and reports `X` unsatisfiable for both `⊥` cases.
+//!
+//! **READ ROBOT'S ERROR STREAM, NOT JUST ITS OUTPUT FILE.** On an ontology with an
+//! unsatisfiable class, `robot reason` writes NO output file and reports the
+//! unsatisfiability on stderr. A check that greps the output file scores that as
+//! "the oracle did not confirm it" — which is what the first version of this
+//! adjudication did, nearly recording a disagreement with `HermiT` that does not
+//! exist. The negative control (drop the `⊥` axiom ⇒ 0 unsatisfiable, `rustdl`
+//! says `sat`) is what makes the positive readings meaningful.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::classify_top_down_with_timeout;
+use std::io::Cursor;
+use std::time::Duration;
+
+const DECLS: &str = "Declaration(Class(:X)) Declaration(Class(:B)) \
+     Declaration(Class(:P)) Declaration(Class(:D)) Declaration(ObjectProperty(:r))";
+/// `X` is an `r`-SOURCE. Nothing here makes it an `r`-target.
+const SRC: &str = "SubClassOf(:X ObjectSomeValuesFrom(:r :B))";
+
+fn classify(body: &str) -> owl_dl_reasoner::Classification {
+    let ofn = format!(
+        "Prefix(:=<http://ex.org/>)\n\
+         Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n\
+         Ontology(<http://ex.org/o>\n{DECLS}\n{body}\n)\n"
+    );
+    let mut reader = Cursor::new(ofn);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    classify_top_down_with_timeout(&onto, Duration::from_secs(10)).expect("classify")
+}
+
+fn holds(body: &str, sub: &str, sup: &str) -> bool {
+    classify(body).is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+/// `Domain(r⁻, P) ≡ Range(r, P)`, so `X`'s `r`-witness is a `B ⊓ P` and
+/// `∃r.(B ⊓ P) ⊑ D` fires. `HermiT` and Konclude both derive `X ⊑ D`; before #125
+/// `classify` returned `[]` with `incomplete: false`.
+#[test]
+fn an_inverse_domain_is_the_forward_range() {
+    let body = format!(
+        "{SRC}\n\
+         ObjectPropertyDomain(ObjectInverseOf(:r) :P)\n\
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)"
+    );
+    assert!(
+        holds(&body, "X", "D"),
+        "Domain(r⁻,P) must act as Range(r,P)"
+    );
+}
+
+/// The mirror identity: `Range(r⁻, P) ≡ Domain(r, P)`, so every `r`-SOURCE is a
+/// `P`, and `X` is an `r`-source.
+#[test]
+fn an_inverse_range_is_the_forward_domain() {
+    let body = format!("{SRC}\nObjectPropertyRange(ObjectInverseOf(:r) :P)");
+    assert!(
+        holds(&body, "X", "P"),
+        "Range(r⁻,P) must act as Domain(r,P)"
+    );
+}
+
+/// THE FP GUARD — the test that fails first if the polarity flip is inverted.
+///
+/// `Domain(r⁻, P)` constrains `r`'s TARGETS. `X` is a `r`-SOURCE and nothing says
+/// it is a target, so `X ⊑ P` (and hence `X ⊑ D`) must NOT be derived. Treating
+/// the axiom as `Domain(r, P)` — i.e. forgetting the flip — makes both fire.
+/// `HermiT` derives neither.
+#[test]
+fn an_inverse_domain_does_not_constrain_the_forward_sources() {
+    let body = format!("{SRC}\nObjectPropertyDomain(ObjectInverseOf(:r) :P)\nSubClassOf(:P :D)");
+    assert!(
+        !holds(&body, "X", "P"),
+        "an r-SOURCE is not constrained by Range(r,·)"
+    );
+    assert!(
+        !holds(&body, "X", "D"),
+        "and so must not inherit P's subsumers"
+    );
+}
+
+/// The other direction of the same mistake: `Range(r⁻, P)` constrains `r`'s
+/// SOURCES, so it must not be folded into the witness as a forward range. `X`'s
+/// `r`-successor is a `B`, not a `B ⊓ P`, so `∃r.(B ⊓ P) ⊑ D` must not fire.
+#[test]
+fn an_inverse_range_does_not_constrain_the_forward_targets() {
+    let body = format!(
+        "{SRC}\n\
+         ObjectPropertyRange(ObjectInverseOf(:r) :P)\n\
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)"
+    );
+    assert!(
+        !holds(&body, "X", "D"),
+        "Range(r⁻,·) must not reach the r-witness"
+    );
+}
+
+/// `⊥` poisons the role in either polarity and on either side: `Domain(r⁻, ⊥)` is
+/// `Range(r, ⊥)`, and both say no `r`-edge can exist in any model, so anything
+/// asserting `∃r.B` is empty. `HermiT` reports `X` unsatisfiable for both.
+#[test]
+fn an_inverse_bot_filler_poisons_the_role_on_either_side() {
+    for ax in [
+        "ObjectPropertyDomain(ObjectInverseOf(:r) owl:Nothing)",
+        "ObjectPropertyRange(ObjectInverseOf(:r) owl:Nothing)",
+    ] {
+        let c = classify(&format!("{SRC}\n{ax}"));
+        assert!(
+            c.unsatisfiable_classes().contains(&"http://ex.org/X"),
+            "{ax} must poison r, making X unsatisfiable"
+        );
+    }
+}
+
+/// DISCRIMINATING CONTROL for the test above: without the `⊥` axiom, `X` is
+/// satisfiable. `HermiT` agrees (0 unsatisfiable classes). Without this the
+/// poisoning assertions could be passing for an unrelated reason.
+#[test]
+fn without_the_bot_axiom_the_source_class_stays_satisfiable() {
+    let c = classify(SRC);
+    assert!(
+        !c.unsatisfiable_classes().contains(&"http://ex.org/X"),
+        "X must stay satisfiable when nothing poisons r"
+    );
+}
+
+/// The non-inverse behaviour is unchanged. Kept because the fix rewrote BOTH arms
+/// into one polarity-aware helper, so a mistake in the shared path would break the
+/// ordinary case too — and that is the case every other test in this crate leans on.
+#[test]
+fn the_forward_polarity_still_works() {
+    assert!(
+        holds(&format!("{SRC}\nObjectPropertyDomain(:r :P)"), "X", "P"),
+        "Domain(r,P): every r-source is a P"
+    );
+    let range_body = format!(
+        "{SRC}\n\
+         ObjectPropertyRange(:r :P)\n\
+         SubClassOf(ObjectSomeValuesFrom(:r ObjectIntersectionOf(:B :P)) :D)"
+    );
+    assert!(
+        holds(&range_body, "X", "D"),
+        "Range(r,P) must reach the r-witness"
+    );
+}

--- a/crates/owl-dl-saturation/src/lib.rs
+++ b/crates/owl-dl-saturation/src/lib.rs
@@ -3152,8 +3152,20 @@ fn collect_el_rules_with_provenance(
             // into (#119, possibly a strict subset), not just a single fully-atomic
             // filler — one provenance entry per conjunct so `prove` can attribute a
             // conjunctive-domain-derived subsumption to this axiom.
-            Axiom::ObjectPropertyDomain { role, domain } if !role.is_inverse() => {
+            Axiom::ObjectPropertyDomain { role, domain }
+                if constrains_sources(Side::Domain, *role) =>
+            {
                 for id in atomic_conjuncts(&internal.concepts, *domain) {
+                    domain_axiom_refs.push((role.role_id(), id, ax_idx));
+                }
+            }
+            // `Range(r⁻, C) ≡ Domain(r, C)` (#125), so an INVERSE range also feeds
+            // `role_domains` and needs the same attribution — without this the
+            // `Domain(sub)` step it licenses prints with an EMPTY `axiom_refs`.
+            Axiom::ObjectPropertyRange { role, range }
+                if constrains_sources(Side::Range, *role) =>
+            {
+                for id in atomic_conjuncts(&internal.concepts, *range) {
                     domain_axiom_refs.push((role.role_id(), id, ax_idx));
                 }
             }
@@ -3218,7 +3230,9 @@ fn collect_el_rules_with_provenance(
         // up as a wrong or missing proof rather than a wrong answer.
         for ax in &internal.axioms {
             match ax {
-                Axiom::ObjectPropertyRange { role, range } if !role.is_inverse() => {
+                Axiom::ObjectPropertyRange { role, range }
+                    if !constrains_sources(Side::Range, *role) =>
+                {
                     // Mirror the real Pass 1 range arm's decomposition exactly
                     // (#118) — a conjunctive filler contributes each atomic
                     // conjunct it decomposes into (#119, possibly a strict
@@ -3229,6 +3243,23 @@ fn collect_el_rules_with_provenance(
                     // Pass 1 — a silent divergence here mis-attributes every
                     // LATER axiom's proof, not just this one's.
                     let ids = atomic_conjuncts(&internal.concepts, *range);
+                    if !ids.is_empty() {
+                        mini_rules
+                            .role_ranges
+                            .entry(role.role_id())
+                            .or_default()
+                            .extend(ids);
+                    }
+                }
+                // `Domain(r⁻, C) ≡ Range(r, C)` (#125): an inverse DOMAIN
+                // contributes a RANGE, so it must enter this simulation too.
+                // Omitting it does not merely blank one node's `axiom_refs` — it
+                // shifts every later axiom's rule-slot cursor, so proofs get cited
+                // to the WRONG axiom, which looks correct and is worse.
+                Axiom::ObjectPropertyDomain { role, domain }
+                    if !constrains_sources(Side::Domain, *role) =>
+                {
+                    let ids = atomic_conjuncts(&internal.concepts, *domain);
                     if !ids.is_empty() {
                         mini_rules
                             .role_ranges
@@ -3465,53 +3496,10 @@ fn collect_el_rules(
                 }
             }
             Axiom::ObjectPropertyDomain { role, domain } => {
-                if role.is_inverse() {
-                    // inverse-role domain = forward range; handled by the tableau
-                } else if matches!(internal.concepts.get(*domain), ConceptExpr::Bot) {
-                    // `ObjectPropertyDomain(r, ⊥)`: semantically `∃r.⊤ ⊑ ⊥` —
-                    // no individual may be an r-source. Poison the role so that
-                    // any class deriving `∃r.X` is marked unsatisfiable.
-                    rules.poisoned_roles.insert(role.role_id());
-                } else {
-                    // `ObjectPropertyDomain(r, P ⊓ Q)` ≡ `∃r.⊤ ⊑ P ⊓ Q` ≡
-                    // `∃r.⊤ ⊑ P` AND `∃r.⊤ ⊑ Q` — a logical identity, so splitting
-                    // is sound and completeness-preserving by construction (#110).
-                    // The atomic case is the one-element instance of it. A part
-                    // that isn't atomic (or a conjunction of atomics) contributes
-                    // nothing rather than dropping the whole filler (#119).
-                    let ids = atomic_conjuncts(&internal.concepts, *domain);
-                    if !ids.is_empty() {
-                        rules
-                            .role_domains
-                            .entry(role.role_id())
-                            .or_default()
-                            .extend(ids);
-                    }
-                }
+                lower_domain_or_range(*role, *domain, Side::Domain, &internal.concepts, &mut rules);
             }
             Axiom::ObjectPropertyRange { role, range } => {
-                if role.is_inverse() {
-                    // inverse-role range = forward domain; handled by the tableau
-                } else if matches!(internal.concepts.get(*range), ConceptExpr::Bot) {
-                    // `ObjectPropertyRange(r, ⊥)`: the r-range is empty ⟹ no
-                    // r-edge can exist in any model. Poison the role so that any
-                    // class deriving `∃r.X` is marked unsatisfiable.
-                    rules.poisoned_roles.insert(role.role_id());
-                } else {
-                    // Same identity on the range side: `Range(r, P ⊓ Q)` ≡
-                    // `Range(r, P)` AND `Range(r, Q)`. Measured to have the same
-                    // defect as the domain arm — HermiT derives the pair, rustdl
-                    // reported `[]` with `incomplete: false` (#110). Same partial
-                    // decomposition as the domain arm applies (#119).
-                    let ids = atomic_conjuncts(&internal.concepts, *range);
-                    if !ids.is_empty() {
-                        rules
-                            .role_ranges
-                            .entry(role.role_id())
-                            .or_default()
-                            .extend(ids);
-                    }
-                }
+                lower_domain_or_range(*role, *range, Side::Range, &internal.concepts, &mut rules);
             }
             Axiom::SubObjectPropertyOf {
                 sub: SubRolePath::Chain(parts),
@@ -4590,6 +4578,72 @@ fn domain_heads_el(
 /// `ObjectPropertyDomain`/`Range` match already run first), so a partly-atomic
 /// filler is never certified `PureEl` even though the engine now derives part
 /// of it. Do NOT loosen that gate to match this function.
+/// Which side of a role an `ObjectProperty{Domain,Range}` axiom constrains.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Side {
+    Domain,
+    Range,
+}
+
+/// Does this (side, polarity) combination constrain the role's SOURCES?
+///
+/// `Domain(r, …)` and `Range(r⁻, …)` do; `Range(r, …)` and `Domain(r⁻, …)`
+/// constrain its TARGETS instead. **This is the single home of that rule** — Pass 1
+/// and BOTH provenance mirrors call it, because a mirror that decides polarity
+/// independently is exactly how #110 became #118/#119.
+const fn constrains_sources(side: Side, role: Role) -> bool {
+    matches!(side, Side::Domain) != role.is_inverse()
+}
+
+/// Lower `ObjectPropertyDomain`/`ObjectPropertyRange`, in EITHER role polarity.
+///
+/// **`Domain(r⁻, C) ≡ Range(r, C)` and `Range(r⁻, C) ≡ Domain(r, C)`** — logical
+/// identities, hence sound and completeness-preserving by construction (#125).
+/// `Role::role_id` returns the underlying `r` for both polarities, so the ONLY
+/// thing an inverse changes is which table receives the classes; that is why this
+/// is a table flip and not a new rule.
+///
+/// Before #125 both arms did nothing at all on an inverse role, under the comment
+/// *"inverse-role domain = forward range; handled by the tableau"*. The identity
+/// was right and the conclusion was false comfort for `classify`: the pair was
+/// SILENTLY missed — `direct_subsumptions: []` with `incomplete: false` and
+/// `dropped: {}`, while `subclass` said `yes` and both oracles derived it.
+///
+/// `⊥` poisons the role in either polarity and on either side: `Domain(r⁻, ⊥)` is
+/// `Range(r, ⊥)`, and both say no `r`-edge can exist in any model.
+///
+/// The two sides are ONE function on purpose. They were parallel code, and this
+/// file has already paid for that once — #110 changed the real Pass 1 and left the
+/// provenance mirrors behind, which is the whole of #118/#119.
+fn lower_domain_or_range(
+    role: Role,
+    filler: ConceptId,
+    side: Side,
+    pool: &ConceptPool,
+    rules: &mut ElRules,
+) {
+    if matches!(pool.get(filler), ConceptExpr::Bot) {
+        rules.poisoned_roles.insert(role.role_id());
+        return;
+    }
+    // `Domain(r, …)` and `Range(r⁻, …)` both constrain r's SOURCES; the other two
+    // combinations constrain its TARGETS.
+    let targets_sources = constrains_sources(side, role);
+    // `Domain(r, P ⊓ Q)` ≡ `∃r.⊤ ⊑ P` AND `∃r.⊤ ⊑ Q` — a logical identity, so
+    // splitting is sound (#110); a non-atomic part contributes nothing rather than
+    // dropping the whole filler (#119).
+    let ids = atomic_conjuncts(pool, filler);
+    if ids.is_empty() {
+        return;
+    }
+    let table = if targets_sources {
+        &mut rules.role_domains
+    } else {
+        &mut rules.role_ranges
+    };
+    table.entry(role.role_id()).or_default().extend(ids);
+}
+
 fn atomic_conjuncts(pool: &ConceptPool, c: ConceptId) -> Vec<ClassId> {
     let mut out = Vec::new();
     collect_atomic_conjuncts(pool, c, &mut out);


### PR DESCRIPTION
Closes #125.

## The defect

Both `collect_el_rules` arms did **nothing** when `role.is_inverse()`, under the comment *"inverse-role domain = forward range; handled by the tableau"*. The identity is right; the conclusion was false comfort for `classify`. The pair was **silently missed** — `direct_subsumptions: []` with `incomplete: false` and `dropped: {}` — while `subclass` answered `yes` and both oracles derived it. The D10 shape.

## The fix is a table flip, not a new rule

```
Domain(r⁻, C) ≡ Range(r, C)        Range(r⁻, C) ≡ Domain(r, C)
```

Both are **logical identities**, and `Role::role_id` already returns the underlying `r` for both polarities — so the only thing an inverse changes is *which table* receives the classes. Sound and completeness-preserving by construction, hence unflagged.

Both arms now route through one `lower_domain_or_range`, and the polarity rule has a **single home** in `constrains_sources`, called by Pass 1 *and* both provenance mirrors — because a mirror that decides polarity independently is exactly how #110 became #118/#119. `⊥` now poisons the role in either polarity (`Domain(r⁻, ⊥)` is `Range(r, ⊥)`); it previously did nothing.

**Both provenance mirrors needed the same treatment**, and the defect was real: `prove` on the inverse-range case printed `(Domain(sub)) ⊢ X SubClassOf P` citing **nothing**, with the licensing axiom absent from the provenance listing entirely.

## Direction of risk is a false positive

Flipping the table the **wrong way** asserts of a role's SOURCES something true only of its TARGETS. `an_inverse_domain_does_not_constrain_the_forward_sources` is the guard that fails first. **`HermiT` agrees 5/5** — both positives, the FP guard, and both `⊥` cases.

**Read robot's error stream, not just its output file.** On an ontology with an unsatisfiable class, `robot reason` writes *no* output file and reports the unsatisfiability on stderr. Grepping the absent file scores that as "the oracle did not confirm it" — which is what my first adjudication did, nearly recording a `HermiT` disagreement that does not exist.

## Feature reach is provably zero; the refactor's blast radius is 868

**Do not conflate them.** Zero of 1,920 ORE ontologies author an inverse Domain/Range — two instruments agree, and all 1,920 pool files start with `Prefix(` (i.e. are OFN), so `ObjectInverseOf` is the only spelling and the grep is a genuine superset. But folding both arms into a shared helper touches the **forward** path that **868** ontologies use, so unlike #110/#114/#84 the sweep here is load-bearing rather than a formality.

Two-arm, pinned (`28010645` / `10ffcc2f`, verified behaviourally), arm order alternated, sequential on an idle host:

| verdict | count |
|---|---|
| IDENTICAL | 816 |
| BOTH_DNF | 49 |
| DIFFER | 2 |
| "REGRESSED" | 1 |

**All three flagged rows adjudicate clean.** `ore_ont_205` and `7499` are byte-identical at `--pair-timeout-ms 1000` (both arms `8e36c487c657` / `e9196bb34435`); every repeat differs from every other *within* each arm at the default. `ore_ont_2111` completes in **both** arms at a 300 s cap, 8/8 runs, identical 66,459 rows.

**I called `ore_ont_2111` a real regression after 3 of 6 data points, and it was noise.** AFTER had DNF'd twice at 180 s while BEFORE completed in 89 s; the remaining runs showed BEFORE DNFing and AFTER completing. Second instance in this session. The mechanism check should have led: all three flagged ontologies contain **zero** inverse domain/range so the feature cannot fire on them, and the mirrors only run under `record_proofs` so they are off the classify path entirely.

## Sabotage: 4 run, 3 caught, 1 survived — and one canary was vacuous

| # | mutation | caught by |
|---|---|---|
| S1 | polarity inverted (**the FP direction**) | 4 canaries + 4 prove + 5 neighbouring |
| S2 | inverse back to a no-op | 2 + 2 |
| S3 | `domain_axiom_refs` drops the inverse range | exactly **one** prove test, and **no** reasoner test — which is why that canary had to exist |
| S4 | mini Pass-1 sim drops the inverse-domain contributor | **SURVIVED** |

S4 is unobservable on **two separately constructed fixtures**, the second built specifically to expose it per #118's note that the damage lands on *later* axioms' cursors; attribution came back byte-identical both times. **The arm is kept** — it maintains the Pass-1 mirror invariant #118 established, and failing to observe it is a limit of my fixtures, not evidence the arm is dead.

**The vacuous canary** asserted on a `ToldSubsumer` node that does not exist in that proof tree, so it could never fire. Only the sabotage revealed it. Retargeted to the folded `ObjectIntersectionOf(:B :P)` witness and re-verified to fail under S2.

## A test was pinning this bug while guarding a flag

`default_classify_off_misses_inverse_domain_subsumption` asserted the default must **not** find `C ⊑ D`. It existed to document `RUSTDL_CLASSIFY_SAME_TIER`'s opt-in semantics, using the inverse-domain miss as its *vehicle*. The fix gives `C` its EL subsumers, fixing the tier grouping as a side effect, so the default now derives a pair the flag-ON test asserts on the **same ontology**.

**Flipped, not deleted.** What is no longer guarded there is a demonstration that the flag *changes* behaviour; the default itself stays pinned by `internal_flag_defaults`. The obvious retarget — `Domain(r, ∃s.Z)` — is **issue #124, an open defect**, so pointing the test at it would re-create the identical trap the moment #124 closes. That reasoning is in the test's doc comment.

## Gates

- suite **1990 passed / 0 failed**
- FP=0 net **12 VERIFIED**, every closure exact, zero mismatches (galen 28007, sio 8904, ore-10080 32356, ore-10908 6001, wine 653, pizza 499, ro 158, ore-15672 142, sulo 51, bibtex 16)
- clippy `--all-targets --all-features` exit 0; `cargo fmt --check` clean
- Canaries: `crates/owl-dl-reasoner/tests/inverse_domain_range.rs` (7) + `crates/owl-dl-cli/tests/prove_conjunctive_domain_range.rs` (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)