### PR TITLE
docs: VarCap is measured out — 11 Horn-bodied refusals, all inert (WS2 negative)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1118,10 +1118,23 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
     NEGATIVE one, which includes an ordinary `EquivalentClasses(C, ObjectHasSelf(r))`: the
     `⊒` direction puts `Self` in the antecedent, and NNF makes it negative. So a grep for
     `ObjectComplementOf(ObjectHasSelf(…))` gives the right answer for the wrong reason;
-    re-scanned for the corrected pattern, ORE still has **0 of 9**. **`VarCap` is the live
-    residual here at 39 ontologies** — a clause silently discarded for exceeding
-    `MAX_BODY_VARS`, the same shape `NotTree` had — recorded, not queued, since raising that
-    cap is a measured hard stop. Two instruments disagreeing on COUNTS (`ro` 2 vs 6) is
+    re-scanned for the corrected pattern, ORE still has **0 of 9**. **`VarCap` WAS the live
+    residual here at 39 ontologies — MEASURED OUT 2026-09-06.** Re-censused at **37** refusing
+    ontologies, of which **11 are ALL-HORN** (`disjunctive=0`, so the refused body is provably
+    Horn) — which **REFUTES** the expectation that they would all be disjunctive. The earlier
+    "23 binders at 8→16, all disjunctive" was not wrong; it measured a DIFFERENT population —
+    binding at 16 and being refused at 8 are not the same set. All 11 refuse at **exactly 9
+    variables**, so the cap is off by ONE for this whole set, not mis-tuned across the
+    9/11/12/16/25/133 spread. **But the shape is INERT:** two arms at cap 8 vs 16, closure-
+    compared — **4 measurable with 0 answer changes; 7 DNF SYMMETRICALLY in both arms**, so
+    there is no answer for a withheld clause to change (claim bounded as 0 of 4, not 0 of 11).
+    And `ore_ont_7775` is both one of the 11 and one of the three completers cap-16 is recorded
+    as destroying, so the naive fix trades recoveries for known regressions. **Do not
+    re-propose without a single ontology where a 9-variable Horn body changes an answer.**
+    **Instrument note:** the first positive control did NOT fire — the fixture was pure-EL, so
+    `classify` took the saturation fast path and never reached the hyper engine; a census run
+    then would have read "0 addressable" from a silent instrument. Adding one `∀` fixed it.
+    See `docs/benchmarks/2026-09-06-varcap-horn-bodies-are-inert.md`. Two instruments disagreeing on COUNTS (`ro` 2 vs 6) is
     expected and was adjudicated rather than papered over: the engine counts indexing EVENTS
     (`ro` is re-indexed 3×) and the probe counts distinct clause bodies; as booleans they
     agree 4/4. See `docs/benchmarks/2026-09-04-self-filter-refusal-census.md`. A companion clausifier gap closed in `8ae984c`: `emit_head`'s `Not` arm handled only

