### PR TITLE
fix(wedge): split SP1.1 Layer A out of Layer B so the role hierarchy is reachable (#128)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2028,6 +2028,73 @@ Data flows: `horned-owl` parse → `owl-dl-core` (IR + preprocessing) →
   paths can label one logical nested-existential witness differently and get deduped into two
   separate elements — not shown unsound, but untested against a future concept-level check).
 
+> **SP1.1 LAYER A SPLIT OUT OF LAYER B (2026-09-11, #128, `RUSTDL_CLASSIFY_ROLE_HIERARCHY`,
+> DEFAULT OFF, `=1` enables) — A CHEAP CORRECTNESS LEVER WAS BUNDLED WITH AN EXPENSIVE ONE.**
+> Externally reported: `Symmetric(p)` + `p ∘ q ⊑ q` + `A ≡ ∃p.Y ⊓ ∃q.Z` + `B ≡ ∃p.(Y ⊓ ∃q.Z)`
+> makes `A ≡ B`, and `classify` derived only `B ⊑ A` — the chain-only direction — with
+> `incomplete: false` and `dropped: {}`. Both peers derive it.
+>
+> **THE ENGINE COULD ALWAYS DO THIS; IT WAS NOT BEING TOLD.** The wedge's `role_matches` honours
+> sub-roles, declared inverses and symmetry only when the role hierarchy is threaded into the
+> per-pair oracle — SP1.1 "Layer A". That threading shared ONE flag with Layer B's label-driven
+> same-tier sweep, and **the recorded ~2× wall for SP1.1 belongs to Layer B**, so Layer A sat
+> behind an opt-in priced for something else. The split is the durable contribution here; the
+> bare engine (`hyper-classify-probe`) derived the pair all along.
+>
+> **DEFAULT OFF ON A MEASURED WALL REGRESSION, NOT ON DOUBT ABOUT CORRECTNESS.** Full 1,920
+> two-arm sweep (one binary, env var the only difference, arm order alternated, 60 s cap):
+> **1,800 IDENTICAL / 95 BOTH_DNF / 23 DIFFER / 2 REGRESSED**, and all 23 DIFFERs are row GAINS
+> (`ore_ont_10019` +2, both Konclude-confirmed; `13647` 202→500; `16457` 125→301). Both
+> regressions reproduce sequentially on an idle host at a 300 s cap, 3 runs per arm, **with
+> IDENTICAL ANSWERS in both arms** — pure wall: `ore_ont_16372` 3–4 s → **66–73 s** (~19×, 0 rows
+> / 744 unsat both arms), `ore_ont_9890` 17–18 s → **89–94 s** (~5×, 642 rows both arms). The gain
+> is completeness and the cost is other people's wall, so **a flip needs 0 REGRESSED**.
+>
+> **THE MECHANISM IS NOT ESTABLISHED — do not quote the index-rebuild story as the cause.**
+> `with_sub_roles` rebuilds the clause index, which is the documented ~20× cost class of
+> `RUSTDL_CLASSIFY_LABELS_AMORTIZE` and the same magnitude, so it is the leading suspect. But on
+> both regressed ontologies EVERY classify phase reports 0 ms with `subsumption` and
+> `satisfiability probes` both 0 — the pure-EL all-phases-zero trap, so the banner attributes
+> nothing — and the one unconditional rebuild site turned out to be `sat_only_with_stats`, a
+> DIAGNOSTIC path. Retry: pin the cost to a site, use `with_sub_roles_keep_index` wherever the
+> base index is already hierarchy-aware, re-run the same sweep.
+>
+> **A 6-ONTOLOGY SAMPLE SAID THIS WAS FREE, AND IT WAS WRONG BY 25×.** Curated corpus 8/8
+> row-identical; a hand-picked wedge-heavy ORE sample gave ratios 1.00–2.40× with the EXPENSIVE
+> members at ~1.1× and found ONE real change. The full sweep found 25 and two regressions the
+> sample's population could not contain. Same failure mode this file already records for the
+> 12-ontology benchmark that took four ontologies to DNF. **Size a default flip on the sweep, and
+> treat any sample as a smoke test.**
+>
+> **THE REPORTER'S FILE NEEDS TWO FIXES, WHICH IS WHY ONE FLAG LOOKED INERT.** It also carries
+> #131 (a chain-clause wake-up ordering gap), so it needs
+> `RUSTDL_CLASSIFY_ROLE_HIERARCHY=1 RUSTDL_SAT_SEED=0` together and **neither alone** — which is
+> how a correct fix can read as doing nothing. A first workaround posted to the issue was verified
+> on the minimal synthetic and NOT on the reporter's file, and was wrong; it had to be retracted
+> publicly. **Validate a workaround on the reporter's actual input.**
+>
+> **AND "NO FLAG RECOVERS IT" WAS MY OWN MEASUREMENT ERROR.** I tested
+> `RUSTDL_CLASSIFY_SAME_TIER=1` through `rustdl subclass` — a surface that flag does not affect —
+> and concluded the calculus was at fault. On `classify` it recovers the minimal shape outright.
+> The lesson is one this file already carries: **run a control through the SAME command that
+> exhibits the defect.**
+>
+> Residuals recorded, not fixed: a length-3 chain with a symmetric leg (pinned, FLIP when it
+> closes); sub-role-of-symmetric reversal; `SymmetricObjectProperty(ObjectInverseOf(:p))` silently
+> dropped (both `expand_role_characteristics` and `mark_symmetric` guard `!role.is_inverse()`);
+> and a LATENT FP — `collect_inverse_pairs` strips polarity and `mark_symmetric` fires on matching
+> ids, so `InverseObjectProperties(:p ObjectInverseOf(:p))` would mark `p` symmetric. Unreachable
+> today only because horned-owl rejects that syntax while both peers accept it; **closing that
+> parser gap makes it live.** Also still open: `apply_role_chains` in the tableau compares raw role
+> ids with `==` instead of `edge_satisfies`, so it independently ignores symmetry, declared
+> inverses AND the sub-role hierarchy — matters for `subclass`/`sat`/`explain`/`realize`.
+>
+> Canaries `crates/owl-dl-reasoner/tests/symmetric_role_chain.rs` (7, incl. 3 FP guards, a pinned
+> residual, and `the_fix_is_opt_in_and_the_default_still_misses` so a future flip cannot happen
+> silently). **Every test in that file locks a shared env mutex, not just the mutating one** —
+> Rust runs tests in parallel and the first version had read-only tests observing another test's
+> `=0`, which failed spuriously.
+
 > **AN INVERSE-ROLE DOMAIN/RANGE WAS DISCARDED UNDER A CORRECT IDENTITY (2026-09-08, #125,
 > unflagged).** Both `collect_el_rules` arms did nothing at all when `role.is_inverse()`, under
 > the comment *"inverse-role domain = forward range; handled by the tableau"*. **The identity is

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -2050,6 +2050,62 @@ pub(crate) fn classify_same_tier_enabled() -> bool {
     std::env::var_os("RUSTDL_CLASSIFY_SAME_TIER").is_some_and(|v| v == "1")
 }
 
