### PR TITLE
fix(classify): the Horn arm of completeness_guaranteed() was a false certificate (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to rustdl are documented here. Format is based on
 
 ## [Unreleased]
 
+### Fixed — `completeness_guaranteed()`'s Horn arm was a false certificate (#124)
+
+`Classification::completeness_guaranteed()` returned `true` for `PureEl | Horn`. `Horn`
+is a property of the **clause shape** — "no disjunctive head, nothing deferred" — and it
+was being read as a property of the **run**. The two came apart:
+
+```
+X ⊑ ∃r.B,   Domain(r, ∃s.Z),   ∃s.Z ⊑ W        ⟹   X ⊑ W
+```
+
+Konclude and HermiT both derive `X ⊑ W`; so does rustdl's own `subclass X W`. But
+`classify` reports **no subsumptions at all**, and the certificate read clean.
+`CLAUDE.md` already recorded the underlying justification as false-as-implemented — *"the
+shortcircuit ran the EL saturator, not the hyper fixpoint"* — and `saturator_complete_
+fragment` had already learned this exact lesson, replacing its clausal test with a strict
+allowlist "anchored to the constructs the saturator's rules genuinely process". This arm
+had not.
+
+`Horn` is now untrusted: the certificate holds only on `PureEl`, whose gate (`is_pure_el`)
+carries an engine-level completeness contract rather than a clause count. The `#
+fragment:` banner no longer claims completeness for Horn either — it reads "Horn clause
+shape (NOT a completeness claim …)". Pinned by
+`horn_clause_shape_does_not_guarantee_completeness` in `tests/completeness_contract.rs`,
+using the ontology above.
+
+**`classify --json` gained `completeness_guaranteed`.** On that same input every existing
+field reads clean on a wrong answer: `consistent: true`, `incomplete: false`
+(*correctly* — no deadline fired), `trusted_sat_refutations: 0` (the pair was not refuted
+by a trusted `Sat`), `direct_subsumptions: []`. The miss was surfaced **nowhere**. The
+new field is the honest signal and is `false` there.
+
+It is a NEW field rather than a change to `incomplete`, because `incomplete`'s documented
+contract is "a deadline fired" and callers depend on that distinction — the same reasoning
+the code already gives for keeping `trusted_sat_refutations` separate. `docs/json-schema.md`
+now states outright that **`incomplete: false` does not mean complete**, and that
+`trusted_sat_refutations: 0` does not either.
+
+`disjoint --json` reads `completeness_guaranteed()` directly, so it now correctly reports
+`incomplete: true` on this ontology — which was #124's headline symptom.
+
 ### Fixed — a role chain leg could not be walked through an inverse-equivalent edge (#128)
 
 `apply_role_chains` resolved each chain position against raw edge labels *and*

--- a/crates/owl-dl-cli/src/json_out.rs
+++ b/crates/owl-dl-cli/src/json_out.rs
@@ -93,6 +93,22 @@ pub(crate) struct ClassifyJson {
     /// distinction callers already depend on. Same reasoning as
     /// `Realization::witness_prune_active`.
     pub(crate) trusted_sat_refutations: usize,
+    /// #124: the honest calibration signal — `Classification::
+    /// completeness_guaranteed()`, i.e. **this hierarchy is provably free of
+    /// missed subsumptions**. `true` only on a fragment where the engine that
+    /// answered is complete, and only with no timed-out pair.
+    ///
+    /// Added because on `X ⊑ ∃r.B`, `Domain(r, ∃s.Z)`, `∃s.Z ⊑ W` (⟹ `X ⊑ W`,
+    /// derived by both Konclude and `HermiT`) every other field here reads
+    /// clean: `consistent: true`, `incomplete: false` (correctly — no deadline
+    /// fired), `trusted_sat_refutations: 0` (the pair was not refuted by a
+    /// trusted `Sat`), `direct_subsumptions: []`. The miss was surfaced NOWHERE.
+    ///
+    /// A SEPARATE field rather than a change to `incomplete`, whose contract is
+    /// "a deadline fired" and which callers depend on: this reports a strictly
+    /// broader thing, and `incomplete == false` implies nothing about
+    /// completeness on its own.
+    pub(crate) completeness_guaranteed: bool,
     pub(crate) unsatisfiable: Vec<String>,
     pub(crate) equivalent_groups: Vec<Vec<String>>,
     pub(crate) direct_subsumptions: Vec<[String; 2]>,
@@ -281,6 +297,7 @@ pub(crate) fn build_classify_json(
         consistent: !stats.inconsistent,
         incomplete: stats.timed_out_pairs > 0,
         trusted_sat_refutations: trusted_sat_risk(&stats),
+        completeness_guaranteed: h.completeness_guaranteed(),
         unsatisfiable,
         equivalent_groups: groups,
         direct_subsumptions,

--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -320,12 +320,17 @@ pub enum FragmentClassification {
     /// Pure EL+ fragment (Kazakov ELK-style). Saturator alone is
     /// complete. `trust_sat` is sound by construction.
     PureEl,
-    /// Horn DL-clauses (every clausified axiom has ≤ 1 head atom
-    /// and the clausifier handles every axiom). The hyper Horn
-    /// fixpoint is complete by construction. `trust_sat` is sound by
-    /// construction. Strict superset of `PureEl` by classification,
-    /// but tagged separately so users see which engine carries the
-    /// guarantee.
+    /// Horn DL-clauses (every clausified axiom has ≤ 1 head atom and the
+    /// clausifier handles every axiom).
+    ///
+    /// **This is a clause-shape observation, NOT a completeness claim** (#124).
+    /// It once asserted "the hyper Horn fixpoint is complete by construction",
+    /// and `completeness_guaranteed()` spent that claim — but the shortcircuit
+    /// runs the EL saturator rather than the hyper fixpoint, and on a Horn
+    /// ontology `classify` can miss a subsumption both peer oracles derive
+    /// (`X ⊑ ∃r.B`, `Domain(r, ∃s.Z)`, `∃s.Z ⊑ W` ⟹ `X ⊑ W`). Kept as a
+    /// diagnostic label because the shape is still worth reporting; it no longer
+    /// certifies anything.
     Horn,
     /// The ontology uses disjunctive heads, axioms the clausifier
     /// defers, or other constructs outside the provably-complete
@@ -342,7 +347,8 @@ impl std::fmt::Display for FragmentClassification {
                 "pure-EL (trust_sat sound by construction; saturator alone is complete)",
             ),
             Self::Horn => f.write_str(
-                "Horn (trust_sat sound by construction; hyper Horn fixpoint is complete)",
+                "Horn clause shape (NOT a completeness claim — see #124; \
+                 trust_sat is empirically sound here, not proven complete)",
             ),
             Self::OutOfFragment => {
                 f.write_str("out-of-EL (trust_sat empirically sound; see fragment-completeness.md)")
@@ -910,10 +916,26 @@ impl Classification {
     /// `false` as "verify externally".
     #[must_use]
     pub fn completeness_guaranteed(&self) -> bool {
-        matches!(
-            self.stats.fragment,
-            FragmentClassification::PureEl | FragmentClassification::Horn
-        ) && self.stats.timed_out_pairs == 0
+        // `Horn` is DELIBERATELY not here (#124). It is a property of the
+        // CLAUSE SHAPE — "no disjunctive head, nothing deferred" — and was read
+        // as a property of the RUN. The two came apart: on
+        //
+        //   X ⊑ ∃r.B,  Domain(r, ∃s.Z),  ∃s.Z ⊑ W        ⟹  X ⊑ W
+        //
+        // (Konclude and HermiT both derive it) the clausification is Horn and
+        // `classify` reports NOTHING, while `subclass X W` answers `yes` — and
+        // the certificate read clean. `CLAUDE.md` already records the
+        // justification as false-as-implemented: "the shortcircuit ran the EL
+        // saturator, not the hyper fixpoint". `saturator_complete_fragment`
+        // learned the same lesson earlier and replaced its clausal test with a
+        // strict allowlist; this arm had not.
+        //
+        // `PureEl` stays because it is gated by `is_pure_el`, whose contract is
+        // that the SATURATOR — the engine that actually answers on that path —
+        // is complete, with the `BareRoleDecls` proof for the admitted inert
+        // declarations. That is an engine property, not a clause count.
+        matches!(self.stats.fragment, FragmentClassification::PureEl)
+            && self.stats.timed_out_pairs == 0
     }
 }
 

--- a/crates/owl-dl-reasoner/tests/completeness_contract.rs
+++ b/crates/owl-dl-reasoner/tests/completeness_contract.rs
@@ -1,7 +1,9 @@
 //! Canary for `Classification::completeness_guaranteed()` — the honest C2 contract.
 //!
-//! `completeness_guaranteed()` ⟹ `MISSED == 0`. It holds only on the
-//! provably-complete fragments (PureEl / Horn) with no timed-out pairs. On
+//! `completeness_guaranteed()` ⟹ `MISSED == 0`. It holds only on `PureEl` with
+//! no timed-out pairs. `Horn` was removed from the trusted set in #124: it is a
+//! clause-shape property that was being read as an engine property, and a Horn
+//! ontology exists on which `classify` misses an oracle-confirmed subsumption. On
 //! `OutOfFragment` inputs it returns `false` even when nothing times out, because
 //! `trust_sat` can silently miss a subsumption on complement/disjunction structure
 //! (the ORE-measured silent-miss hole — see
@@ -53,5 +55,32 @@ fn out_of_fragment_does_not_guarantee_completeness() {
     assert!(
         !c.completeness_guaranteed(),
         "OutOfFragment: completeness must NOT be guaranteed (trust_sat may silently miss)"
+    );
+}
+
+#[test]
+fn horn_clause_shape_does_not_guarantee_completeness() {
+    // #124's reproducer. The clausification is Horn (no disjunctive head, nothing
+    // deferred) and `X ⊑ W` IS entailed — Konclude and HermiT both derive it, and
+    // rustdl's own `subclass X W` answers `yes`. But `classify` misses it, so the
+    // certificate must NOT be handed out. Before #124 this returned `true`, which
+    // is the exact shape of a false completeness claim: wrong answer, clean flag.
+    //
+    // If `classify` ever learns this subsumption, this test still passes (the
+    // certificate stays false on `Horn` by construction) — but then consider
+    // whether `Horn` deserves a real, engine-backed allowlist rather than being
+    // untrusted wholesale.
+    let c = classify(
+        "Prefix(:=<http://ex.org/>)\nOntology(\n\
+         Declaration(Class(:X)) Declaration(Class(:B)) Declaration(Class(:Z)) Declaration(Class(:W))\n\
+         Declaration(ObjectProperty(:r)) Declaration(ObjectProperty(:s))\n\
+         SubClassOf(:X ObjectSomeValuesFrom(:r :B))\n\
+         ObjectPropertyDomain(:r ObjectSomeValuesFrom(:s :Z))\n\
+         SubClassOf(ObjectSomeValuesFrom(:s :Z) :W)\n)",
+    );
+    assert!(
+        !c.completeness_guaranteed(),
+        "Horn clause shape must NOT guarantee completeness: this very ontology \
+         is Horn and classify misses X ⊑ W, which both oracles derive"
     );
 }

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -7,12 +7,27 @@ All arrays are sorted (byte order); pairs are `[sub, sup]`.
 
 ```json
 { "schema_version": 1, "consistent": bool, "incomplete": bool,
+  "completeness_guaranteed": bool, "trusted_sat_refutations": int,
   "unsatisfiable": [iri], "equivalent_groups": [[iri, ...]],
   "direct_subsumptions": [[sub_iri, sup_iri], ...] }
 ```
 
 `incomplete` = some class pair hit the time budget (defaulted to not-subsumed);
 the hierarchy is sound (no false subsumptions) but may miss real ones.
+
+`completeness_guaranteed` = **the flag to read if you want to know whether the
+hierarchy can be trusted as complete** (#124). `true` only on a fragment where
+the engine that answered is provably complete, and only when no pair timed out.
+
+**`incomplete: false` does NOT mean complete.** It means no deadline fired.
+There are Horn ontologies where `classify` misses a subsumption both Konclude and
+HermiT derive while `incomplete` is `false`, `trusted_sat_refutations` is `0`, and
+`consistent` is `true` — every field reading clean on a wrong answer. That is what
+`completeness_guaranteed` exists to say, and it is `false` there.
+
+`trusted_sat_refutations` = pairs concluded not-subsumed from the wedge's own
+`Sat` verdict outside the fragment where that verdict is complete. An exposure
+count, not a defect count; `0` does not imply completeness either.
 
 `equivalent_groups` lists only *satisfiable* equivalence classes; unsatisfiable
 classes are reported in `unsatisfiable` (they are all mutually equivalent to


### PR DESCRIPTION
Fixes #124.

## The bug

`completeness_guaranteed()` returned `true` for `PureEl | Horn`. `Horn` is a property of the **clause shape** — no disjunctive head, nothing deferred — and it was being read as a property of the **run**. The two came apart:

```
X ⊑ ∃r.B,   Domain(r, ∃s.Z),   ∃s.Z ⊑ W        ⟹   X ⊑ W
```

Konclude and HermiT both derive `X ⊑ W`. So does rustdl's own `subclass X W`. But `classify` reports **no subsumptions at all**, and the certificate read clean.

This was already documented as false. `CLAUDE.md`: *"The 'hyper Horn fixpoint is complete on Horn' justification was false-as-implemented: the shortcircuit ran the EL saturator, not the hyper fixpoint."* And `saturator_complete_fragment`'s own doc comment records replacing its clausal test with a strict allowlist because *"the old `analyze_fragment == Horn` gate silently mis-classified Horn-but-not-EL inputs and reported complete"*. `completeness_guaranteed()` was still spending the retired claim.

## The change

`Horn` is untrusted. The certificate holds only on `PureEl`, whose gate (`is_pure_el`) carries an engine-level completeness contract — the saturator is complete on that fragment, with the `BareRoleDecls` proof for the inert declarations it admits — rather than a clause count. The `# fragment:` banner no longer claims completeness for Horn; it reads "Horn clause shape (NOT a completeness claim …)". The enum's doc records why.

## `classify --json` gained `completeness_guaranteed`

On the ontology above, every existing field reads clean on a wrong answer:

| field | value | |
| --- | --- | --- |
| `consistent` | `true` | correct |
| `incomplete` | `false` | **correct** — no deadline fired |
| `trusted_sat_refutations` | `0` | correct — the pair was not refuted by a trusted `Sat` |
| `direct_subsumptions` | `[]` | **wrong** |

The miss was surfaced **nowhere**. `completeness_guaranteed` is the honest signal and is `false` there (`true` on a pure-EL control).

Deliberately a **new field**, not a change to `incomplete`: that flag's documented contract is "a deadline fired", and the code already argues for keeping `trusted_sat_refutations` separate for the same reason — *"overloading it would destroy a distinction callers already depend on"*. `docs/json-schema.md` now states outright that **`incomplete: false` does not mean complete**, and that `trusted_sat_refutations: 0` does not either.

`disjoint --json` reads the certificate directly, so it now correctly reports `incomplete: true` on this input — #124's headline symptom.

## Verification

fmt, clippy `-D warnings`, and doctests clean. `completeness_contract.rs` extended with `horn_clause_shape_does_not_guarantee_completeness` using this exact ontology; all 3 canaries pass.

Full suite green **except** `incremental_fixpoint_identity`, which is **#137** and unrelated to this branch — it fails on `main` too whenever `ontologies/real/` is provisioned, and is fixed in **#140**. Merge order doesn't matter; the two touch disjoint code.

## Worth deciding separately

`Horn` is now untrusted *wholesale*, which is honest but coarse — there is presumably a real Horn-shaped fragment on which the engine is complete. Giving it the `saturator_complete_fragment` treatment (a strict allowlist anchored to what the engine demonstrably processes) would recover the certificate for inputs that deserve it. That is a bigger, evidence-driven change and I have not attempted it here; being conservative is the safe direction for a calibration flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
