### PR TITLE
perf(classify): ask about inconsistency before paying for a hierarchy nobody reads (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ All notable changes to rustdl are documented here. Format is based on
 
 ## [Unreleased]
 
+### Added — early inconsistency exit, removing one of the two blockers on the role-hierarchy flip (#128)
+
+`probe_says_inconsistent` runs AFTER the tier walk. When it fires,
+`classify_inconsistent` discards the walk wholesale — every class is unsatisfiable, so
+the hierarchy it just computed is thrown away. On `ore_ont_16372` that is **20.5 s of
+tier walk plus 5.5 s of sweeps computed and binned**. `RUSTDL_EARLY_INCONSISTENCY_PROBE`
+(**default OFF**, `=1` enables) asks first.
+
+| `ore_ont_16372`, `RUSTDL_CLASSIFY_ROLE_HIERARCHY=1` | wall | rows |
+| --- | --- | --- |
+| early probe off | 31.6 s | 745 |
+| early probe on | **5.9 s** | 745 (byte-identical) |
+
+That is one of the **two** ontologies whose wall regression keeps
+`RUSTDL_CLASSIFY_ROLE_HIERARCHY` (worth 313 recovered subsumptions at FP=0) default-OFF
+against a "0 REGRESSED" bar — and with this it stops being a regression at all: the ON
+arm (5.9 s) is now FASTER than the OFF arm (9.1 s). `ore_ont_9890` is **not** fixed and
+is the harder case; its regression is genuine per-class wedge divergence rather than
+discarded work.
+
+**Two hidden gates, both found by measurement after a straight hoist did nothing.**
+`unsatisfiable_idxs` is still EMPTY before the walk — those 744 unsat classes are found
+BY the walk — so the probe's normal admission rejects. And there is a SECOND
+`!incomplete_abox` bypass further down (the minimum-unsat-fraction guard) that likewise
+rejects on a count not yet computed. Both are now threaded by an explicit
+`extra_admission` parameter, `false` at the existing post-walk call site so its behaviour
+is unchanged.
+
+The early call's admission evidence is a large `NoVerdict` share of the label cache —
+per-class wedge satisfiability that did not converge in its budget, the same "did not
+look long enough" species the existing `RUSTDL_CLASSIFY_PROBE_ON_INCOMPLETE` arm already
+admits on. A wrong admission costs one bounded probe, never a wrong answer: the probe
+PROVES inconsistency. It CAN change output — a proof-backed all-unsat where the late
+probe was never admitted — which is a row gain at FP=0, and is why this ships default-OFF
+pending the two-arm sweep.
+
+**Two corrections to the #128 record while establishing this.** The regression is a
+BRANCH STORM, not matcher cross-product: enumeration frames per match call are ≈1 in both
+arms (nothing to prune), while ⊔ branches go 54k → 632k and restores 45k → 631k.
+Per-branch matcher cost actually falls; the tree grows. And the all-zero phase banner that
+made the cost unattributable is an artifact — `classify_inconsistent` rebuilds stats as
+`{ inconsistent, fragment, ..Default::default() }`, zeroing every timer after the work is
+done.
+
+Verification: fmt, clippy `-D warnings`, full test suite green; corpus soundness net every
+fixture FP=0/MISSED=0 (sio 8904, wine 653, ro 158, sulo 51, pizza 112).
+
 ### Fixed — `completeness_guaranteed()`'s Horn arm was a false certificate (#124)
 
 `Classification::completeness_guaranteed()` returned `true` for `PureEl | Horn`. `Horn`

--- a/crates/owl-dl-reasoner/src/classify.rs
+++ b/crates/owl-dl-reasoner/src/classify.rs
@@ -1542,6 +1542,7 @@ fn classify_internal_with_timeout_impl(
         &unsatisfiable_idxs,
         n,
         &mut stats,
+        false,
     ) {
         return Ok(classify_inconsistent(classes, index, stats.fragment));
     }
@@ -1742,6 +1743,7 @@ fn probe_says_inconsistent(
     unsatisfiable_idxs: &HashSet<usize>,
     n_classes: usize,
     stats: &mut ClassificationStats,
+    extra_admission: bool,
 ) -> bool {
     if !crate::classify_consistency_probe_enabled() || stats.inconsistent {
         return false;
@@ -1755,7 +1757,14 @@ fn probe_says_inconsistent(
     let incomplete_abox = crate::classify_probe_on_incomplete()
         && stats.timed_out_pairs > 0
         && has_abox_axioms(internal);
-    if unsatisfiable_idxs.is_empty() && !incomplete_abox {
+    // `extra_admission` is the #128 early-exit arm: at the pre-walk call site
+    // `unsatisfiable_idxs` is still empty (the unsat classes are found BY the walk)
+    // and `timed_out_pairs` is still 0, so BOTH standing admissions reject and the
+    // probe returns before doing any work. The caller supplies its own evidence
+    // there — a large `NoVerdict` share of the label cache, the same "did not look
+    // long enough" species `incomplete_abox` already admits on. Always `false` at
+    // the post-walk call site, which therefore behaves exactly as before.
+    if unsatisfiable_idxs.is_empty() && !incomplete_abox && !extra_admission {
         return false;
     }
     // (1) ASSERTED INSTANCE OF AN UNSATISFIABLE CLASS ⟹ inconsistent.
@@ -1833,7 +1842,14 @@ fn probe_says_inconsistent(
     // behaviour, so this can only fail to fix, never break.
     let min_permille = crate::classify_probe_min_frac_permille();
     let min_permille = usize::try_from(min_permille).unwrap_or(usize::MAX);
-    if !incomplete_abox && unsatisfiable_idxs.len() * 1000 < n_classes.max(1) * min_permille {
+    // `extra_admission` bypasses this minimum-fraction guard for the same reason it
+    // bypasses the admission above: at the #128 pre-walk call site
+    // `unsatisfiable_idxs` is empty, so the guard would reject on a count that has
+    // not been computed yet rather than on one that came back small.
+    if !incomplete_abox
+        && !extra_admission
+        && unsatisfiable_idxs.len() * 1000 < n_classes.max(1) * min_permille
+    {
         return false;
     }
     // Past every admission test: layers 2-3 are about to run.
@@ -3926,6 +3942,62 @@ fn classify_top_down_internal_impl(
     }
     stats.unsat_probe_wall_ms = elapsed_ms(t_unsat_probe);
 
+    // EARLY INCONSISTENCY EXIT (#128). The same `probe_says_inconsistent` also
+    // runs after the tier walk, but by then the walk and the defined sweeps have
+    // been computed — and if the probe fires they are thrown away wholesale, since
+    // an inconsistent KB makes every class unsatisfiable and
+    // `classify_inconsistent` rebuilds the result from scratch.
+    //
+    // Its layer-1 evidence is ready HERE: an asserted instance of an unsatisfiable
+    // class is sound and exact, and `unsatisfiable_idxs` is final from this point
+    // (the walk below only reads it). So when the KB is provably inconsistent we
+    // can say so before paying for a hierarchy nobody will look at.
+    //
+    // Measured on `ore_ont_16372` (inconsistent per Konclude AND HermiT, and the
+    // ontology whose wall regression gates `RUSTDL_CLASSIFY_ROLE_HIERARCHY`):
+    // 31.6 s -> 5.8 s with byte-identical output, because tier_walk (20.5 s) and
+    // sweeps (5.5 s) are skipped rather than computed-then-discarded.
+    //
+    // ADMISSION. The late probe's normal admission — "some class is already proved
+    // unsatisfiable" — is NOT yet satisfied here on the ontology this targets:
+    // `ore_ont_16372`'s 744 unsat classes are discovered BY the walk, so
+    // `unsatisfiable_idxs` is still empty at this point and a straight hoist fires
+    // nothing (measured: no change). The evidence available early is the label
+    // cache's `NoVerdict` count — per-class wedge satisfiability that did not
+    // converge inside its budget. That is the same "we did not look long enough"
+    // species the existing `RUSTDL_CLASSIFY_PROBE_ON_INCOMPLETE` arm already admits
+    // on, which is why it is the right signal rather than a new idea.
+    //
+    // A wrong admission costs a bounded probe, never a wrong answer: the probe
+    // PROVES inconsistency (layer 1 is an asserted instance of an unsatisfiable
+    // class; the rest are bounded wedge/⊤ probes under their own budget). It can
+    // only turn "no verdict yet" into a proof-backed all-unsat.
+    //
+    // It CAN change output: on a KB where the late probe would never have been
+    // admitted but the early one is, and the probe succeeds, the result becomes
+    // all-unsat where it previously was a partial hierarchy. That is a row GAIN
+    // backed by a proof (FP=0), not a loss — but it is a behaviour change, so it is
+    // gated and must clear the corpus net and the two-arm ORE sweep before the
+    // default moves.
+    let noverdict = label_cache
+        .iter()
+        .filter(|o| matches!(o, crate::LabelOracle::NoVerdict))
+        .count();
+    let early_admitted = crate::early_inconsistency_probe_enabled() && n > 0 && noverdict * 4 >= n;
+    if early_admitted
+        && probe_says_inconsistent(
+            internal,
+            &prepared,
+            &reported,
+            &unsatisfiable_idxs,
+            n,
+            &mut stats,
+            true,
+        )
+    {
+        return Ok(classify_inconsistent(classes, index, stats.fragment));
+    }
+
     // Compute closure-subsumer counts once per class (used for sort key and
     // tier grouping). `subsumers_count` is O(1) (no Vec allocation) vs
     // `subsumers_of` (allocates Vec<ClassId> per call). sort_by_key calls the
@@ -4539,6 +4611,7 @@ fn classify_top_down_internal_impl(
         &unsatisfiable_idxs,
         n,
         &mut stats,
+        false,
     ) {
         return Ok(classify_inconsistent(classes, index, stats.fragment));
     }

--- a/crates/owl-dl-reasoner/src/lib.rs
+++ b/crates/owl-dl-reasoner/src/lib.rs
@@ -2031,6 +2031,22 @@ pub fn reseed_verify_enabled() -> bool {
     std::env::var_os("RUSTDL_RESEED_VERIFY").is_none_or(|v| v != "0" && !v.is_empty())
 }
 
+/// Early inconsistency exit (#128, `RUSTDL_EARLY_INCONSISTENCY_PROBE`,
+/// **default OFF** pending the two-arm ORE sweep; `=1` enables). Runs
+/// `probe_says_inconsistent` BEFORE the tier walk when a large share of the label
+/// cache came back `NoVerdict`, so a provably inconsistent KB is not charged for a
+/// hierarchy that `classify_inconsistent` then discards wholesale.
+///
+/// Worth 31.6 s -> 5.8 s with byte-identical output on `ore_ont_16372`, one of the
+/// two ontologies whose wall regression gates `RUSTDL_CLASSIFY_ROLE_HIERARCHY` —
+/// there the ON arm becomes FASTER than the OFF arm. Sound in both settings: the
+/// probe proves inconsistency, so a wrong admission costs one bounded probe, never
+/// a wrong answer.
+#[must_use]
+pub(crate) fn early_inconsistency_probe_enabled() -> bool {
+    std::env::var_os("RUSTDL_EARLY_INCONSISTENCY_PROBE").is_some_and(|v| v == "1")
+}
+
 /// Per-class label heuristic (Phase 7) — when enabled, the classifier
 /// runs wedge satisfiability once per named class to build a label
 /// cache, then prunes non-subsumption pairs whose candidate super is


### PR DESCRIPTION
Refs #128. Removes **one of the two** wall regressions blocking the `RUSTDL_CLASSIFY_ROLE_HIERARCHY` default flip.

## The waste

`probe_says_inconsistent` runs **after** the tier walk. When it fires, `classify_inconsistent` discards the walk wholesale — every class is unsatisfiable, so the hierarchy just computed is binned. On `ore_ont_16372` that is **20.5 s of tier walk + 5.5 s of sweeps computed and thrown away**.

`RUSTDL_EARLY_INCONSISTENCY_PROBE` (**default OFF**, `=1` enables) asks first.

| `ore_ont_16372`, `RUSTDL_CLASSIFY_ROLE_HIERARCHY=1` | wall | rows |
| --- | --- | --- |
| early probe off | 31.6 s | 745 |
| early probe on | **5.9 s** | 745, byte-identical |

`ore_ont_16372` stops being a regression at all: the ON arm (5.9 s) is now **faster than the OFF arm** (9.1 s). `ore_ont_9890` is **not** fixed — its regression is genuine per-class wedge divergence under hierarchy-aware matching, not discarded work, and needs separate investigation before the flip.

## Two hidden gates

A straight hoist does nothing, and measuring why is the whole content of this change:

1. `unsatisfiable_idxs` is still **empty** before the walk — `ore_ont_16372`'s 744 unsat classes are discovered *by* the walk — so the probe's normal admission rejects.
2. There is a **second** `!incomplete_abox` bypass further down (the minimum-unsat-fraction guard, `classify.rs:1845`) which likewise rejects on a count that has not been computed yet.

Both are threaded by an explicit `extra_admission` parameter, passed `false` at the existing post-walk call site so its behaviour is bit-for-bit unchanged. I used a parameter rather than temporarily lending `stats.timed_out_pairs` a fake value, so a statistic is not repurposed to signal a callee.

## Admission and safety

The early call's evidence is a large `NoVerdict` share of the label cache — per-class wedge satisfiability that did not converge inside its budget. That is the same "did not look long enough" species the existing `RUSTDL_CLASSIFY_PROBE_ON_INCOMPLETE` arm already admits on, not a new idea.

A wrong admission costs **one bounded probe, never a wrong answer**: the probe *proves* inconsistency (layer 1 is an asserted instance of an unsatisfiable class; the rest are bounded wedge/⊤ probes under their own budget).

It **can** change output — on a KB where the late probe would never have been admitted but the early one is *and* the probe succeeds, the result becomes a proof-backed all-unsat where it was previously a partial hierarchy. That is a row **gain** at FP=0, not a loss, but it is a behaviour change, which is why this is default-OFF pending the two-arm sweep. A row-change sweep over the 610-ontology trigger set is running; results to follow.

## Corrections to the #128 record established here

- **The regression is a branch storm, not matcher cross-product.** Enumeration frames per match call are ≈1 in *both* arms — the hot bodies have 0–1 role atoms and essentially never recurse, so there is nothing to prune. Meanwhile ⊔ branches go 54k → 632k and restores 45k → 631k. Per-branch matcher cost *falls*; the search tree grows ~12×. My earlier "candidates multiply rather than add" explanation on #128 is withdrawn.
- **The all-zero phase banner is a reporting artifact.** `classify_inconsistent` rebuilds stats as `{ inconsistent, fragment, ..Default::default() }`, zeroing every timer *after* the work is done. The flag doc's "every classify phase reports 0 ms … the cost is not attributable from the banner" has a cause, and it is this.

Credit: the counter instrumentation and the original prototype measurement came from an independent analysis pass; I verified the stats-discard and the timing independently and reimplemented the fix.

## Verification

fmt, clippy `-D warnings`, full test suite green. Corpus soundness net every fixture FP=0/MISSED=0 — sio 8904, wine 653, ro 158, sulo 51, pizza 112.

Also filed **#147** on the way: `RUSTDL_SEMANTIC_BRANCHING=1` aborts with a rayon stack overflow on `ore_ont_9890`, which matters because that lever's prune is exactly the shape the remaining branch storm needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
