### PR TITLE
fix(hyper): the incremental Horn drain silently lost subsumptions (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,66 @@ now states outright that **`incomplete: false` does not mean complete**, and tha
 `disjoint --json` reads `completeness_guaranteed()` directly, so it now correctly reports
 `incomplete: true` on this ontology — which was #124's headline symptom.
 
+### Fixed — the incremental Horn drain silently lost subsumptions; three missing triggers (#137)
+
+`RUSTDL_HYPER_INCREMENTAL_FIXPOINT` (**default ON**) drains only the delta a decision
+pushed, which is correct only if every rule has a trigger for every way its premises can
+arrive. The non-incremental path re-seeds from the graph every pass and so masks a
+missing trigger; incremental mode simply never fires the rule and reports `Sat` — and
+with `trust_sat` on (also default) that spurious `Sat` is believed, the pair never
+reaches the tableau, and the subsumption is lost **with no signal**.
+
+Found by provisioning `ontologies/real/` for #133's soundness run, which activated a
+test that had been skipping. Three distinct holes, all fixed:
+
+1. **The qualified-`≤1` label trigger.** `≤1 r.C` counts only the `r`-successors
+   carrying `C`, and the label can arrive *after* the edge, with no `Event::Edge` to
+   notice. Every violation observed was `qual=Some(..)`, never unqualified — which is
+   why functional-only corpora (galen, notgalen) never showed it. Fixed by
+   `at_most_ones_qualified` + a neighbour walk in the `Event::Label` arm, mirroring the
+   edge trigger's src/tgt symmetry.
+2. **Merge-inherited `≤1`.** A merge copies `s_j`'s `at_most` onto the survivor without
+   firing the constraint-added trigger the `Atom::AtMost` head path gets, so a survivor
+   already holding ≥2 matching successors was never re-checked.
+3. **The general case**, since (1) and (2) are unlikely to be the last: a completeness
+   net. On reaching quiescence `horn_fixpoint` re-seeds once and re-drains, so a rule
+   whose premise arrived without a trigger still fires. Sound by construction — it can
+   only add entailed facts, i.e. only turn a wrong `Sat` into `Unsat`. Gated by
+   `RUSTDL_RESEED_VERIFY` (**default ON**, `=0` reverts).
+
+**The net is load-bearing 142 times on `sio` and twice on `ro`**, so the drain's
+incompleteness is widespread; it happened to change a verdict only on pizza. A residual
+hole therefore remains — `stats.reseed_recovered` counts it and `RUSTDL_RESEED_PROBE=1`
+prints each occurrence. It is deliberately a COUNTER, not a `debug_assert`: asserting
+"no trigger is ever missing" fires immediately, because that is exactly what is still
+false. Finding the last trigger is follow-up work; the verdict is correct either way.
+
+**Two completeness recoveries, both oracle-confirmed:**
+
+- **`pizza` closes the corpus net's last MISSED: 111/112 → 112/112, FP=0, MISSED=0.**
+  `SpicySalamiPizza ⊑ SpicyPizza` (HermiT and Konclude both derive it) was being dropped
+  on the default config. Every curated-corpus fixture is now MISSED=0.
+- **A pinned known-miss now derives.** `dkey_collapse_broadcast`'s
+  `KNOWN-MISS-forall-super-value-sub` — `∀f.DataOneOf("a")`, `p ⊑ f`, `p(i,"b")` — is
+  logically inconsistent and rustdl reported it consistent. Its own comment said to flip
+  the expectation once the gap closed; done. Note the asymmetry that makes this a #137
+  fix and not a data-property one: `RUSTDL_HYPER_INCREMENTAL_FIXPOINT=0` still misses it.
+
+Cost, A/B-able via the flag: `sio` 1.07 → 1.15 s (+7%), `ro` 0.30 → 0.60 s, `pizza` and
+`wine` unchanged.
+
+**The gate that should have caught this was passing vacuously**, which is the more
+transferable lesson. `incremental_fixpoint_identity.rs` is described as the "durable
+byte-identity gate" on this flag, and its only fixture that ever caught a real bug was
+the **gitignored** `ontologies/real/pizza.ofn` — absent in CI and in every fresh
+checkout, while its `compared >= 2` guard was satisfied by two checked-in bench fixtures.
+So it reported `ok` for as long as nobody provisioned the corpus by hand. The pizza pair
+is now reduced to a 7-class fixture and **checked in** at
+`crates/owl-dl-cli/tests/fixtures/incremental/qualified-card-forall-union.ofn`; verified
+with pizza moved aside that the gate fails on it under `RUSTDL_RESEED_VERIFY=0` and
+passes with the net on. Same pattern as the `[fp0]` net's "9 of 22 fixture blocks could
+skip while still reporting ok" — worth auditing the other gitignored-fixture gates.
+
 ### Fixed — a role chain leg could not be walked through an inverse-equivalent edge (#128)
 
 `apply_role_chains` resolved each chain position against raw edge labels *and*

--- a/crates/owl-dl-cli/tests/fixtures/incremental/qualified-card-forall-union.ofn
+++ b/crates/owl-dl-cli/tests/fixtures/incremental/qualified-card-forall-union.ofn
@@ -1,0 +1,28 @@
+# #137 regression fixture, CHECKED IN deliberately.
+#
+# `SSP ⊑ SpicyPizza` is entailed (HermiT and Konclude agree) and was LOST by
+# the incremental Horn drain on the DEFAULT config: the drain reported `Sat`,
+# `trust_sat` believed it, and the subsumption vanished with no signal.
+# Reduced from `ontologies/real/pizza.ofn`'s SpicySalamiPizza/SpicyPizza pair.
+#
+# It lives HERE rather than under the gitignored /ontologies because the
+# incremental identity gate was passing vacuously in CI and in any fresh
+# checkout: its only catching fixture was the gitignored pizza, so the bug was
+# invisible until someone provisioned the corpus by hand.
+#
+# The shape that matters: a qualified `=1 r.C` whose qualifier arrives as a
+# LABEL after the edge (via the `∀` + `⊔` branch), feeding an `∃` under an `∃`.
+Prefix(:=<http://ex.org/>)
+Ontology(<http://ex.org/spicy>
+Declaration(Class(:Pizza)) Declaration(Class(:PizzaSauce)) Declaration(Class(:SpicySalami))
+Declaration(Class(:SpicyHot)) Declaration(Class(:SpicyMedium))
+Declaration(Class(:SpicyPizza)) Declaration(Class(:SSP))
+Declaration(ObjectProperty(:hasDirectPart)) Declaration(ObjectProperty(:hasFeature))
+SubClassOf(:SpicySalami ObjectSomeValuesFrom(:hasFeature ObjectUnionOf(:SpicyHot :SpicyMedium)))
+EquivalentClasses(:SpicyPizza ObjectIntersectionOf(:Pizza
+  ObjectSomeValuesFrom(:hasDirectPart ObjectSomeValuesFrom(:hasFeature ObjectUnionOf(:SpicyHot :SpicyMedium)))))
+EquivalentClasses(:SSP ObjectIntersectionOf(:Pizza
+  ObjectAllValuesFrom(:hasDirectPart ObjectUnionOf(:PizzaSauce :SpicySalami))
+  ObjectExactCardinality(1 :hasDirectPart :PizzaSauce)
+  ObjectExactCardinality(1 :hasDirectPart :SpicySalami)))
+)

--- a/crates/owl-dl-cli/tests/incremental_fixpoint_identity.rs
+++ b/crates/owl-dl-cli/tests/incremental_fixpoint_identity.rs
@@ -84,6 +84,13 @@ fn incremental_matches_baseline_on_fixtures() {
         "ontologies/real/pizza.ofn",
         "crates/owl-dl-bench/fixtures/27_eight_way_disjunction_sat.ofn",
         "crates/owl-dl-bench/fixtures/18_diamond_subsumption_unsat.ofn",
+        // #137: the ONLY fixture here that ever caught a real incremental-drain
+        // bug was the gitignored `ontologies/real/pizza.ofn`, so this gate passed
+        // vacuously in CI and in every fresh checkout while the default config
+        // silently lost `SpicySalamiPizza ⊑ SpicyPizza`. This is that pair
+        // reduced to 7 classes and CHECKED IN, so the gate has teeth without the
+        // corpus. Verify with `RUSTDL_RESEED_VERIFY=0`: it must FAIL.
+        "crates/owl-dl-cli/tests/fixtures/incremental/qualified-card-forall-union.ofn",
     ] {
         let path = fixture_path(rel);
         if !path.exists() {

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -2017,6 +2017,20 @@ pub fn hyper_trust_sat_enabled() -> bool {
     std::env::var_os("RUSTDL_HYPERTABLEAU_TRUST_SAT").is_none_or(|v| v != "0" && !v.is_empty())
 }
 
+/// #137 completeness net for the incremental Horn drain
+/// (`RUSTDL_RESEED_VERIFY`, **default ON**; `=0` reverts to the pre-fix
+/// behaviour). When on, `horn_fixpoint` re-seeds once from the graph on reaching
+/// quiescence and re-drains, so a rule whose premise arrived without a trigger
+/// still fires. Without it the incremental drain reports `Sat`, `trust_sat`
+/// believes it, and the subsumption is lost silently — measured on
+/// `ontologies/real/pizza.ofn` (`SpicySalamiPizza ⊑ SpicyPizza`, confirmed by
+/// `HermiT` and Konclude). Sound in both settings: the net can only add entailed
+/// facts, i.e. only turn a wrong `Sat` into `Unsat`.
+#[must_use]
+pub fn reseed_verify_enabled() -> bool {
+    std::env::var_os("RUSTDL_RESEED_VERIFY").is_none_or(|v| v != "0" && !v.is_empty())
+}
+
 /// Per-class label heuristic (Phase 7) — when enabled, the classifier
 /// runs wedge satisfiability once per named class to build a label
 /// cache, then prunes non-subsumption pairs whose candidate super is

--- a/crates/owl-dl-reasoner/tests/dkey_collapse_broadcast.rs
+++ b/crates/owl-dl-reasoner/tests/dkey_collapse_broadcast.rs
@@ -129,16 +129,22 @@ fn negative_functional_sub_values_on_super() {
     check("NEGATIVE-functional-sub-values-on-super", false, 0);
 }
 
-/// PRE-EXISTING MISS — pinned so it is not mistaken for a regression.
+/// FORMERLY a pinned miss; now DERIVED (#137).
 ///
-/// `∀f.DataOneOf` on a super + conflicting value on a sub is MISSED by rustdl:
-/// the `KB` is logically inconsistent (as Konclude/HermiT derive) but rustdl
-/// currently reports it consistent. This is an asymmetric `∀`-propagation gap
-/// down the data-property hierarchy, not introduced by the collapse/broadcast
-/// split. The expectation encodes today's (wrong but stable) behaviour
-/// deliberately; do NOT change it to the logically-correct `true` — that would
-/// only pass once the gap is closed.
+/// `∀f.DataOneOf("a")` on a super, `p ⊑ f`, and `p(i, "b")`: the `KB` is
+/// logically inconsistent, as Konclude and `HermiT` derive. rustdl used to report
+/// it consistent — an asymmetric `∀`-propagation gap down the data-property
+/// hierarchy — and the previous revision of this test pinned that wrong-but-
+/// stable verdict, with a note to flip the expectation to the logically-correct
+/// `true` once the gap closed. It has: the #137 completeness net in
+/// `horn_fixpoint` re-seeds at quiescence, which re-fires the `∀` down the
+/// hierarchy and finds the clash.
+///
+/// Kept under its original name so the history stays greppable. NOTE the
+/// asymmetry that makes this a `#137` fix rather than a data-property one:
+/// `RUSTDL_HYPER_INCREMENTAL_FIXPOINT=0` still reports this KB consistent,
+/// because the net only guards the incremental drain — which is the default.
 #[test]
 fn known_miss_forall_super_value_sub() {
-    check("KNOWN-MISS-forall-super-value-sub", false, 0);
+    check("KNOWN-MISS-forall-super-value-sub", true, 0);
 }

--- a/crates/owl-dl-tableau/src/hyper.rs
+++ b/crates/owl-dl-tableau/src/hyper.rs
@@ -554,6 +554,12 @@ impl DepSetSnapshot {
 pub struct SearchStats {
     /// Disjuncts asserted across the whole search (decisions made).
     pub branches_taken: u64,
+    /// #137: times the completeness net's re-seed recovered work the
+    /// incremental delta drain had left undone. **Nonzero means a rule premise
+    /// can arrive without a trigger** — the verdict is still correct (the net
+    /// recovers it) but the missing trigger is a real bug worth locating.
+    /// `RUSTDL_RESEED_PROBE=1` prints each occurrence.
+    pub reseed_recovered: u64,
     /// Of `branches_taken`, those from the ⊔ disjunction rule
     /// (`find_open_disjunction`). Split out from `≤n` merge branches so
     /// search-quality work can tell which branch kind dominates a stall.
@@ -741,6 +747,11 @@ pub struct HyperEngine<'c> {
     /// whole graph each solve frame. Default OFF until validated FP=0 AND
     /// MISSED=0.
     incremental_fixpoint: bool,
+    /// #137 completeness net enabled (`RUSTDL_RESEED_VERIFY`, default ON).
+    reseed_verify: bool,
+    /// Re-entrancy guard for the #137 completeness net, keeping the re-seed
+    /// recursion exactly one level deep.
+    reseed_verify_active: bool,
     /// Fix#2 Layer A (`RUSTDL_SEMANTIC_BRANCHING`, via
     /// [`with_semantic_branching`]): opt-in in-search boolean constraint
     /// propagation at the `⊔` decision point — drop told-disjoint disjuncts and
@@ -1379,6 +1390,8 @@ impl<'c> HyperEngine<'c> {
             clash_deps: DepSet::EMPTY,
             double_blocking: false,
             incremental_fixpoint: false,
+            reseed_verify: crate::reseed_verify_enabled(),
+            reseed_verify_active: false,
             semantic_branching: false,
             precise_card_deps: false,
             at_most_exhaust_probe: false,
@@ -1438,6 +1451,8 @@ impl<'c> HyperEngine<'c> {
             clash_deps: DepSet::EMPTY,
             double_blocking: false,
             incremental_fixpoint: false,
+            reseed_verify: crate::reseed_verify_enabled(),
+            reseed_verify_active: false,
             semantic_branching: false,
             precise_card_deps: false,
             at_most_exhaust_probe: false,
@@ -2181,6 +2196,54 @@ impl<'c> HyperEngine<'c> {
         if self.match_deadline_hit.get() {
             return HyperResult::Stalled;
         }
+        // #137 completeness net for the INCREMENTAL drain. Incremental mode
+        // drains only the delta its own decision pushed, which is correct only
+        // if every rule has a trigger for every way its premises can arrive. A
+        // single missing trigger is then a SILENT incompleteness: the
+        // non-incremental path re-seeds from the graph every pass and so
+        // recovers it, while incremental mode simply never fires the rule and
+        // reports `Sat`. With `trust_sat` on (the default) that spurious `Sat`
+        // is believed and the subsumption is lost with no signal — measured on
+        // `ontologies/real/pizza.ofn`, where `SpicySalamiPizza ⊑ SpicyPizza`
+        // (confirmed by HermiT and Konclude) was dropped on the DEFAULT config.
+        //
+        // So before concluding `Sat`, re-seed once from the saturated graph and
+        // re-drain. Quiescence-triggered, not per-pass: the fast path still pays
+        // no re-seed while it is making progress, and the guard makes the
+        // recursion exactly one level deep. Any work this recovers was a missing
+        // trigger, and recovering it can only ADD entailed facts, so the net is
+        // sound by construction and can only turn a wrong `Sat` into `Unsat`.
+        //
+        // This is a safety net, not a licence to skip triggers: a rule reached
+        // only through it costs a full re-seed. Two genuine holes are fixed
+        // directly in this change (the qualified-`≤1` label trigger and the
+        // merge-inherited `≤1`), and any further one the net catches should be
+        // fixed at its trigger and pinned by
+        // `owl-dl-cli/tests/incremental_fixpoint_identity.rs`.
+        if self.incremental_fixpoint && self.reseed_verify && !self.reseed_verify_active {
+            let before = self.graph_fingerprint();
+            self.reseed_verify_active = true;
+            self.seed_worklist_from_graph();
+            let r = self.horn_fixpoint(max_iters);
+            self.reseed_verify_active = false;
+            if !matches!(r, HyperResult::Sat) {
+                return r;
+            }
+            // Count, do NOT assert. A nonzero count means a trigger is still
+            // missing somewhere — which is true today, so an assert here would
+            // fire on `pizza`. The count is the tracking signal for finding the
+            // remaining hole; the verdict is already correct either way.
+            if self.graph_fingerprint() != before {
+                self.stats.reseed_recovered += 1;
+                if std::env::var_os("RUSTDL_RESEED_PROBE").is_some() {
+                    eprintln!(
+                        "RESEED_PROBE: incremental drain left work undone \
+                         (recovered by the #137 net); a rule premise arrived \
+                         without a trigger"
+                    );
+                }
+            }
+        }
         HyperResult::Sat
     }
 
@@ -2189,6 +2252,23 @@ impl<'c> HyperEngine<'c> {
     /// the non-incremental `horn_fixpoint` re-seed (every pass) and the
     /// one-time root seed in `decide_with_deadline` under
     /// `incremental_fixpoint`.
+    /// Cheap O(nodes) structural fingerprint — total labels, total out-edges,
+    /// node count, merged-node count. Used by the #137 completeness net to tell
+    /// whether a re-seed recovered work the delta drain missed.
+    fn graph_fingerprint(&self) -> (usize, usize, usize, usize) {
+        let mut l = 0usize;
+        let mut e = 0usize;
+        let mut m = 0usize;
+        for (i, n) in self.nodes.iter().enumerate() {
+            l += n.labels.len();
+            e += n.edges.len();
+            if self.representative[i] != HNode(u32::try_from(i).expect("fits")) {
+                m += 1;
+            }
+        }
+        (l, e, self.nodes.len(), m)
+    }
+
     fn seed_worklist_from_graph(&mut self) {
         self.worklist.clear();
         for idx in 0..self.nodes.len() {
@@ -2257,6 +2337,33 @@ impl<'c> HyperEngine<'c> {
                 // other node carrying it (clashing if they are `≠`).
                 if matches!(self.apply_nn_rule(n, c), FireOutcome::Clash) {
                     return FireOutcome::Clash;
+                }
+                // #137 label trigger for QUALIFIED `≤1`. `n` gaining `c` grows the
+                // `≤1 r.c`-relevant successor set of every NEIGHBOUR of `n`, in
+                // both directions, mirroring the `Event::Edge` trigger's src/tgt
+                // symmetry: `distinct_role_succ` counts an out-edge `p —r→ n` at
+                // `p`, and (under `inverse_func_merge`) counts the pred `n —r→ m`
+                // at `m` via `r.flip()`.
+                if self.inverse_func_merge {
+                    let nbrs: SmallVec<[(HNode, Role); 8]> = self.nodes[n.index()]
+                        .preds
+                        .iter()
+                        .map(|&(r, p)| (p, r))
+                        .chain(
+                            self.nodes[n.index()]
+                                .edges
+                                .iter()
+                                .map(|&(r, m)| (m, r.flip())),
+                        )
+                        .collect();
+                    for (holder, via) in nbrs {
+                        for (cr, q) in self.at_most_ones_qualified(holder, via, c) {
+                            if matches!(self.enforce_at_most_one(holder, cr, q), FireOutcome::Clash)
+                            {
+                                return FireOutcome::Clash;
+                            }
+                        }
+                    }
                 }
                 let key = c.index() as usize;
                 // Clauses with `c` as an `X`-class fire at `n`.
@@ -2864,6 +2971,8 @@ impl<'c> HyperEngine<'c> {
             clash_deps: DepSet::EMPTY,
             double_blocking: false,
             incremental_fixpoint: false,
+            reseed_verify: crate::reseed_verify_enabled(),
+            reseed_verify_active: false,
             semantic_branching: false,
             precise_card_deps: false,
             at_most_exhaust_probe: false,
@@ -3555,6 +3664,31 @@ impl<'c> HyperEngine<'c> {
             .collect()
     }
 
+    /// The `(role, qual)` keys of `node`'s active QUALIFIED `≤1` constraints
+    /// that a neighbour newly labelled `c` can now violate.
+    ///
+    /// Companion to [`Self::at_most_ones`], which triggers off an `Event::Edge`.
+    /// An edge trigger alone is not enough for a QUALIFIED bound: `≤1 r.C`
+    /// counts only the `r`-successors carrying `C`, and the label can arrive
+    /// *after* the edge, at which point the successor set grows with no
+    /// `Event::Edge` to notice. That was #137 — the missing label trigger let a
+    /// genuine `≤1` violation survive the incremental drain and reach
+    /// `find_open_at_most`, which asserts it cannot.
+    fn at_most_ones_qualified(
+        &self,
+        node: HNode,
+        edge_role: Role,
+        c: ClassId,
+    ) -> SmallVec<[(Role, Option<ClassId>); 2]> {
+        let hier = self.sub_roles.as_ref();
+        self.nodes[self.resolve(node).index()]
+            .at_most
+            .iter()
+            .filter(|&&(cr, q, n)| n == 1 && q == Some(c) && role_matches(edge_role, cr, hier))
+            .map(|&(cr, q, _)| (cr, q))
+            .collect()
+    }
+
     /// Fire a deterministic `≤1`/functional merge for the `(role, qual)`
     /// constraint at `node`, INCREMENTALLY inside the Horn fixpoint — mirroring
     /// [`Self::apply_nn_rule`] (nominals). A `≤1` is deterministic: two
@@ -4031,9 +4165,23 @@ impl<'c> HyperEngine<'c> {
                 self.worklist.push(Event::Edge(rp, r, s_i));
             }
         }
+        let mut inherited_at_most_ones: SmallVec<[(Role, Option<ClassId>); 2]> = SmallVec::new();
         for c in self.nodes[s_j.index()].at_most.clone() {
             if !self.nodes[s_i.index()].at_most.contains(&c) {
                 self.nodes[s_i.index()].at_most.push(c);
+                // #137: a MERGE-inherited `≤1` needs the same constraint-added
+                // trigger the `Atom::AtMost` head path gets — the survivor may
+                // already hold ≥2 matching successors (its own plus those just
+                // absorbed) and no `Event::Edge` describes the constraint's
+                // arrival. Fired below, once these borrows have ended.
+                if c.2 == 1 {
+                    inherited_at_most_ones.push((c.0, c.1));
+                }
+            }
+        }
+        for (cr, q) in inherited_at_most_ones {
+            if matches!(self.enforce_at_most_one(s_i, cr, q), FireOutcome::Clash) {
+                return true;
             }
         }
         if !self.nodes[s_j.index()].at_most.is_empty() {

--- a/crates/owl-dl-tableau/src/lib.rs
+++ b/crates/owl-dl-tableau/src/lib.rs
@@ -4038,3 +4038,10 @@ pub fn hyper_fixpoint_deadline_enabled() -> bool {
     // Default-ON idiom (house convention): an EMPTY value enables.
     std::env::var_os("RUSTDL_FIXPOINT_DEADLINE").is_none_or(|v| v != "0")
 }
+
+/// #137 completeness net for the incremental Horn drain (`RUSTDL_RESEED_VERIFY`,
+/// **default ON**; `=0` reverts). See `hyper::HyperEngine::horn_fixpoint`.
+#[must_use]
+pub fn reseed_verify_enabled() -> bool {
+    std::env::var_os("RUSTDL_RESEED_VERIFY").is_none_or(|v| v != "0" && !v.is_empty())
+}


### PR DESCRIPTION
Fixes #137, and closes the corpus net's last MISSED.

## The bug

`RUSTDL_HYPER_INCREMENTAL_FIXPOINT` (**default ON**) drains only the delta a decision pushed. That is correct only if every rule has a trigger for every way its premises can arrive. The non-incremental path re-seeds from the graph every pass and so *masks* a missing trigger; incremental mode simply never fires the rule and reports `Sat` — and with `trust_sat` on (also default) that spurious `Sat` is believed, the pair never reaches the tableau, and the subsumption is lost **with no signal**.

Surfaced by provisioning `ontologies/real/` for #133's soundness run, which activated a test that had been quietly skipping.

## Three holes

1. **Qualified-`≤1` label trigger.** `≤1 r.C` counts only the `r`-successors carrying `C`, and the label can arrive *after* the edge, with no `Event::Edge` to notice. Every violation I dumped was `qual=Some(..)`, never unqualified — which is exactly why functional-only corpora (galen, notgalen) never showed this. Fixed with `at_most_ones_qualified` plus a neighbour walk in the `Event::Label` arm, mirroring the edge trigger's src/tgt symmetry.
2. **Merge-inherited `≤1`.** A merge copies `s_j.at_most` onto the survivor without firing the constraint-added trigger that the `Atom::AtMost` head path gets, so a survivor already holding ≥2 matching successors was never re-checked.
3. **The general case**, because (1) and (2) are unlikely to be the last: on reaching quiescence, re-seed once and re-drain. Sound by construction — it can only add entailed facts, i.e. only turn a wrong `Sat` into `Unsat`. Gated by `RUSTDL_RESEED_VERIFY` (**default ON**, `=0` reverts).

**The net is load-bearing 142 times on `sio` and twice on `ro`**, so the drain's incompleteness is widespread — it just happened to change a verdict only on pizza. So a residual hole remains: `stats.reseed_recovered` counts it and `RUSTDL_RESEED_PROBE=1` prints each occurrence. That is deliberately a **counter, not a `debug_assert`** — asserting "no trigger is ever missing" fires immediately, because it is precisely what is still false. Locating the last trigger is follow-up work; the verdict is correct either way.

## Two recoveries, both oracle-confirmed

- **`pizza`: 111/112 → 112/112, FP=0, MISSED=0.** `SpicySalamiPizza ⊑ SpicyPizza`, which HermiT and Konclude both derive, was being dropped on the default config. **Every curated-corpus fixture is now MISSED=0.**
- **A pinned known-miss now derives.** `dkey_collapse_broadcast`'s `KNOWN-MISS-forall-super-value-sub` (`∀f.DataOneOf("a")`, `p ⊑ f`, `p(i,"b")`) is logically inconsistent and rustdl reported it consistent. Its own comment said to flip the expectation once the gap closed — done. Note the asymmetry that makes this a #137 fix rather than a datatype one: `RUSTDL_HYPER_INCREMENTAL_FIXPOINT=0` still misses it.

## Cost

A/B-able via the flag: `sio` 1.07 → 1.15 s (+7%), `ro` 0.30 → 0.60 s, `pizza` and `wine` unchanged.

## The gate was vacuous — the transferable part

`incremental_fixpoint_identity.rs` is described in its own header as the "durable byte-identity gate" on this flag. The only fixture in it that ever caught a real bug was the **gitignored** `ontologies/real/pizza.ofn` — absent in CI and in every fresh checkout — while its `compared >= 2` guard was satisfied by two checked-in bench fixtures. So it reported `ok` for as long as nobody provisioned the corpus by hand, and the default config silently lost a subsumption the whole time.

That pizza pair is now reduced to a 7-class fixture and **checked in**. Verified by moving pizza aside (simulating CI): the gate fails on the new fixture under `RUSTDL_RESEED_VERIFY=0` and passes with the net on. Same shape as the `[fp0]` net's recorded "9 of 22 fixture blocks could skip while the suite still reported `ok`" — the other gitignored-fixture gates are worth the same audit.

## Verification

Full suite + doctests green (including the previously-failing identity gate); fmt and clippy `-D warnings` clean; corpus soundness net with every fixture FP=0/MISSED=0 — `sio` 8904, `wine` 653, `ro` 158, `sulo` 51, `pizza` 112, `family` inconsistency detected. The net's 7 failures are the unchanged fixture-absence panics for `galen`/`notgalen`/`alehif`/ORE/`bibtex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
