### PR TITLE
fix(classify): the wedge ran without the role hierarchy, hiding symmetry (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ All notable changes to rustdl are documented here. Format is based on
 
 ## [Unreleased]
 
+### Fixed — the classify wedge ran without the role hierarchy, hiding symmetry (#135, #128)
+
+`RUSTDL_CLASSIFY_SAME_TIER` bundled two independent things behind one **default-OFF**
+lever, justified by a "~2× wall":
+
+- **Layer A** — carry the role hierarchy into the classify wedge.
+- **Layer B** — broaden the same-tier sweep to label-driven.
+
+With Layer A off, every wedge on the default path ran with `sub_roles == None`, so
+`hyper::role_matches` fell back to exact role-id **and** exact polarity: **symmetry and
+sub-role matching were invisible to the engine that decides most pairs**. That is why
+#128's symmetric-chain entailment still vanished from `classify` after the calculus was
+fixed in #133 — `subclass` was right and `classify` was wrong on the same binary.
+
+Layer A is now its own lever, `RUSTDL_CLASSIFY_WEDGE_HIERARCHY`, **default ON**
+(`=0` reverts). Layer B keeps `RUSTDL_CLASSIFY_SAME_TIER`.
+
+**The "~2× wall" belonged to Layer B.** Layer A alone, measured: `sio` 1.07 → 1.36 s,
+`wine` 3.17 → 3.99 s (~25-30%), `ro` 0.27 → 0.29 s, `pizza` unchanged.
+
+**And "corpus-invisible" was wrong — it is ORE-visible by 313 subsumptions.** Paired A/B
+over the 610-ontology trigger set, 463 with both binaries completing:
+
+| metric | baseline | with Layer A |
+| --- | --- | --- |
+| rustdl subsumptions | 6,458,921 | 6,459,234 |
+| false positives | **0** | **0** |
+| MISSED | 4,265 | **3,952** |
+
+`ore_ont_16457` alone goes 936 → 695 MISSED; `ore_ont_16666`, `ore_ont_2792` and
+`ore_ont_8148` each recover ~20. Of the 13 DIFF rows, 4 are TIMEOUT flips at the 90 s cap
+in both directions and one (`ore_ont_9662`) looked like a regression (MISSED 1 → 2) but is
+budget noise — identical at a 600 s cap, 3/3 runs. Corpus net unchanged, all FP=0.
+
+**This does NOT close #128 on its own.** The reporter's file needs a third fix: with
+Domain/Range stripped the entailment now appears in `classify`, with them present it does
+not — so #131 (range on a chain leg) co-blocks it. Measured:
+
+| `epi_corrected_debug_minimal` | default | with Layer A |
+| --- | --- | --- |
+| as submitted | 0 | 0 |
+| `Domain`/`Range` stripped | 0 | **1** |
+
+**#135's other half is NOT fixed.** `role_matches` still has no notion of
+`InverseObjectProperties` between two DISTINCT roles; only the `r == s` (symmetry) case
+works. Three attempts failed — adding the pairs to `RoleHierarchy`, a cross-polarity arm
+in `role_matches`, and indexing the first-leg trigger under the partner's key — and were
+reverted rather than left as dead code. The reassessment: the codebase's existing strategy
+for distinct inverse pairs is CANONICALISATION (`build_role_hierarchy`'s `canon_map`
+rewrites `s → co⁻`), and teaching a second matcher about a second representation fights
+it. The route worth trying is applying `canon` during clausification so the case collapses
+into the polarity handling the wedge already has.
+
 ### Fixed — a role chain leg could not be walked through an inverse-equivalent edge (#128)
 
 `apply_role_chains` resolved each chain position against raw edge labels *and*

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -2040,6 +2040,23 @@ pub fn counting_pair_verify_enabled() -> bool {
     std::env::var_os("RUSTDL_COUNTING_PAIR_VERIFY").is_none_or(|v| v != "0" && !v.is_empty())
 }
 
+/// Layer A of SP1.1, split out (#135): carry the role hierarchy into the classify
+/// wedge, so `hyper::role_matches` can see sub-roles and symmetry. **Default ON.**
+/// `RUSTDL_CLASSIFY_WEDGE_HIERARCHY=0` reverts.
+///
+/// Previously this rode on `RUSTDL_CLASSIFY_SAME_TIER` together with Layer B (the
+/// label-driven same-tier sweep), and that combined lever is DEFAULT OFF for a
+/// "~2× wall" that is dominated by Layer B. The consequence was that on the
+/// default path the wedge ran with `sub_roles == None`, so `role_matches` fell
+/// back to exact role-id plus exact polarity and **symmetry and sub-role matching
+/// were invisible to it** — which is why #128's symmetric-chain entailment
+/// survived in `classify` after the calculus itself was fixed. Splitting the two
+/// lets the cheap half be on by default; Layer B keeps the old flag.
+#[must_use]
+pub(crate) fn classify_wedge_hierarchy_enabled() -> bool {
+    std::env::var_os("RUSTDL_CLASSIFY_WEDGE_HIERARCHY").is_none_or(|v| v != "0" && !v.is_empty())
+}
+
 /// Same-tier classify-completeness (SP1.1): carry the role hierarchy into the
 /// classify oracle (Layer A) + broaden the same-tier sweep to label-driven
 /// (Layer B), so inverse/symmetric-domain subsumptions surface in default
@@ -3722,7 +3739,7 @@ impl HyperCache {
         } else {
             value_disjoint
         };
-        let same_tier = crate::classify_same_tier_enabled();
+        let same_tier = crate::classify_wedge_hierarchy_enabled();
         let idx_hier = if same_tier { Some(&sub_roles) } else { None };
         let mut base_indexes_inner =
             owl_dl_tableau::hyper::build_clause_indexes(&clauses, idx_hier);
@@ -4112,7 +4129,7 @@ impl HyperCache {
             // differently between base and delta (advisor B1). The extras all
             // have class-only bodies, so the hierarchy argument is irrelevant
             // to them; pass the same gate as the base build for consistency.
-            let idx_hier = if crate::classify_same_tier_enabled() {
+            let idx_hier = if crate::classify_wedge_hierarchy_enabled() {
                 Some(&self.sub_roles)
             } else {
                 None
@@ -4152,7 +4169,7 @@ impl HyperCache {
         // role-body atoms, so `with_sub_roles_keep_index` suffices; the old
         // path rebuilds the per-pair index with the hierarchy exactly as
         // before (`with_sub_roles`).
-        if crate::classify_same_tier_enabled() {
+        if crate::classify_wedge_hierarchy_enabled() {
             engine = if self.amortize_idx {
                 engine.with_sub_roles_keep_index(self.sub_roles.clone())
             } else {
@@ -4222,7 +4239,7 @@ impl HyperCache {
         if crate::semantic_branching_enabled() {
             engine = engine.with_semantic_branching();
         }
-        if crate::classify_same_tier_enabled() {
+        if crate::classify_wedge_hierarchy_enabled() {
             engine = engine.with_sub_roles(self.sub_roles.clone());
         }
         if hyper_double_block_enabled() {
@@ -4357,7 +4374,7 @@ impl HyperCache {
             // ⊥-headed value-disjoint clashes), so the hierarchy argument is
             // irrelevant to them; pass the same gate as the base build for
             // consistency with `decide_with_stats`.
-            let idx_hier = if crate::classify_same_tier_enabled() {
+            let idx_hier = if crate::classify_wedge_hierarchy_enabled() {
                 Some(&self.sub_roles)
             } else {
                 None
@@ -4375,7 +4392,7 @@ impl HyperCache {
                 std::sync::Arc::clone(&self.base_disjoint_pairs),
                 delta,
             );
-            if crate::classify_same_tier_enabled() {
+            if crate::classify_wedge_hierarchy_enabled() {
                 e = e.with_sub_roles_keep_index(self.sub_roles.clone());
             }
             e
@@ -4389,7 +4406,7 @@ impl HyperCache {
                 || self.value_disjoint.is_some()
             {
                 let mut e = HyperEngine::new(&full_clauses, self.fresh_q);
-                if crate::classify_same_tier_enabled() {
+                if crate::classify_wedge_hierarchy_enabled() {
                     e = e.with_sub_roles(self.sub_roles.clone());
                 }
                 e
@@ -4400,7 +4417,7 @@ impl HyperCache {
                     std::sync::Arc::clone(&self.base_indexes),
                     std::sync::Arc::clone(&self.base_disjoint_pairs),
                 );
-                if crate::classify_same_tier_enabled() {
+                if crate::classify_wedge_hierarchy_enabled() {
                     e = e.with_sub_roles_keep_index(self.sub_roles.clone());
                 }
                 e

--- a/crates/owl-dl-reasoner/tests/chain_symmetric_leg.rs
+++ b/crates/owl-dl-reasoner/tests/chain_symmetric_leg.rs
@@ -42,10 +42,11 @@
 //! [`is_subclass_of`] drives. Default `classify` answers this shape EARLIER — the
 //! hypertableau wedge decides the pair (and the label heuristic prunes it on the
 //! wedge's labels) — and the wedge carries its own copy of this gap, so the #128
-//! ontology still classifies wrongly. That remaining gap is pinned separately by
-//! `default_classify_still_misses_the_symmetric_chain_leg`, per the
-//! pin-the-defect-visibly convention in
-//! `owl-dl-verify/tests/known_limitations.rs`.
+//! ontology used to classify wrongly even so. #135 closed that by carrying the
+//! role hierarchy into the wedge by default, and
+//! `default_classify_now_finds_the_symmetric_chain_leg` — formerly a pinned
+//! known-limitation, flipped when CI caught it passing — holds both paths to the
+//! same answer.
 //!
 //! # The negatives are the point of this file
 //!
@@ -257,29 +258,28 @@ EquivalentClasses(:T1b ObjectSomeValuesFrom(:s ObjectIntersectionOf(\
 }
 
 #[test]
-fn default_classify_still_misses_the_symmetric_chain_leg() {
-    // KNOWN LIMITATION, pinned deliberately rather than `#[ignore]`d — see
-    // `docs/2026-08-18-ignored-sentinels-went-stale-unobserved.md`. The chain-rule
-    // fix above repairs the classic tableau, but default `classify` never reaches
-    // it on this shape: the hypertableau wedge decides the pair, and the wedge's
-    // `role_matches` can only traverse a symmetric edge backwards when the role
-    // hierarchy is threaded in — which happens ONLY under
-    // `RUSTDL_CLASSIFY_SAME_TIER=1` ("DEFAULT OFF — sound (FP=0) but
-    // corpus-invisible and ~2× wall"). #128 is the counterexample to
-    // "corpus-invisible": a user hit it. `is_subclass_of` is the correct answer
-    // today; `classify` is not.
+fn default_classify_now_finds_the_symmetric_chain_leg() {
+    // WAS a pinned known limitation. When this fix landed the chain rule, default
+    // `classify` still missed this shape: the hypertableau wedge decided the pair
+    // first and ran with `sub_roles == None`, so `role_matches` fell back to exact
+    // role-id AND exact polarity and symmetry was invisible to it. The hierarchy
+    // reached the wedge only under `RUSTDL_CLASSIFY_SAME_TIER=1`, a lever bundled
+    // with an expensive sweep and defaulted OFF.
     //
-    // If this assertion starts FAILING, that is the good news — the wedge learned
-    // the backward hop (or the gate was flipped). Turn it into a positive and
-    // retire this note.
+    // #135 split that lever: `RUSTDL_CLASSIFY_WEDGE_HIERARCHY` (default ON) now
+    // carries the hierarchy into the wedge on its own. The pin's own failure
+    // message asked for exactly this flip, and CI delivered it.
+    //
+    // Both paths must now agree — that agreement is the point, since the bug this
+    // file exists for was `subclass` and `classify` disagreeing on one binary.
     let ofn = two_definitions("SymmetricObjectProperty(:co)\n");
     assert!(
-        !classify_holds(&ofn, "T1a", "T1b"),
-        "default classify now reports T1a ⊑ T1b — the wedge-side gap behind #128 \
-         is closed; make this a positive assertion and update the module docs"
+        classify_holds(&ofn, "T1a", "T1b"),
+        "default classify must find T1a ⊑ T1b now that the wedge carries the role \
+         hierarchy (#135)"
     );
     assert!(
         holds(&ofn, "T1a", "T1b"),
-        "the complete path must still get it right even while classify does not"
+        "the complete path must agree with classify"
     );
 }


### PR DESCRIPTION
Refs #135, refs #128 — **partial**. Fixes the half that makes symmetry visible to `classify`; the distinct-role inverse-pair half is not fixed and is explained below.

## The bug

`RUSTDL_CLASSIFY_SAME_TIER` bundled two independent things behind one **default-OFF** lever, justified by a "~2× wall":

- **Layer A** — carry the role hierarchy into the classify wedge
- **Layer B** — broaden the same-tier sweep to label-driven

With Layer A off, every wedge on the default path ran with `sub_roles == None`, so `hyper::role_matches` fell back to exact role-id **and** exact polarity. **Symmetry and sub-role matching were invisible to the engine that decides most pairs.** That is why #128's entailment still vanished from `classify` after the calculus was fixed in #133 — `subclass` was right and `classify` wrong, on the same binary and the same pair.

Layer A is now its own lever, `RUSTDL_CLASSIFY_WEDGE_HIERARCHY` (**default ON**, `=0` reverts). Layer B keeps the old flag.

## Both halves of the old justification were wrong

**The "~2× wall" was Layer B's.** Layer A alone: `sio` 1.07 → 1.36 s, `wine` 3.17 → 3.99 s (~25-30%), `ro` 0.27 → 0.29 s, `pizza` unchanged.

**"Corpus-invisible" is true of the corpus and false of ORE — by 313 subsumptions.** Paired A/B over the 610-ontology trigger set, 463 with both binaries completing:

| metric | baseline | with Layer A |
| --- | --- | --- |
| rustdl subsumptions | 6,458,921 | 6,459,234 |
| oracle subsumptions | 6,462,873 | 6,462,873 |
| **false positives** | **0** | **0** |
| MISSED | 4,265 | **3,952** |

`ore_ont_16457` alone goes 936 → 695 MISSED; `ore_ont_16666`, `ore_ont_2792`, `ore_ont_8148` each recover ~20. Of the 13 DIFF rows, 4 are TIMEOUT flips at the 90 s cap in **both** directions, and `ore_ont_9662` looked like a regression (MISSED 1 → 2) but is budget noise — identical at a 600 s cap, 3/3 runs. I re-ran that row specifically because it was the only one pointing the wrong way.

Corpus soundness net unchanged, every fixture FP=0.

## This does NOT close #128 on its own

The reporter's ontology needs a third fix:

| `epi_corrected_debug_minimal` | default | with Layer A |
| --- | --- | --- |
| as submitted | 0 | **0** |
| `Domain`/`Range` stripped | 0 | **1** ✓ |

So **#131 co-blocks it**. #128 needs #133 (merged) + this + #131. Leaving #128 open.

## #135's other half is NOT fixed

`role_matches` still has no notion of `InverseObjectProperties` between two **distinct** roles; only the `r == s` (symmetry) case works. Three attempts failed:

1. carrying the pairs on `RoleHierarchy`,
2. a cross-polarity arm in `role_matches`,
3. indexing the first-leg trigger under the partner's key (the `Event::Edge` lookup is keyed by the **edge's** role, which is why symmetry gets away with the atom's own key and a distinct partner does not).

All three were reverted rather than left as dead code. The reassessment worth recording: the codebase already has a strategy for distinct inverse pairs — **canonicalisation**, `build_role_hierarchy`'s `canon_map` rewriting `s → co⁻` — and teaching a second matcher about a second representation fights it. The route worth trying is applying `canon` during clausification so the case collapses into the polarity handling the wedge already has. That is a clausifier change and deserves its own attempt, not a fourth patch on three failures.

## Verification

fmt and clippy `-D warnings` clean; corpus soundness net all FP=0 with closures unchanged; ORE as above. Full suite green except `incremental_fixpoint_identity`, which is **#137** — it fails on `main` too whenever `ontologies/real/` is provisioned, and is fixed in **#140**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