--- a/docs/benchmarks/2026-09-06-varcap-horn-bodies-are-inert.md
+++ b/docs/benchmarks/2026-09-06-varcap-horn-bodies-are-inert.md
@@ -1,0 +1,90 @@
+# `VarCap`: the Horn-bodied refusals exist, and they are inert — WS2 closed as a negative
+
+**Verdict: stop.** The roadmap's kill condition fires, but on B2 rather than B1, and the route
+there corrects two things that were previously inferred rather than measured.
+
+## What was expected, and why that was wrong
+
+`docs/2026-08-03-max-body-vars.md` found 23 binders when raising `MAX_BODY_VARS` 8 → 16 and
+recorded that **in each case the withheld clause is disjunctive**. I predicted B1 would therefore
+find ~0 Horn-bodied refusals and the kill condition would fire immediately.
+
+**It did not. 11 of 37 refusing ontologies are all-Horn.**
+
+The prior was not wrong — it measured a *different population*. "Binds when the cap is raised to
+16" and "is refused at 8" are not the same set. Both hold at once: the bodies that start firing at
+16 are disjunctive, while other bodies refused at 8 are Horn. This is why B1 was specified as a
+measurement rather than an inference, and it is worth keeping as an instance of a recorded number
+being true and still not answering the question asked of it.
+
+## B1 — the census
+
+Instrument: `RUSTDL_TRACE_BODY_VARS=1` over `classify`, all 1,920, 30 s cap, 6-way.
+Joined against `examples/clause_stats_probe` (clausify-only) over the same 1,920 to identify
+ontologies with `disjunctive=0` — an ontology with only Horn clauses can only have Horn-bodied
+refusals, which makes that half of the split *provable* rather than inferred.
+
+| | count |
+|---|---:|
+| refusing ontologies | **37** |
+| of which **all-Horn** (`disjunctive=0`) | **11** |
+| of which mixed (`disjunctive>0`) — body indeterminate | 26 |
+| unmeasured at the 30 s cap | 134 |
+| corpus split: all-Horn / mixed / unmeasured | 1,226 / 689 / 5 |
+
+The 11: `ore_ont_` `1182, 3529, 3575, 5218, 7361, 7775, 9855, 11629, 11745, 12432, 14572`.
+(The earlier census said 39; the difference sits inside the 134 unmeasured at this cap.)
+
+**INSTRUMENT VALIDATION, and it nearly cost the whole result.** The first positive control —
+twelve `∃`-conjuncts, 13 distinct body variables — produced **zero** trace lines. Had the census
+run then, "0 refusals" would have read as "0 addressable" from an instrument that was not firing.
+Cause: the fixture was pure-EL, so `classify` took the saturation fast path and the hyper engine
+never indexed a clause. Adding one `∀` to force the hybrid path made it fire at once
+(`[mbv] refused body: vars=13 ... reason=VarCap { vars: 9, cap: 8 }`). Both negative controls
+(`ro`, `pizza`) stay silent. **Prove the instrument fires, on the path the defect lives on.**
+
+## The cap is off by ONE, not mis-tuned across a range
+
+Every one of the 11 refuses at **exactly 9 variables** — not the 9/11/12/16/25/133 spread the
+earlier census recorded for binders.
+
+## B2 — does the withheld clause change an ANSWER?
+
+Two arms (`RUSTDL_WIDE_BODY_VARS` 0 vs 1, cap 8 vs 16 — enough to admit every one of the 11 at
+9 vars), arm order alternated, 300 s cap, compared on the transitive closure with
+`scripts/closure-diff.py`.
+
+| | count |
+|---|---:|
+| completed in both arms | 4 |
+| **answer changes among them** | **0** (gained 0 / lost 0, all four) |
+| DNF **symmetrically** in both arms — UNMEASURED | 7 |
+
+`ore_ont_1182` 1,835 · `ore_ont_3529` 3,278 · `ore_ont_7775` 3,765 · `ore_ont_12432` 27,997
+closure entries, identical across arms.
+
+**The 7 unmeasured do not weaken the verdict**: they produce no answer in *either* arm, so there
+is no answer for a withheld clause to change within reach of this budget. The claim is bounded
+accordingly — 0 of 4 measurable, not 0 of 11.
+
+## Why the naive fix stays disqualified
+
+`ore_ont_7775` is in the 11 **and** is one of the three completers `docs/2026-08-03-max-body-vars.md`
+records as destroyed by cap 16 (3.14 s → DNF). Raising the cap admits the Horn bodies and the
+disjunctive ones together; only a Horn/disjunctive split separates them.
+
+**One discrepancy, recorded not resolved:** here `ore_ont_7775` **completes** in the wide arm
+(3 s → 11 s, 3.7× slower, answers identical), where that document records a DNF. Different
+conditions are the likely explanation and I did not chase it. Anyone reviving this must re-measure
+that case rather than trust either number.
+
+## Verdict
+
+**Kill condition fires on B2.** The shape the roadmap hoped for is real and larger than expected —
+11 ontologies, all one variable over the cap — but **inert**: it changes no answer anywhere it can
+be measured. A branching-cap policy in the wedge's hot path cannot be justified by a population
+whose withheld clauses derive nothing, and the one case that would most benefit is the same case
+the cap increase is known to destroy.
+
+**Do not re-propose without new evidence.** The cheapest thing that would change this verdict is a
+single ontology where a 9-variable Horn body changes an answer; none of the 4 measurable ones does.


### PR DESCRIPTION
Two commits that were sitting **unpushed on a local `main`** and would have been lost with the machine. `origin/main` still carried the superseded conclusion, so this is a correction, not just an addition.

## What changed in the conclusion

`main` says `VarCap` "**is the live residual** here at 39 ontologies" — a clause-discarding refusal (`MAX_BODY_VARS`) left open as the last addressable item in that census. Measured, it is **inert**, and the route there corrects two things that had been inferred rather than measured:

| | before | measured |
|---|---|---|
| refusing ontologies | 39 | **37** |
| expected to be all disjunctive | assumed | **11 are ALL-HORN** (`disjunctive=0`) — refutes the expectation |
| variables needed | spread 9/11/12/16/25/133 | all 11 refuse at **exactly 9** — the cap is off by ONE for this set |
| answer changes at cap 8 vs 16 | unknown | **0 of 4 measurable; 7 DNF symmetrically in both arms** |

So the shape is real and the reward is zero: with no answer to change, there is nothing for a withheld clause to alter. The claim is deliberately bounded as **0 of 4**, not 0 of 11, because the other 7 produce no verdict in either arm.

Also recorded: `ore_ont_7775` is both one of the 11 **and** one of the three completers that cap 16 is already documented to destroy — so the naive fix trades known recoveries for known regressions.

## The instrument note is the transferable part

The first positive control **did not fire**: the fixture was pure-EL, so `classify` took the saturation fast path and never reached the hyper engine. A census run at that point would have read "0 addressable" from a silent instrument and looked like a clean negative. Adding one `∀` fixed it.

## Why this is a separate PR

The 90-line benchmark doc exists nowhere but this branch. Kept off #130 (which is three unrelated `CLAUDE.md` fact corrections) so each can be reviewed and reverted on its own.

Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzVE2TSVVMc3n8Wrce65Jg