+/// SP1.1 **Layer A** alone: carry the role hierarchy into the classify oracle
+/// (`HyperCache::{build,decide_with_stats,classify_labels}`) so `role_matches`
+/// can honour sub-roles, declared inverses and symmetry. **DEFAULT OFF**
+/// (`RUSTDL_CLASSIFY_ROLE_HIERARCHY=1` enables) — see the wall measurement below.
+///
+/// **Split out of `RUSTDL_CLASSIFY_SAME_TIER` for #128.** Layer A (threading)
+/// and Layer B (the label-driven same-tier sweep) shared one flag, and the ~2×
+/// wall recorded for SP1.1 is attributable to **Layer B's sweep**, not to
+/// threading — so the two were bundled at a cost only one of them incurs.
+/// Without Layer A the wedge's `role_matches` is exact-id and same-polarity, so
+/// a chain whose first leg is symmetric never fires in the reverse direction and
+/// `classify` misses an oracle-confirmed subsumption while reporting
+/// `incomplete: false` (the D10 shape — see #128).
+///
+/// `RUSTDL_CLASSIFY_SAME_TIER=1` **implies** this, because Layer B's sweep is
+/// documented as relying on the oracle already being hierarchy-aware; letting
+/// this flag's absence silently strip that out from under it would make the
+/// opt-in incoherent rather than merely slower.
+///
+/// **DEFAULT OFF ON A MEASURED WALL REGRESSION, NOT ON DOUBT ABOUT CORRECTNESS.**
+/// A full 1,920-ontology two-arm sweep (one binary, env var the only difference,
+/// arm order alternated, 60 s cap) reads **1,800 IDENTICAL / 95 `BOTH_DNF` /
+/// 23 DIFFER / 2 REGRESSED**, and the 23 DIFFERs are row GAINS. But both
+/// regressions reproduce sequentially on an idle host at a 300 s cap, 3 runs per
+/// arm, with **identical answers in both arms** — they are pure wall:
+///
+/// | ontology | answers | OFF | ON |
+/// |---|---|---|---|
+/// | `ore_ont_16372` | identical (0 rows, 744 unsat) | 3–4 s | **66–73 s** |
+/// | `ore_ont_9890` | identical (642 rows) | 17–18 s | **89–94 s** |
+///
+/// ~19× and ~5×, reproducible, and enough to cross a 60 s budget. **The
+/// mechanism is NOT established** — `with_sub_roles` rebuilds the clause index
+/// (the documented ~20× cost class of `RUSTDL_CLASSIFY_LABELS_AMORTIZE`, and the
+/// same magnitude), which is the leading suspect, but on these two ontologies
+/// every classify phase reports 0 ms and `subsumption`/`satisfiability probes`
+/// are both 0, so the cost is not attributable from the banner and the one
+/// unconditional rebuild site turned out to be a diagnostic path. Do not quote
+/// the index-rebuild story as the cause until someone profiles it.
+///
+/// **Retry conditions:** pin the cost to a site, use
+/// `with_sub_roles_keep_index` wherever the base index is already
+/// hierarchy-aware, then re-run the same sweep. A flip needs 0 REGRESSED, since
+/// the gain is completeness and the cost is other people's wall.
+///
+/// **A 6-ONTOLOGY SAMPLE SAID THIS WAS FREE.** Curated corpus row-identical 8/8;
+/// a hand-picked wedge-heavy ORE sample gave ratios 1.00–2.40× with the
+/// expensive members at ~1.1× and found ONE real change. The full sweep found
+/// 25. Sizing a default flip on a sample is the failure mode this repo already
+/// records for a 12-ontology benchmark that took four ontologies to DNF.
+#[must_use]
+pub(crate) fn classify_role_hierarchy_enabled() -> bool {
+    std::env::var_os("RUSTDL_CLASSIFY_ROLE_HIERARCHY").is_some_and(|v| v == "1")
+        || classify_same_tier_enabled()
+}
+
 /// Defined-sup sweep VERIFY mode. For a class defined via a non-EL body
 /// (`D ≡ … ⊓ ¬… / ⊔ / ∀ …`), the wedge's label countermodel is an unreliable
 /// counterexample: it can satisfy `cand ⊓ ¬D` only because the wedge is
