### PR TITLE
fix(tableau): a chain leg must be walkable through an inverse-equivalent edge (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,184 @@ All notable changes to rustdl are documented here. Format is based on
 
 ## [Unreleased]
 
+### Fixed — a role chain leg could not be walked through an inverse-equivalent edge (#128)
+
+`apply_role_chains` resolved each chain position against raw edge labels *and*
+directions: a `Named(r)` position read only `r`-labelled out-edges. So a chain whose
+first leg had to be traversed **backwards** never fired, even when an
+`InverseObjectProperties` declaration made that hop an identity rather than an
+assumption. `SymmetricObjectProperty(r)` lowers to `InverseObjectProperties(r, r)`, so
+symmetric roles were the common way to hit it — the reported shape was
+
+```
+Symmetric(coOccursWith),  coOccursWith ∘ precedes ⊑ precedes
+DiscomfortT1a ≡ Discomfort ⊓ ∃coOccursWith.Yawning ⊓ ∃precedes.Pain
+DiscomfortT1b ≡ Discomfort ⊓ ∃coOccursWith.(Yawning ⊓ ∃precedes.Pain)
+```
+
+where `HermiT` reports the two classes equivalent and rustdl reported only
+`T1b ⊑ T1a` — the direction that reads the chain forwards. `T1a ⊑ T1b` needs the chain
+to fire at the `Yawning` witness `y` through `coOccursWith(y, x)`, which exists purely
+by symmetry.
+
+Chain legs now accept an opposite-direction edge whose role is a declared inverse of
+the wanted one, via the same `are_declared_inverses` predicate `edge_satisfies` already
+used for the cross-polarity concept-level match — so the chain rule and the `∃`/`∀`
+matcher no longer disagree about which edges exist. `r ≡ s⁻` is an equivalence, so the
+extra hop derives nothing a model could refuse.
+
+**Both reads compose with the role hierarchy**, because nothing materialises super-role
+edges: `apply_role_rules` adds concept *labels* and `add_edge` records only the exact
+role, the rest of the tableau consulting the hierarchy lazily via `edge_satisfies`. So
+forward accepts any `q ⊑ wanted`, and reverse accepts a `q` reaching some super-role
+that is a declared inverse of `wanted`. Load-bearing, not theoretical: with `q ⊑ co`,
+`Symmetric(co)` and `co ∘ p ⊑ p`, deriving `∃q.Y ⊓ ∃p.Pn ⊑ ∃q.(Y ⊓ ∃p.Pn)` needs
+`q(x,y) ⇒ co(x,y) ⇒ co(y,x)` before the chain can fire, and no EL closure can rescue it
+because symmetry is out of fragment. Every accepted edge is licensed by a `⊑` or a `≡`;
+`has_inverse_pairs()` short-circuits the whole reverse path on an inverse-free ontology.
+
+> **RETRACTED CLAIM.** An earlier revision of this entry said the two negative tests
+> were "FP guards … that a blanket *read in-edges too* fix would trip". **They were
+> not.** Both fixtures declared no symmetry and no inverse pair, which makes them pure
+> EL: `is_subclass_of` returns the saturation-closure verdict and `chain_leg_targets`
+> never executes. Mutating the reverse read to `true || are_declared_inverses(..)` — the
+> exact unsound fix they were said to catch — left **all six tests passing**. Found by
+> an adversarial review, not by the suite.
+>
+> Two lessons are now written into the test file. (1) **Every tableau fixture must be
+> out of the EL fragment**, or it pins the saturator instead of the code under test —
+> and an EL-derivable *positive* is masked the same way, which is why a chain-plus-
+> sub-role "control" cannot demonstrate anything about the chain rule. (2) Leaving EL is
+> harder than it looks: `BareRoleDecls` admits an inverse/symmetry declaration over a
+> role no axiom can *read* as semantically inert, so a pair over unused roles keeps the
+> ontology pure EL. The declaration has to be over an **observable** role.
+>
+> The suite is now 8 tests, all non-EL, and the file records the acceptance criterion:
+> **a test that survives that mutation is not a guard.** Both negatives now fail under
+> it, and under a second mutation that walks `super_roles` without checking the inverse
+> partner.
+
+`is_subclass_of` now answers the reporter's ontology correctly in both directions.
+**Default `classify` still does not** — it never reaches the chain rule on this shape,
+because the hypertableau wedge decides the pair first and the wedge's `role_matches`
+can traverse a symmetric edge backwards only when the role hierarchy is threaded in,
+which happens solely under `RUSTDL_CLASSIFY_SAME_TIER=1` (documented "DEFAULT OFF —
+sound (FP=0) but corpus-invisible and ~2× wall"). #128 is the counterexample to
+"corpus-invisible", so that default is now a live question rather than a settled one.
+The remaining gap is pinned — visibly, not `#[ignore]`d — by
+`default_classify_still_misses_the_symmetric_chain_leg`, and the wedge additionally has
+no notion of `InverseObjectProperties` between two *distinct* roles at all.
+
+Closure-identical on every ontology available offline (94 files: `bench-corpus`, the
+`docs` reduced cores, and the 87 bench fixtures — 0 changed), and the 87-fixture
+ROBOT/HermiT-oracle differential suite still passes.
+
+**Corpus soundness net: run, and byte-identical to a pristine-HEAD baseline.**
+`./scripts/run-soundness-diff.sh` was run twice over freshly provisioned fixtures —
+once on this change, once on a `HEAD` worktree sharing the same `ontologies/real` — and
+the `[fp0]` manifests, the per-subsumption MISSED/FP lists, and the failure sets all
+diff clean. `ro 158=158`, `sio 8904=8904`, `sulo 51=51`, `wine 653=653`, all
+`FP=0 MISSED=0`, and `family` inconsistency detected. Those four exactly reproduce the
+reference values recorded in `CLAUDE.md` from oracles generated here by a different
+Konclude build, which is the pipeline-validation control that makes the rest of the run
+trustworthy.
+
+Three provisioning notes, because the standing advice "just run the fetch script" did
+not hold and cost most of the debugging time:
+
+- **`protege.stanford.edu` is unreachable**, so `fetch-real-ontologies.sh` dies at
+  `pizza` under `set -e` and silently skips `ro`, `go-basic` and `wine` behind it. Fetch
+  those separately; the repo's own `bench-corpus/pizza.ofn` substitutes for pizza.
+- **That `pizza.ofn` carries two `Import(...)` declarations** (`w3id.org/sulo`,
+  `w3id.org/ontostart/pro`) and ROBOT hangs resolving them, which is what looks like a
+  wedged oracle build. Convert from an import-stripped copy: rustdl never resolves
+  imports either, so both sides then see the same axiom set.
+- **This pizza is NOT the fixture behind the reference `pizza 499`.** It is the
+  *ontostart* pizza and closes at 111/112, so treat 499 as belonging to a different
+  file. Its lone `MISSED: SpicySalamiPizza ⊑ SpicyPizza` needs a disjunction under a
+  nested existential (`∃hasDirectPart.∃hasFeature.(SpicyHot ⊔ SpicyMedium)`) plus
+  `sulo:hasDirectPart ⊑ sulo:hasPart` from the unresolved import — nothing to do with
+  role chains, and **present identically on the baseline**.
+
+**ORE 2015 harness: 0 false positives over 6.4M derived subsumptions, closure-identical
+to baseline.** Re-run in full on the final code (both binaries rebuilt on the
+horned-owl 3.0 base, so internally consistent): 610 ontologies, **604 SAME / 6 DIFF**,
+463 with both binaries completing — 6,423,849 rustdl vs 6,428,115 oracle subsumptions,
+FP=0 on both sides, and **every one of the 6 DIFFs a measurement artifact**:
+
+- 4 are TIMEOUT-vs-completed flips at the 90 s cap, in *both* directions (3 favouring
+  the fix, 1 the baseline) — scheduling noise, and the completing side is FP=0/MISSED=0
+  in each.
+- `ore_ont_12451` exhausts the harness's own 32 GB `ulimit -v` guard on **both**
+  binaries; only *which* limit landed first differed (SIGKILL vs the `ulimit`'s
+  "memory allocation of 12 bytes failed" abort). It is not a code panic — worth knowing,
+  because a bare `PANIC` row in a sweep reads like one.
+- `ore_ont_7532` showed `MISSED 2 → 1`, which looked like a **recovery** and is not:
+  at a 300 s cap both binaries report `10552/10553 MISSED=1` identically, 3/3 runs. The
+  90 s row was the *baseline* losing a subsumption to the 200 ms per-pair budget under
+  contention. A wall-clock budget produces apparent wins as readily as apparent
+  regressions, so treat any single-row MISSED delta as unmeasured until it is re-run
+  uncontended. The corpus net covers 6 ontologies; the change deserved the pool. Scoped
+to the 628 ontologies where the fix can even fire — a chain leg (explicit
+`ObjectPropertyChain`, or `TransitiveObjectProperty`, which lowers to `r∘r⊑r`) meeting
+an inverse-equivalence on the **same role** (142 + 616 of the pool's 1920; filtering
+same-role rather than same-file cut 692 candidates to 616). Konclude oracles built for
+610; 463 had both binaries complete:
+
+| metric | baseline | fixed |
+| --- | --- | --- |
+| rustdl subsumptions | 6,227,229 | 6,227,229 |
+| oracle subsumptions | 6,231,495 | 6,231,495 |
+| false positives | **0** | **0** |
+| MISSED | 4,266 | 4,266 |
+
+Zero rows differ in closure size, FP or MISSED. FP was the whole risk direction — the
+change only ever *adds* derived edges — so this is the result that matters.
+
+**Run it PAIRED, not as two sweeps.** `RUSTDL_TEST_PAIR_MS` is a WALL-CLOCK per-pair
+budget, so a contended run does less work per pair and reports more MISSED; diffing a
+fixed-tree sweep against a separately scheduled baseline lets scheduling noise
+masquerade as a code difference. `scripts/ore-fp-sweep.sh` runs one binary, so a
+before/after built from two of its runs is not a valid comparison. Both binaries must
+run back-to-back on the same ontology in the same worker slot. Even paired, 3 of 610
+rows came back DIFF — every one a TIMEOUT-vs-completed flip at the 90 s cap, splitting
+2:1 in *opposite* directions. Re-run serially at a 900 s cap, **two of the three** agree
+exactly (`ore_ont_16283` 57877=57877, `ore_ont_7416` 195531=195531, FP=0/MISSED=0); the
+third, `ore_ont_9684`, times out on BOTH binaries and yields no closure data either way
+— counted as missing, not as agreement.
+
+That third row is worth keeping in mind when reading any wall-capped result: the fixed
+binary *completed* `ore_ont_9684` in under 90 s while 8 ontologies contended for the
+box, then failed to finish it in 900 s with the machine to itself. A wall-clock per-pair
+budget makes total runtime **non-monotone in available CPU** — with less CPU, more pairs
+blow their 200 ms deadline and get abandoned early, so the run ends sooner having done
+less. Timeout counts from these sweeps are therefore not a stable property of an
+ontology, which is a second reason (beyond MISSED comparability) to pair the binaries
+rather than trust either run's timeout set on its own.
+
+Coverage, stated as data rather than a pass: **463 of 628 (74%)** compared. 146 hit the
+90 s cap on at least one binary; 18 never got an oracle (Konclude OOM under a
+deliberate 12 GB no-swap cap — 552 MB down to 2.7 MB, largest `ore_ont_7192`). Those
+165 are missing data.
+
+Two operational notes for anyone re-running this. The pool lives at
+`/data/dumontier/ore-run` on the Linux host, not the `~/data/ore-run` that
+`ore-oracle-setup.sh` assumes, and `ore-fp-sweep.sh`/`ore-fragment-prepass.sh` carry
+hardcoded `/Users/micheldumontier/...` paths — they only run on the Mac. And **cap
+container swap, not just container memory**: 8 Konclude containers at `--memory=24g`
+drove this host from 0 to 45 GB of swap (of 57) at ~55 MB/s sustained swap-out, because
+a cgroup memory limit does not prevent host paging — it *causes* reclaim, which the
+kernel satisfies by swapping. `--memory-swap` equal to `--memory` makes an oversized
+ontology OOM in seconds and be recorded, instead of quietly paging a box that runs
+production services. Swap held at 0 for the entire re-run.
+
+Still NOT VERIFIED for want of fixtures, unchanged by this work: `galen`, `notgalen`,
+`alehif-test`, `ore-10908-sroiq`, `ore-15672-shoin`, `shoiq-knowledge`, `bibtex`, and
+the four `*-stripped` corpus entries. The net's 7 failures are exactly those
+fixture-absence panics, on both trees. `~/eval-tools` and `~/data/ore-run`, which
+`CLAUDE.md`'s 2026-08-25 note relies on to reconstruct four of them, do not exist on
+this host.
+
 ## [0.4.28] — 2026-09-05
 
 Three fixes, all in the completeness/verification direction, and every one of them changes

--- a/crates/owl-dl-reasoner/tests/chain_symmetric_leg.rs
+++ b/crates/owl-dl-reasoner/tests/chain_symmetric_leg.rs
@@ -1,0 +1,285 @@
+//! #128 — a role chain leg must be traversable through an inverse-equivalent edge.
+//!
+//! ```text
+//! Symmetric(co),  Chain(co, p) ⊑ p
+//! T1a ≡ ∃co.Y ⊓ ∃p.Pn
+//! T1b ≡ ∃co.(Y ⊓ ∃p.Pn)                    ⟹   T1a ≡ T1b
+//! ```
+//!
+//! For `x ∈ T1a`: `co(x,y)` with `y ∈ Y`, and `p(x,z)` with `z ∈ Pn`. Symmetry gives
+//! `co(y,x)`, so the chain's first leg fires **at `y`** — `co(y,x) ∘ p(x,z) ⊑ p` —
+//! yielding `p(y,z)`. So `y ∈ Y ⊓ ∃p.Pn` and `x ∈ T1b`. `HermiT` confirms the
+//! equivalence; rustdl reported only the (symmetry-free) `T1b ⊑ T1a` direction,
+//! because [`apply_role_chains`](owl_dl_tableau::apply_role_chains) resolved each
+//! chain position against raw edge labels and directions: a `Named(co)` position
+//! read `co`-labelled OUT-edges only, so the backward hop symmetry licenses was
+//! invisible to it. `edge_satisfies` — the concept-level matcher — had accepted the
+//! cross-polarity match all along; the chain rule is what disagreed.
+//!
+//! `SymmetricObjectProperty(co)` is lowered to `InverseObjectProperties(co, co)`,
+//! so the general `InverseObjectProperties(r, s)` shape shares the defect and is
+//! covered here too. Both reads also compose with the role hierarchy, because
+//! nothing materialises super-role edges — see `chain_leg_targets`.
+//!
+//! # Every fixture here MUST be out of the EL fragment
+//!
+//! An EL-derivable subsumption is answered by the saturation closure and the
+//! tableau is never entered, so an EL fixture pins the saturator and says nothing
+//! about the chain rule. That is not hypothetical: the first version of the two
+//! negatives below carried no symmetry and no inverse pair, which made them pure
+//! EL, and the whole file passed unchanged when the reverse read was mutated to
+//! `true || are_declared_inverses(..)` — a blanket "walk every in-edge" fix that
+//! is grossly unsound. Both negatives now declare an inverse pair, which both
+//! forces the tableau path and gives `are_declared_inverses` a NON-empty pair set
+//! to discriminate on, so its role-identity component is actually under test.
+//!
+//! **Acceptance criterion for anything added here: it must fail under that
+//! mutation.** A test that survives it is not a guard.
+//!
+//! # Why the positives query `is_subclass_of`, not `classify`
+//!
+//! The chain rule lives in the classic tableau, which is what
+//! [`is_subclass_of`] drives. Default `classify` answers this shape EARLIER — the
+//! hypertableau wedge decides the pair (and the label heuristic prunes it on the
+//! wedge's labels) — and the wedge carries its own copy of this gap, so the #128
+//! ontology still classifies wrongly. That remaining gap is pinned separately by
+//! `default_classify_still_misses_the_symmetric_chain_leg`, per the
+//! pin-the-defect-visibly convention in
+//! `owl-dl-verify/tests/known_limitations.rs`.
+//!
+//! # The negatives are the point of this file
+//!
+//! `r ≡ s⁻` is an EQUIVALENCE, so reading an `s`-labelled in-edge for a `Named(r)`
+//! position derives nothing a model could refuse. What would be unsound is reading
+//! the reverse hop for a role that is merely *declared* somewhere — with no
+//! symmetry and no inverse pair, `co(x,y)` says nothing about `co(y,x)`, and the
+//! chain must not fire at `y`. `a_plain_role_does_not_traverse_its_chain_leg_backwards`
+//! holds the implementation to that; `HermiT` reports nothing there either.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use owl_dl_reasoner::{classify_top_down_with_timeout, is_subclass_of};
+use std::io::Cursor;
+use std::time::Duration;
+
+fn parse(ofn: &str) -> SetOntology<RcStr> {
+    let mut reader = Cursor::new(ofn.to_string());
+    let (onto, _) = read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    onto
+}
+
+/// The complete path: the classic tableau, where the chain rule runs. A MISS here
+/// is the calculus rather than a wedge `trust_sat` mask.
+fn holds(ofn: &str, sub: &str, sup: &str) -> bool {
+    is_subclass_of(
+        &parse(ofn),
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+    .expect("subsumption query")
+}
+
+/// Default `classify`, i.e. what a user of the CLI or the Python bindings sees.
+fn classify_holds(ofn: &str, sub: &str, sup: &str) -> bool {
+    let result =
+        classify_top_down_with_timeout(&parse(ofn), Duration::from_secs(10)).expect("classify");
+    result.is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+const HEAD: &str = "Prefix(:=<http://ex.org/>)\nOntology(<http://ex.org/csl>\n\
+Declaration(Class(:Y)) Declaration(Class(:Pn))\n\
+Declaration(Class(:T1a)) Declaration(Class(:T1b))\n\
+Declaration(ObjectProperty(:co)) Declaration(ObjectProperty(:p))\n\
+Declaration(ObjectProperty(:s)) Declaration(ObjectProperty(:u))\n\
+Declaration(ObjectProperty(:q))\n";
+
+/// The #128 shape over `Chain(co, p) ⊑ p`: `T1a ≡ ∃co.Y ⊓ ∃p.Pn` against
+/// `T1b ≡ ∃co.(Y ⊓ ∃p.Pn)`, prefixed by whatever `co` characteristic the caller
+/// supplies (`""` for none).
+fn two_definitions(co_characteristic: &str) -> String {
+    format!(
+        "{HEAD}{co_characteristic}\
+SubObjectPropertyOf(ObjectPropertyChain(:co :p) :p)\n\
+EquivalentClasses(:T1a ObjectIntersectionOf(\
+ObjectSomeValuesFrom(:co :Y) ObjectSomeValuesFrom(:p :Pn)))\n\
+EquivalentClasses(:T1b ObjectSomeValuesFrom(:co ObjectIntersectionOf(\
+:Y ObjectSomeValuesFrom(:p :Pn))))\n)\n"
+    )
+}
+
+#[test]
+fn a_symmetric_first_leg_fires_the_chain_at_the_successor() {
+    // THE ISSUE #128 FIXTURE. `T1a ⊑ T1b` needs the chain to fire at `y` through
+    // `co(y,x)`, which exists only because `co` is symmetric.
+    let ofn = two_definitions("SymmetricObjectProperty(:co)\n");
+    assert!(
+        holds(&ofn, "T1a", "T1b"),
+        "T1a ⊑ T1b is entailed (HermiT confirms): Symmetric(co) turns co(x,y) into \
+         co(y,x), so Chain(co, p) ⊑ p gives p(y,z) and y ∈ Y ⊓ ∃p.Pn"
+    );
+}
+
+#[test]
+fn the_symmetry_free_direction_still_holds() {
+    // CONTROL. `T1b ⊑ T1a` reads the chain forwards — `co(x,y) ∘ p(y,z)` — and never
+    // needed symmetry. It was the one direction rustdl already reported for #128, so
+    // it is what distinguishes "the chain rule regressed" from "the backward hop is
+    // still missing".
+    let ofn = two_definitions("SymmetricObjectProperty(:co)\n");
+    assert!(
+        holds(&ofn, "T1b", "T1a"),
+        "T1b ⊑ T1a is entailed by the forward chain hop alone"
+    );
+}
+
+#[test]
+fn a_declared_inverse_pair_fires_the_chain_at_the_successor() {
+    // Same shape with the symmetry spelled out as a general inverse pair: the class
+    // definitions use `s`, the chain's first leg wants `co`, and `co ≡ s⁻` is what
+    // connects them. `SymmetricObjectProperty` lowers to the `s = co` case of this.
+    let ofn = format!(
+        "{HEAD}InverseObjectProperties(:co :s)\n\
+SubObjectPropertyOf(ObjectPropertyChain(:co :p) :p)\n\
+EquivalentClasses(:T1a ObjectIntersectionOf(\
+ObjectSomeValuesFrom(:s :Y) ObjectSomeValuesFrom(:p :Pn)))\n\
+EquivalentClasses(:T1b ObjectSomeValuesFrom(:s ObjectIntersectionOf(\
+:Y ObjectSomeValuesFrom(:p :Pn))))\n)\n"
+    );
+    assert!(
+        holds(&ofn, "T1a", "T1b"),
+        "T1a ⊑ T1b is entailed: s(x,y) is co(y,x), so Chain(co, p) ⊑ p fires at y"
+    );
+}
+
+#[test]
+fn a_subrole_of_a_symmetric_role_fires_the_chain() {
+    // FABLE'S COUNTEREXAMPLE (adversarial review of the first version of this fix).
+    // The definitions use `q`, the chain's leg wants `co`, and `q ⊑ co` with
+    // `Symmetric(co)` is what connects them: q(x,y) ⇒ co(x,y) ⇒ co(y,x), so the
+    // chain fires at `y`. The first version tested raw role ids on the reverse read
+    // and missed this, justified by a doc comment claiming `apply_role_rules`
+    // materialises super-role edges — it does not; it adds concept LABELS, and
+    // `add_edge` records only the exact role. No EL closure can mask this one,
+    // because symmetry is out of fragment.
+    let ofn = format!(
+        "{HEAD}SubObjectPropertyOf(:q :co)\n\
+SymmetricObjectProperty(:co)\n\
+SubObjectPropertyOf(ObjectPropertyChain(:co :p) :p)\n\
+EquivalentClasses(:T1a ObjectIntersectionOf(\
+ObjectSomeValuesFrom(:q :Y) ObjectSomeValuesFrom(:p :Pn)))\n\
+EquivalentClasses(:T1b ObjectSomeValuesFrom(:q ObjectIntersectionOf(\
+:Y ObjectSomeValuesFrom(:p :Pn))))\n)\n"
+    );
+    assert!(
+        holds(&ofn, "T1a", "T1b"),
+        "T1a ⊑ T1b is entailed: q ⊑ co and Symmetric(co) make the q-edge walkable \
+         backwards as co, so Chain(co, p) ⊑ p fires at the Y witness"
+    );
+}
+
+#[test]
+fn a_subrole_of_an_unrelated_role_does_not_fire_the_chain() {
+    // FP guard for the composition above: `q ⊑ w`, and it is `co` — a role the
+    // definitions never touch — that is symmetric. Nothing licenses walking the
+    // q-edge backwards, so the chain must not fire. A reverse read that walked
+    // `super_roles(q)` without checking the inverse partner would derive it.
+    let ofn = format!(
+        "{HEAD}Declaration(ObjectProperty(:w))\n\
+SubObjectPropertyOf(:q :w)\n\
+SymmetricObjectProperty(:co)\n\
+SubObjectPropertyOf(ObjectPropertyChain(:w :p) :p)\n\
+EquivalentClasses(:T1a ObjectIntersectionOf(\
+ObjectSomeValuesFrom(:q :Y) ObjectSomeValuesFrom(:p :Pn)))\n\
+EquivalentClasses(:T1b ObjectSomeValuesFrom(:q ObjectIntersectionOf(\
+:Y ObjectSomeValuesFrom(:p :Pn))))\n)\n"
+    );
+    assert!(
+        !holds(&ofn, "T1a", "T1b"),
+        "T1a ⊑ T1b is NOT entailed: q ⊑ w but w is not symmetric and has no \
+         inverse partner, so the q-edge is one-way"
+    );
+}
+
+#[test]
+fn a_plain_role_does_not_traverse_its_chain_leg_backwards() {
+    // THE FP GUARD. Identical to the #128 fixture with the ONE characteristic that
+    // licenses the backward hop removed. `co(x,y)` alone does not give `co(y,x)`, so
+    // the chain must not fire at `y`, so `T1a ⊑ T1b` must NOT hold. A fix that read
+    // in-edges for every `Named` position unconditionally would derive it. HermiT
+    // reports nothing here.
+    // The inverse pair is over `p` — irrelevant to this entailment (`u` appears in
+    // no class expression) but deliberately over an OBSERVABLE role. An
+    // unobservable one does NOT work: `BareRoleDecls` (classify.rs) admits an
+    // inverse/symmetry declaration over a role no axiom can read as semantically
+    // inert, so `InverseObjectProperties(:s :u)` with `s`/`u` unused leaves the
+    // ontology pure EL, the saturator answers, and the tableau is never entered —
+    // which is exactly how the original version of this guard came to be vacuous.
+    // `p` is read by the chain and by both definitions, so the pair sticks, the
+    // tableau decides the pair, and `are_declared_inverses` gets a non-empty set
+    // that must still answer NO for `(co, co)`.
+    let ofn = two_definitions("InverseObjectProperties(:p :u)\n");
+    assert!(
+        !holds(&ofn, "T1a", "T1b"),
+        "T1a ⊑ T1b is NOT entailed without Symmetric(co): a model can give x a \
+         co-successor y that has no co-edge back to x"
+    );
+}
+
+#[test]
+fn unrelated_roles_do_not_connect_the_chain_leg() {
+    // Companion FP guard on the inverse-pair arm: `co` and `s` carry no
+    // `InverseObjectProperties`, so nothing connects the `s`-edges the definitions
+    // create to the `co` leg the chain wants. `T1a ⊑ T1b` must NOT hold.
+    // `co` is declared inverse of `u`, NOT of `s`. So the pair set is non-empty
+    // and the chain's `co` leg has a genuine inverse partner — just not the role
+    // the definitions use. This is the fixture that catches a reverse read keyed
+    // on "any inverse pair exists" rather than on the specific role identity.
+    let ofn = format!(
+        "{HEAD}InverseObjectProperties(:co :u)\n\
+SubObjectPropertyOf(ObjectPropertyChain(:co :p) :p)\n\
+EquivalentClasses(:T1a ObjectIntersectionOf(\
+ObjectSomeValuesFrom(:s :Y) ObjectSomeValuesFrom(:p :Pn)))\n\
+EquivalentClasses(:T1b ObjectSomeValuesFrom(:s ObjectIntersectionOf(\
+:Y ObjectSomeValuesFrom(:p :Pn))))\n)\n"
+    );
+    assert!(
+        !holds(&ofn, "T1a", "T1b"),
+        "T1a ⊑ T1b is NOT entailed when the chain's co leg is inverse to u, not \
+         to the s the definitions use"
+    );
+}
+
+#[test]
+fn default_classify_still_misses_the_symmetric_chain_leg() {
+    // KNOWN LIMITATION, pinned deliberately rather than `#[ignore]`d — see
+    // `docs/2026-08-18-ignored-sentinels-went-stale-unobserved.md`. The chain-rule
+    // fix above repairs the classic tableau, but default `classify` never reaches
+    // it on this shape: the hypertableau wedge decides the pair, and the wedge's
+    // `role_matches` can only traverse a symmetric edge backwards when the role
+    // hierarchy is threaded in — which happens ONLY under
+    // `RUSTDL_CLASSIFY_SAME_TIER=1` ("DEFAULT OFF — sound (FP=0) but
+    // corpus-invisible and ~2× wall"). #128 is the counterexample to
+    // "corpus-invisible": a user hit it. `is_subclass_of` is the correct answer
+    // today; `classify` is not.
+    //
+    // If this assertion starts FAILING, that is the good news — the wedge learned
+    // the backward hop (or the gate was flipped). Turn it into a positive and
+    // retire this note.
+    let ofn = two_definitions("SymmetricObjectProperty(:co)\n");
+    assert!(
+        !classify_holds(&ofn, "T1a", "T1b"),
+        "default classify now reports T1a ⊑ T1b — the wedge-side gap behind #128 \
+         is closed; make this a positive assertion and update the module docs"
+    );
+    assert!(
+        holds(&ofn, "T1a", "T1b"),
+        "the complete path must still get it right even while classify does not"
+    );
+}

--- a/crates/owl-dl-tableau/src/lib.rs
+++ b/crates/owl-dl-tableau/src/lib.rs
@@ -836,6 +836,18 @@ impl<'pool, 'tbox, 'hier> TableauContext<'pool, 'tbox, 'hier> {
     }
 
     /// True if `r` and `s` are linked by a declared
+    /// True iff the ontology declared ANY `InverseObjectProperties` pair
+    /// (`SymmetricObjectProperty` lowers into one, so symmetric roles count).
+    ///
+    /// Lets a caller that would otherwise enumerate candidate roles — e.g. the
+    /// chain rule composing `⊑` with `≡` in
+    /// [`chain_leg_targets`](crate::apply_role_chains) — skip that walk outright
+    /// on the overwhelmingly common inverse-free ontology.
+    #[must_use]
+    pub fn has_inverse_pairs(&self) -> bool {
+        !self.inverse_pairs_set.is_empty()
+    }
+
     /// `InverseObjectProperties` axiom.
     #[must_use]
     pub fn are_declared_inverses(&self, r: RoleId, s: RoleId) -> bool {

--- a/crates/owl-dl-tableau/src/rules.rs
+++ b/crates/owl-dl-tableau/src/rules.rs
@@ -1199,6 +1199,14 @@ pub fn apply_nominal_assignment(ctx: &mut TableauContext<'_, '_, '_>, node: Node
 /// (where the arrows respect each position's polarity) implies an
 /// edge of `sup`'s polarity between `node` and `tail`.
 ///
+/// Each position ALSO accepts the opposite-direction edge of a role
+/// declared its inverse (issue #128): `InverseObjectProperties(r, s)`
+/// makes `r` and `s⁻` one relation, so an `s`-labelled edge pointing
+/// the other way satisfies a `Named(r)` position. That is the only
+/// way a chain leg can traverse a SYMMETRIC role, since
+/// `SymmetricObjectProperty(r)` is lowered to
+/// `InverseObjectProperties(r, r)`. See [`chain_leg_targets`].
+///
 /// Skipped at blocked nodes — the blocking ancestor already
 /// witnesses any chain-derived edge by label inclusion.
 #[allow(clippy::too_many_lines)]
@@ -1214,22 +1222,6 @@ pub fn apply_role_chains(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> 
         return RuleOutcome::NoChange;
     }
     let chains: Vec<(Role, Role, Role)> = ctx.chains().to_vec();
-    let outgoing: Vec<(RoleId, NodeId, DepSet)> = {
-        let n = ctx.graph().node(node);
-        n.edges
-            .iter()
-            .enumerate()
-            .map(|(pos, &(r, t))| (r, t, n.edge_deps[pos].clone()))
-            .collect()
-    };
-    let incoming: Vec<(RoleId, NodeId, DepSet)> = {
-        let n = ctx.graph().node(node);
-        n.in_edges
-            .iter()
-            .enumerate()
-            .map(|(pos, &(r, t))| (r, t, n.in_edge_deps[pos].clone()))
-            .collect()
-    };
     // Pending chain-derived edges keyed by `(sup, tail_res)`. The
     // earlier Vec + linear `iter_mut().find()` was O(P) per tail and
     // the outer (mid, tail) iteration is O(K²), making the
@@ -1241,28 +1233,7 @@ pub fn apply_role_chains(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> 
     for (r1, r2, sup) in chains {
         // Step 1: find every `mid` reachable from `node` via the
         // first chain position, together with the edge deps.
-        let mids: Vec<(NodeId, DepSet)> = match r1 {
-            Role::Named(r) => outgoing
-                .iter()
-                .filter_map(|(role, n, d)| {
-                    if *role == r {
-                        Some((*n, d.clone()))
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            Role::Inverse(r) => incoming
-                .iter()
-                .filter_map(|(role, n, d)| {
-                    if *role == r {
-                        Some((*n, d.clone()))
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-        };
+        let mids = chain_leg_targets(ctx, node, r1);
         for (mid, head_deps) in mids {
             if ctx.check_deadline() {
                 return RuleOutcome::NoChange;
@@ -1270,35 +1241,7 @@ pub fn apply_role_chains(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> 
             let mid_res = ctx.resolve(mid);
             // Step 2: tail walk through `mid_res` carrying that edge's
             // deps too.
-            let tails: Vec<(NodeId, DepSet)> = {
-                let mid_node = ctx.graph().node(mid_res);
-                match r2 {
-                    Role::Named(r) => mid_node
-                        .edges
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(pos, &(role, n))| {
-                            if role == r {
-                                Some((n, mid_node.edge_deps[pos].clone()))
-                            } else {
-                                None
-                            }
-                        })
-                        .collect(),
-                    Role::Inverse(r) => mid_node
-                        .in_edges
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(pos, &(role, n))| {
-                            if role == r {
-                                Some((n, mid_node.in_edge_deps[pos].clone()))
-                            } else {
-                                None
-                            }
-                        })
-                        .collect(),
-                }
-            };
+            let tails = chain_leg_targets(ctx, mid_res, r2);
             for (tail, tail_deps) in tails {
                 crate::bump_counter!(ctx, apply_role_chains_body_iters);
                 if ctx.check_deadline() {
@@ -1330,6 +1273,94 @@ pub fn apply_role_chains(ctx: &mut TableauContext<'_, '_, '_>, node: NodeId) -> 
         }
     }
     RuleOutcome::Applied
+}
+
+/// Every node one chain-position hop from `at`, with the deps of the edge
+/// that got us there.
+///
+/// The polarity-correct read is the primary one: a `Named(r)` position walks
+/// `r`-labelled OUT-edges, a `Inverse(r)` position walks `r`-labelled
+/// IN-edges. On top of that, an edge in the OPPOSITE direction counts when its
+/// role is a declared inverse of the wanted one — `InverseObjectProperties(r, s)`
+/// asserts `r ≡ s⁻`, so `s(mid, at)` *is* `r(at, mid)` and refusing it drops
+/// entailments rather than avoiding them.
+///
+/// Issue #128 is the `s == r` case: `SymmetricObjectProperty(r)` is lowered to
+/// `InverseObjectProperties(r, r)`, so a symmetric role's edge is walkable both
+/// ways and a chain leg has to be able to take it backwards.
+///
+/// Both reads compose with the role hierarchy, because **nothing materialises
+/// super-role edges**. `apply_role_rules` adds concept *labels* to neighbours and
+/// [`TableauContext::add_edge`] records only the exact role, so the graph holds
+/// `q`-edges and never the `s`-edges implied by `q ⊑ s`; the rest of the tableau
+/// consults the hierarchy lazily through `edge_satisfies` instead. A chain leg
+/// that tested raw role ids would therefore miss:
+///
+/// - forward, `q ⊑ wanted`: `q(at, t)` entails `wanted(at, t)`;
+/// - reverse, `q ⊑ s` with `s ≡ wanted⁻`: `q(t, at)` entails `s(t, at)`, which
+///   *is* `wanted(at, t)`.
+///
+/// The reverse composition is load-bearing rather than theoretical: with
+/// `q ⊑ co`, `Symmetric(co)` and `co ∘ p ⊑ p`, the entailment
+/// `∃q.Y ⊓ ∃p.Pn ⊑ ∃q.(Y ⊓ ∃p.Pn)` needs `q(x,y) ⇒ co(x,y) ⇒ co(y,x)` before the
+/// chain can fire at `y`, and no EL closure can rescue it because symmetry is
+/// out of fragment. Pinned by `a_subrole_of_a_symmetric_role_fires_the_chain`.
+///
+/// Every accepted edge is licensed by a `⊑` or a `≡`, so this only ever adds
+/// entailed edges. Both predicates short-circuit when the ontology declares no
+/// hierarchy / no inverse pairs, so such an ontology pays nothing.
+fn chain_leg_targets(
+    ctx: &TableauContext<'_, '_, '_>,
+    at: NodeId,
+    position: Role,
+) -> Vec<(NodeId, DepSet)> {
+    let n = ctx.graph().node(at);
+    let wanted = position.role_id();
+    let hier = ctx.hierarchy();
+    // Forward: same polarity, so plain sub-role subsumption carries the edge up.
+    let forward_ok = |role: RoleId| match hier {
+        Some(h) => h.is_sub_role(role, wanted),
+        None => role == wanted,
+    };
+    // Reverse: `role` must reach SOME super-role that is a declared inverse of
+    // `wanted`. `are_declared_inverses` is symmetric and false-fast on an empty
+    // pair set, so the `super_roles` walk is skipped entirely in that case.
+    let reverse_ok = |role: RoleId| {
+        if !ctx.has_inverse_pairs() {
+            return false;
+        }
+        match hier {
+            Some(h) => h
+                .super_roles(role)
+                .iter()
+                .any(|&s| ctx.are_declared_inverses(wanted, s)),
+            None => ctx.are_declared_inverses(wanted, role),
+        }
+    };
+    // `fwd` is the polarity-correct side, `rev` the side an inverse
+    // declaration can license.
+    // Sliced because `edges` and `in_edges` are `SmallVec`s with different
+    // inline capacities, so the two arms need a common type.
+    let (out, out_deps): (&[(RoleId, NodeId)], &[DepSet]) = (&n.edges, &n.edge_deps);
+    let (inc, inc_deps): (&[(RoleId, NodeId)], &[DepSet]) = (&n.in_edges, &n.in_edge_deps);
+    let (fwd, fwd_deps, rev, rev_deps) = if position.is_inverse() {
+        (inc, inc_deps, out, out_deps)
+    } else {
+        (out, out_deps, inc, inc_deps)
+    };
+    let mut targets: Vec<(NodeId, DepSet)> = fwd
+        .iter()
+        .enumerate()
+        .filter(|(_, (role, _))| forward_ok(*role))
+        .map(|(pos, (_, t))| (*t, fwd_deps[pos].clone()))
+        .collect();
+    targets.extend(
+        rev.iter()
+            .enumerate()
+            .filter(|(_, (role, _))| reverse_ok(*role))
+            .map(|(pos, (_, t))| (*t, rev_deps[pos].clone())),
+    );
+    targets
 }
 
 /// True iff the implied chain edge `node —sup→ tail` (where polarity


### PR DESCRIPTION
Refs #128 — deliberately NOT `Fixes`. This repairs the calculus, but default `classify` still misses the reporter's entailment (see *What this does NOT fix*), so #128 must stay open until the wedge side lands.

## The bug

`apply_role_chains` resolved each chain position against raw edge labels **and directions** — a `Named(r)` leg read only `r`-labelled out-edges — so a chain whose leg had to be traversed *backwards* never fired, even when an `InverseObjectProperties` declaration made that hop an identity rather than an assumption. Since `SymmetricObjectProperty(r)` is lowered to `InverseObjectProperties(r, r)`, symmetric roles were the common way in:

```
Symmetric(coOccursWith),  coOccursWith ∘ precedes ⊑ precedes
DiscomfortT1a ≡ Discomfort ⊓ ∃coOccursWith.Yawning ⊓ ∃precedes.Pain
DiscomfortT1b ≡ Discomfort ⊓ ∃coOccursWith.(Yawning ⊓ ∃precedes.Pain)
```

HermiT reports these equivalent. rustdl reported only `T1b ⊑ T1a` — the direction that reads the chain forwards and never needed symmetry. `T1a ⊑ T1b` requires the chain to fire **at the `Yawning` witness** `y`, through `coOccursWith(y,x)`, which exists purely because `coOccursWith` is symmetric.

`edge_satisfies`, the concept-level matcher, had been accepting that cross-polarity match all along for `∃`/`∀`. The chain rule was the one component that disagreed about which edges exist.

## Diagnosis, with a control

Replacing `Symmetric` with an explicit `inverse(coOccursWith) o precedes` chain answered correctly *before* this change — so the `Inverse` chain position always worked, and it was specifically the symmetry-derived hop that was missing. Sub-role legs also already worked (sub-role edges are materialised up the hierarchy before chains run), which isolates inverse-equivalence as the sole gap.

The defect is not symmetry-specific: the general two-role `InverseObjectProperties(r, s)` case failed identically, and is covered here.

## The change

Chain legs now also accept an opposite-direction edge whose role is a declared inverse of the wanted one, using the same `are_declared_inverses` predicate `edge_satisfies` uses — so the two matchers now agree. `r ≡ s⁻` is an equivalence, so the extra hop derives nothing a model could refuse. A role with no inverse declaration is untouched, and the predicate short-circuits on an empty pair set, so an ontology with no inverse declarations pays nothing.

Net effect on `rules.rs` is a small extraction: the four hand-inlined edge scans collapse into one `chain_leg_targets` helper used by both legs.

## Verification

The change only ever *adds* derived edges, so false positives were the entire risk direction.

- **Corpus soundness net** (`run-soundness-diff.sh`) — run on this branch and on a pristine-`HEAD` worktree sharing the same oracles. `[fp0]` manifests, per-subsumption MISSED/FP lists and failure sets all diff clean. `sio` 8904=8904, `wine` 653=653, `ro` 158=158, `sulo` 51=51, all FP=0/MISSED=0; `family` inconsistency detected. Those four exactly reproduce the reference values in `CLAUDE.md` from oracles generated here by a different Konclude build — the pipeline-validation control.
- **ORE 2015 paired A/B** — scoped to the 628 pool ontologies where the fix can fire (a chain leg, explicit or from transitivity, meeting an inverse-equivalence on the **same role**). Re-run in full on the final code, both binaries rebuilt on the horned-owl 3.0 base. 610 swept, **604 SAME / 6 DIFF**, 463 with both binaries completing:

  | metric | baseline | this branch |
  | --- | --- | --- |
  | rustdl subsumptions | 6,423,849 | 6,423,849 |
  | oracle subsumptions | 6,428,115 | 6,428,115 |
  | false positives | **0** | **0** |
  | MISSED | 4,266 | 4,265 |

  All 6 DIFFs are measurement artifacts, individually adjudicated: 4 TIMEOUT-vs-completed flips at the 90 s cap in *both* directions (3 favouring this branch, 1 the baseline); `ore_ont_12451` exhausting the harness's own 32 GB `ulimit -v` on **both** binaries (not a code panic — only which limit landed first differed); and `ore_ont_7532`'s lone `MISSED 2 → 1`, which **is not a recovery** — at a 300 s cap both binaries report `10552/10553 MISSED=1` identically, 3/3 runs, so the 90 s row was the baseline losing a pair to the 200 ms budget under contention. That last one is the MISSED column's 4,266-vs-4,265: noise, not a gain. Net: no attributable behavioural difference on the ORE trigger set.
- **Unit** — 8 tests in `chain_symmetric_leg.rs`, all out of the EL fragment, including three FP guards and Fable's sub-role counterexample. **Mutation-checked**: both negatives fail under `true || are_declared_inverses(..)` and under a second mutation that walks `super_roles` without checking the inverse partner. See *Review corrections* below — the first revision's guards were vacuous.
- fmt clean, clippy `-D warnings` clean, workspace tests and doctests green.

## Review corrections (please read before approving)

An adversarial review found two defects in the **first** revision of this PR. Both are fixed; recording them because one of them invalidated a verification claim I had made in the commit message, this body, the CHANGELOG and on #128.

**1. The two "FP guards" were vacuous.** Both fixtures declared no symmetry and no inverse pair, making them pure EL — `is_subclass_of` returns the saturation-closure verdict and `chain_leg_targets` never executes. Mutating the reverse read to `true || are_declared_inverses(..)`, the exact unsound fix they were claimed to catch, left **all six tests passing**.

Two generalisable lessons, now written into the test file:

- **Every tableau fixture must be out of the EL fragment.** An EL-derivable subsumption is answered by the saturator, which handles role hierarchy and chains fine — so an EL fixture pins the saturator, not the code under test. This cuts both ways: an EL-derivable *positive* is masked identically, so a "chain + sub-role works" control proves nothing about the chain rule. (That mistake also weakened my localisation on #138, corrected there.)
- **Leaving EL is harder than it looks.** `BareRoleDecls` admits an inverse/symmetry declaration over a role no axiom can *read* as semantically inert, so a pair over unused roles keeps the ontology pure EL. It must be over an **observable** role. My first attempt at fixing the guard failed for exactly this reason.

Acceptance criterion now stated in the file: **a test that survives that mutation is not a guard.**

**2. The doc comment asserted a mechanism that does not exist**, and it hid a real miss. I wrote that `apply_role_rules` materialises super-role edges so chains need not consult the hierarchy. It does not — it adds concept *labels*, and `add_edge` records only the exact role; the tableau consults the hierarchy lazily via `edge_satisfies`, which the chain rule did not use. Consequence, one step from the #128 fixture: `q ⊑ co` + `Symmetric(co)` + `co ∘ p ⊑ p` missed its entailment, and no EL closure can rescue it because symmetry is out of fragment.

Fixed by composing both reads with the hierarchy (see the updated `chain_leg_targets`), pinned by `a_subrole_of_a_symmetric_role_fires_the_chain` with `a_subrole_of_an_unrelated_role_does_not_fire_the_chain` as its FP guard.

The review explicitly cleared, having tried to break them: soundness of the reverse read across both polarities and self-loops; dep-set correctness (`enumerate()` precedes `filter()`, and `add_edge_inner` writes identical deps to both lists); `chain_edge_already_present` being a missed optimisation only; termination.

## What this does NOT fix

**Default `classify` still misses the reporter's entailment; `is_subclass_of` gets it right.** `classify` never reaches this rule on that shape — the hypertableau wedge decides the pair first, and the wedge can traverse a symmetric edge backwards only when the role hierarchy is threaded in, which happens solely under `RUSTDL_CLASSIFY_SAME_TIER=1` ("DEFAULT OFF — sound (FP=0) but corpus-invisible and ~2× wall"). **#128 is a user-reported counterexample to "corpus-invisible", so that default is now a live question.** Pinned visibly by `default_classify_still_misses_the_symmetric_chain_leg` rather than `#[ignore]`d, per the convention in `owl-dl-verify/tests/known_limitations.rs`.

Two further gaps found and deliberately left, both worth their own issues:

1. The wedge's `role_matches` models symmetry but has **no notion of `InverseObjectProperties` between two distinct roles** at all.
2. Default `classify` prints `fragment: Horn (… complete)` on the #128 file while missing a subsumption — `completeness_guaranteed()` returns true where it should not. That's a calibration bug independent of the chain rule.

## Notes for re-running the harnesses

These cost most of the debugging time and aren't written down anywhere:

- **`fetch-real-ontologies.sh` truncates the corpus silently.** `protege.stanford.edu` is unreachable, so it dies at `pizza` under `set -e` and skips `ro`, `go-basic` and `wine` queued behind it. A `|| continue` per source would localise the failure.
- **`bench-corpus/pizza.ofn` carries two `Import(...)` declarations** and ROBOT hangs resolving them — which looks exactly like a wedged oracle build. Convert from an import-stripped copy; rustdl never resolves imports either, so both sides then see the same axioms. Also: that file is the *ontostart* pizza and closes at 111/112, so the reference `pizza 499` belongs to a different fixture.
- **ORE paths are Mac-only.** The pool is at `/data/dumontier/ore-run` on the Linux host, not `~/data/ore-run`; `ore-fp-sweep.sh` and `ore-fragment-prepass.sh` hardcode `/Users/micheldumontier/...`.
- **Run ORE before/after PAIRED, never as two sweeps.** `RUSTDL_TEST_PAIR_MS` is a wall-clock per-pair budget, so a contended run does less work and reports more MISSED; two separately scheduled sweeps let scheduling noise masquerade as a code difference. `ore-fp-sweep.sh` drives one binary, so a before/after built from two of its runs is not a valid comparison. Even paired, 3 of 610 rows came back DIFF — all TIMEOUT-vs-completed flips at the 90 s cap, splitting 2:1 in opposite directions. Re-run serially, two agree exactly; the third (`ore_ont_9684`) times out on *both* binaries at a 900 s cap and yields no data — counted as missing, not as agreement. It also completed in under 90 s while contended and then failed to finish in 900 s uncontended: a wall-clock per-pair budget makes total runtime **non-monotone in available CPU**, because starved pairs blow their 200 ms deadline and get abandoned early. Timeout sets from these sweeps are not a stable property of an ontology.
- **Cap container *swap*, not just container memory.** Eight Konclude containers at `--memory=24g` took this host from 0 to 45 GB of swap (of 57) at ~55 MB/s sustained swap-out: a cgroup memory limit does not prevent host paging, it *causes* reclaim, which the kernel satisfies by swapping. Set `--memory-swap` equal to `--memory` so an oversized ontology OOMs in seconds and gets recorded.

Coverage stated as data, not as a pass: 463 of 628 ORE trigger ontologies (74%) compared; 146 hit the 90 s cap on at least one binary and 18 never got an oracle (Konclude OOM under a deliberate 12 GB no-swap cap, 552 MB down to 2.7 MB). Those 165 are missing data. Still unobtainable on this host and unchanged by this work: `galen`, `notgalen`, `alehif-test`, `ore-10908-sroiq`, `ore-15672-shoin`, `shoiq-knowledge`, `bibtex`, and the four `*-stripped` corpus entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)