@@ -3722,8 +3778,11 @@ impl HyperCache {
         } else {
             value_disjoint
         };
-        let same_tier = crate::classify_same_tier_enabled();
-        let idx_hier = if same_tier { Some(&sub_roles) } else { None };
+        let idx_hier = if crate::classify_role_hierarchy_enabled() {
+            Some(&sub_roles)
+        } else {
+            None
+        };
         let mut base_indexes_inner =
             owl_dl_tableau::hyper::build_clause_indexes(&clauses, idx_hier);
         {
@@ -4112,7 +4171,7 @@ impl HyperCache {
             // differently between base and delta (advisor B1). The extras all
             // have class-only bodies, so the hierarchy argument is irrelevant
             // to them; pass the same gate as the base build for consistency.
-            let idx_hier = if crate::classify_same_tier_enabled() {
+            let idx_hier = if crate::classify_role_hierarchy_enabled() {
                 Some(&self.sub_roles)
             } else {
                 None
@@ -4152,7 +4211,7 @@ impl HyperCache {
         // role-body atoms, so `with_sub_roles_keep_index` suffices; the old
         // path rebuilds the per-pair index with the hierarchy exactly as
         // before (`with_sub_roles`).
-        if crate::classify_same_tier_enabled() {
+        if crate::classify_role_hierarchy_enabled() {
             engine = if self.amortize_idx {
                 engine.with_sub_roles_keep_index(self.sub_roles.clone())
             } else {
@@ -4222,7 +4281,7 @@ impl HyperCache {
         if crate::semantic_branching_enabled() {
             engine = engine.with_semantic_branching();
         }
-        if crate::classify_same_tier_enabled() {
+        if crate::classify_role_hierarchy_enabled() {
             engine = engine.with_sub_roles(self.sub_roles.clone());
         }
         if hyper_double_block_enabled() {
@@ -4357,7 +4416,7 @@ impl HyperCache {
             // ⊥-headed value-disjoint clashes), so the hierarchy argument is
             // irrelevant to them; pass the same gate as the base build for
             // consistency with `decide_with_stats`.
-            let idx_hier = if crate::classify_same_tier_enabled() {
+            let idx_hier = if crate::classify_role_hierarchy_enabled() {
                 Some(&self.sub_roles)
             } else {
                 None
@@ -4375,7 +4434,7 @@ impl HyperCache {
                 std::sync::Arc::clone(&self.base_disjoint_pairs),
                 delta,
             );
-            if crate::classify_same_tier_enabled() {
+            if crate::classify_role_hierarchy_enabled() {
                 e = e.with_sub_roles_keep_index(self.sub_roles.clone());
             }
             e
@@ -4389,7 +4448,7 @@ impl HyperCache {
                 || self.value_disjoint.is_some()
             {
                 let mut e = HyperEngine::new(&full_clauses, self.fresh_q);
-                if crate::classify_same_tier_enabled() {
+                if crate::classify_role_hierarchy_enabled() {
                     e = e.with_sub_roles(self.sub_roles.clone());
                 }
                 e
@@ -4400,7 +4459,7 @@ impl HyperCache {
                     std::sync::Arc::clone(&self.base_indexes),
                     std::sync::Arc::clone(&self.base_disjoint_pairs),
                 );
-                if crate::classify_same_tier_enabled() {
+                if crate::classify_role_hierarchy_enabled() {
                     e = e.with_sub_roles_keep_index(self.sub_roles.clone());
                 }
                 e
@@ -12916,6 +12975,14 @@ mod internal_flag_defaults {
                 "RUSTDL_CLASSIFY_LABELS_AMORTIZE",
                 super::classify_labels_amortize_enabled,
                 true,
+            ),
+            // #128: split out of SAME_TIER. Both OFF — Layer A on a measured
+            // ~19× wall regression (2 ontologies past a 60 s cap, answers
+            // identical), Layer B on its recorded ~2x sweep cost.
+            (
+                "RUSTDL_CLASSIFY_ROLE_HIERARCHY",
+                super::classify_role_hierarchy_enabled,
+                false,
             ),
             (
                 "RUSTDL_CLASSIFY_SAME_TIER",

--- a/crates/owl-dl-reasoner/tests/symmetric_role_chain.rs
+++ b/crates/owl-dl-reasoner/tests/symmetric_role_chain.rs
@@ -1,0 +1,208 @@
+//! #128 — a chain whose first leg is SYMMETRIC must fire in the reverse
+//! direction, at the DEFAULT.
+//!
+//! Reported externally with a real ontology. `Symmetric(p)` + `p ∘ q ⊑ q` +
+//! `A ≡ ∃p.Y ⊓ ∃q.Z` + `B ≡ ∃p.(Y ⊓ ∃q.Z)` makes `A ≡ B`: symmetry gives
+//! `p(y,x)` from `p(x,y)`, and the chain then puts the `Z`-successor on the
+//! `Y`-witness. `classify` derived only `B ⊑ A` — the chain-only direction —
+//! and reported `incomplete: false` with `dropped: {}`. `HermiT` and Konclude
+//! both derive the equivalence.
+//!
+//! **The engine could always do this; it was not being TOLD.** The wedge's
+//! `role_matches` honours sub-roles, declared inverses and symmetry only when
+//! the role hierarchy is threaded into the per-pair oracle, and that threading
+//! (SP1.1 "Layer A") shared one flag with the label-driven same-tier sweep
+//! ("Layer B"). The ~2× wall recorded for SP1.1 belongs to Layer B's sweep, so
+//! the two were bundled at a cost only one of them incurs, and Layer A sat
+//! behind an opt-in nobody sets. `RUSTDL_CLASSIFY_ROLE_HIERARCHY` (default ON)
+//! separates them.
+//!
+//! **DIRECTION OF RISK IS A FALSE POSITIVE** — threading the hierarchy makes
+//! `role_matches` accept MORE edges, so a role that is not symmetric must never
+//! get bidirectional treatment. That is what the `_must_not_` tests below guard,
+//! and they are the ones that fail first if the matching is loosened too far.
+
+#![allow(clippy::unwrap_used)]
+
+use horned_owl::io::ParserConfiguration;
+use horned_owl::io::ofn::reader::read as read_ofn;
+use horned_owl::model::RcStr;
+use horned_owl::ontology::set::SetOntology;
+use std::io::Cursor;
+
+const DECLS: &str = "Declaration(Class(:A)) Declaration(Class(:B)) Declaration(Class(:Y)) \
+     Declaration(Class(:Z)) Declaration(ObjectProperty(:p)) Declaration(ObjectProperty(:p2)) \
+     Declaration(ObjectProperty(:q)) Declaration(ObjectProperty(:s))";
+
+/// Every test in this file locks this, not just the one that MUTATES the env.
+/// Rust runs tests in parallel, so a read-only test can otherwise observe
+/// another test's `RUSTDL_CLASSIFY_ROLE_HIERARCHY=0` and fail spuriously — which
+/// is exactly what happened on the first run of this file. Mirrors the idiom in
+/// `classify_inverse_domain.rs`.
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Classify with `RUSTDL_CLASSIFY_ROLE_HIERARCHY=1`. The fix is **opt-in** — it
+/// is default OFF on a measured ~19× wall regression, not on any doubt about
+/// correctness (see the flag's doc comment). Every test here therefore sets it
+/// explicitly, and `the_fix_is_opt_in_and_the_default_still_misses` pins that
+/// the default does NOT have it.
+fn classify_with_hierarchy(body: &str) -> owl_dl_reasoner::Classification {
+    // SAFETY: set_var is unsafe under edition 2024. Callers hold `lock()`, and
+    // the value is restored by `remove_var` before returning.
+    #[allow(unsafe_code)]
+    unsafe {
+        std::env::set_var("RUSTDL_CLASSIFY_ROLE_HIERARCHY", "1");
+    }
+    let c = classify(body);
+    #[allow(unsafe_code)]
+    unsafe {
+        std::env::remove_var("RUSTDL_CLASSIFY_ROLE_HIERARCHY");
+    }
+    c
+}
+
+fn classify(body: &str) -> owl_dl_reasoner::Classification {
+    let ofn = format!(
+        "Prefix(:=<http://ex.org/>)\n\
+         Ontology(<http://ex.org/o>\n{DECLS}\n{body}\n)\n"
+    );
+    let mut reader = Cursor::new(ofn);
+    let (onto, _): (SetOntology<RcStr>, _) =
+        read_ofn(&mut reader, ParserConfiguration::default()).expect("parse ofn");
+    owl_dl_reasoner::classify(&onto).expect("classify")
+}
+
+fn holds(body: &str, sub: &str, sup: &str) -> bool {
+    classify_with_hierarchy(body).is_subclass(
+        &format!("http://ex.org/{sub}"),
+        &format!("http://ex.org/{sup}"),
+    )
+}
+
+/// The two class definitions from the report, parameterised on the role axioms.
+fn shape(role_axioms: &str) -> String {
+    format!(
+        "{role_axioms}\n\
+         EquivalentClasses(:A ObjectIntersectionOf(ObjectSomeValuesFrom(:p :Y) \
+         ObjectSomeValuesFrom(:q :Z)))\n\
+         EquivalentClasses(:B ObjectSomeValuesFrom(:p ObjectIntersectionOf(:Y \
+         ObjectSomeValuesFrom(:q :Z))))"
+    )
+}
+
+/// THE REPORTED BUG. `A ⊑ B` is the direction needing symmetry ∘ chain; before
+/// #128 only `B ⊑ A` was derived.
+#[test]
+fn a_symmetric_first_leg_fires_the_chain_in_reverse() {
+    let _serial = lock();
+    let body = shape(
+        "SymmetricObjectProperty(:p)\n\
+         SubObjectPropertyOf(ObjectPropertyChain(:p :q) :q)",
+    );
+    assert!(
+        holds(&body, "A", "B"),
+        "A ⊑ B needs symmetry composed with the chain — the #128 direction"
+    );
+    assert!(holds(&body, "B", "A"), "B ⊑ A needs the chain alone");
+}
+
+/// A named inverse was already handled; kept so a regression in the shared
+/// matching path cannot hide behind the symmetric case passing.
+#[test]
+fn an_explicitly_named_inverse_first_leg_still_works() {
+    let _serial = lock();
+    let body = shape(
+        "Declaration(ObjectProperty(:pi))\n\
+         InverseObjectProperties(:p :pi)\n\
+         SubObjectPropertyOf(ObjectPropertyChain(:pi :q) :q)\n\
+         SubObjectPropertyOf(ObjectPropertyChain(:p :q) :q)",
+    );
+    assert!(holds(&body, "A", "B"));
+}
+
+/// FP GUARD, and the test that fails first if edge matching is loosened beyond
+/// what symmetry licenses: with NO symmetry declared, the reverse direction is
+/// not entailed and must not be derived. `HermiT` derives neither direction's
+/// `A ⊑ B` here.
+#[test]
+fn a_plain_chain_must_not_fire_in_reverse() {
+    let _serial = lock();
+    let body = shape("SubObjectPropertyOf(ObjectPropertyChain(:p :q) :q)");
+    assert!(
+        !holds(&body, "A", "B"),
+        "without symmetry the reverse traversal is unlicensed"
+    );
+    assert!(holds(&body, "B", "A"), "the forward direction still holds");
+}
+
+/// FP GUARD. A SUB-ROLE of a symmetric role is not itself symmetric, so a chain
+/// on `p2 ⊑ p` must not be reversed even though `p` is symmetric.
+#[test]
+fn a_sub_role_of_a_symmetric_role_must_not_be_reversed() {
+    let _serial = lock();
+    let body = shape(
+        "SymmetricObjectProperty(:p)\n\
+         SubObjectPropertyOf(:p2 :p)\n\
+         SubObjectPropertyOf(ObjectPropertyChain(:p2 :q) :q)",
+    );
+    assert!(
+        !holds(&body, "A", "B"),
+        "p2 ⊑ p with p symmetric does NOT make p2 symmetric"
+    );
+}
+
+/// Symmetry alone, with no chain, entails neither direction — pins that the
+/// gain comes from the two interacting rather than from symmetry being read.
+#[test]
+fn symmetry_without_a_chain_entails_neither_direction() {
+    let _serial = lock();
+    let body = shape("SymmetricObjectProperty(:p)");
+    assert!(!holds(&body, "A", "B"));
+    assert!(!holds(&body, "B", "A"));
+}
+
+/// The fix is OPT-IN, and this pins both halves of that: the default still
+/// misses the pair, and `=1` derives it. If a future change flips the default,
+/// this test tells you immediately — and the flag's doc comment records what
+/// evidence a flip needs (0 REGRESSED on the full sweep).
+#[test]
+fn the_fix_is_opt_in_and_the_default_still_misses() {
+    let _serial = lock();
+    let body = shape(
+        "SymmetricObjectProperty(:p)\n\
+         SubObjectPropertyOf(ObjectPropertyChain(:p :q) :q)",
+    );
+    // Default: no flag set at all.
+    assert!(
+        !classify(&body).is_subclass("http://ex.org/A", "http://ex.org/B"),
+        "default is OFF on a measured wall regression; if this now passes the \
+         default was flipped — update the flag doc and the pin table together"
+    );
+    assert!(
+        holds(&body, "A", "B"),
+        "RUSTDL_CLASSIFY_ROLE_HIERARCHY=1 must derive it"
+    );
+}
+
+/// KNOWN RESIDUAL, pinned so it is not mistaken for coverage. A length-3 chain
+/// with a symmetric first leg is still missed at the default; both peers derive
+/// it. FLIP this assertion rather than deleting it when that closes.
+#[test]
+fn a_length_three_chain_with_a_symmetric_leg_is_a_known_miss() {
+    let _serial = lock();
+    let body = "SymmetricObjectProperty(:p)\n\
+         SubObjectPropertyOf(ObjectPropertyChain(:p :q :s) :s)\n\
+         EquivalentClasses(:A ObjectIntersectionOf(ObjectSomeValuesFrom(:p :Y) \
+         ObjectSomeValuesFrom(:q :Z)))\n\
+         EquivalentClasses(:B ObjectSomeValuesFrom(:s :Z))";
+    assert!(
+        !holds(body, "A", "B"),
+        "if this now passes, #128's residual has closed — FLIP this test, do not delete it"
+    );
+}


### PR DESCRIPTION
Refs #128. **Does not close it** — the reporter's ontology additionally needs #131.

## The bug

Externally reported. `Symmetric(p)` + `p ∘ q ⊑ q` + `A ≡ ∃p.Y ⊓ ∃q.Z` + `B ≡ ∃p.(Y ⊓ ∃q.Z)` makes `A ≡ B`. `classify` derived only `B ⊑ A` — the chain-only direction — with `incomplete: false` and `dropped: {}`. HermiT and Konclude both derive the equivalence.

## The engine could always do this; it was not being told

The wedge's `role_matches` honours sub-roles, declared inverses and symmetry **only when the role hierarchy is threaded into the per-pair oracle** — SP1.1 "Layer A". That threading shared one flag with Layer B's label-driven same-tier sweep, and **the recorded ~2× wall for SP1.1 belongs to Layer B** — so Layer A sat behind an opt-in priced for something else. The bare engine derived the pair all along.

`RUSTDL_CLASSIFY_ROLE_HIERARCHY` separates them. `RUSTDL_CLASSIFY_SAME_TIER=1` implies it, so the older opt-in cannot be left incoherent. **The split is the durable contribution here.**

## Default OFF on a measured wall regression, not on doubt about correctness

Full 1,920-ontology two-arm sweep (one binary, env var the only difference, arm order alternated, 60 s cap):

| verdict | count |
|---|---|
| IDENTICAL | 1,800 |
| BOTH_DNF | 95 |
| DIFFER | 23 |
| **REGRESSED** | **2** |

All 23 DIFFERs are row **gains** (`ore_ont_10019` +2, both Konclude-confirmed; `13647` 202→500; `16457` 125→301). Both regressions reproduce sequentially on an idle host at a 300 s cap, 3 runs per arm, **with identical answers in both arms** — they are pure wall:

| ontology | answers | OFF | ON |
|---|---|---|---|
| `ore_ont_16372` | identical (0 rows, 744 unsat) | 3–4 s | **66–73 s** (~19×) |
| `ore_ont_9890` | identical (642 rows) | 17–18 s | **89–94 s** (~5×) |

Enough to cross a 60 s budget. The gain is completeness; the cost is other people's wall. **A flip needs 0 REGRESSED.**

## The mechanism is NOT established, and the flag doc says so

`with_sub_roles` rebuilds the clause index — the documented ~20× cost class of `RUSTDL_CLASSIFY_LABELS_AMORTIZE`, and the same magnitude — so it is the leading suspect. But on both regressed ontologies **every classify phase reports 0 ms** with `subsumption` and `satisfiability probes` both 0 (the pure-EL all-phases-zero trap, so the banner attributes nothing), and the one unconditional rebuild site turned out to be `sat_only_with_stats`, a **diagnostic** path. Do not quote the index-rebuild story as the cause. Retry conditions are recorded on the flag.

## A 6-ontology sample said this was free, and was wrong by 25×

Curated corpus 8/8 row-identical; a hand-picked wedge-heavy ORE sample gave ratios 1.00–2.40× with the **expensive** members at ~1.1× and found **one** real change. The sweep found 25, plus two regressions the sample's population could not contain. Same failure mode this repo already records for the 12-ontology benchmark that took four ontologies to DNF. **Size a default flip on the sweep; treat any sample as a smoke test.**

## Two of my own errors, recorded because they shaped the diagnosis

- **"No flag recovers it" was a measurement error.** I tested `SAME_TIER=1` through `rustdl subclass` — a surface that flag does not affect — and concluded the calculus was at fault. On `classify` it recovers the minimal shape outright. Corrected publicly on the issue.
- **A workaround I posted was verified on the minimal synthetic and not on the reporter's file**, and was wrong. Retracted publicly. Their file also carries #131, so it needs `ROLE_HIERARCHY=1` + `SAT_SEED=0` and **neither alone** — which is how a correct fix reads as doing nothing.

## Gates

- suite **1997 passed / 0 failed**
- FP=0 net **12 VERIFIED**, every closure exact — **run with the feature ON**, the more demanding arm
- clippy `--all-targets --all-features` exit 0; `cargo fmt --check` clean
- Canaries `crates/owl-dl-reasoner/tests/symmetric_role_chain.rs` (7): 3 FP guards, a pinned residual, and `the_fix_is_opt_in_and_the_default_still_misses` so a future flip cannot happen silently. Every test locks a shared env mutex — the first version had read-only tests observing another test's `=0` under parallel execution and failing spuriously.

## Residuals recorded, not fixed

Length-3 chain with a symmetric leg (pinned, FLIP when it closes); sub-role-of-symmetric reversal; `SymmetricObjectProperty(ObjectInverseOf(:p))` silently dropped; a **latent FP** in `collect_inverse_pairs` polarity-stripping, unreachable today only because horned-owl rejects a syntax both peers accept — **closing that parser gap makes it live**, which is worth knowing before #126 lands; and `apply_role_chains` comparing raw role ids with `==` instead of `edge_satisfies`, so it independently ignores symmetry, declared inverses and the sub-role hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)